### PR TITLE
test: prove live Graphiti Neo4j materialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,71 @@ jobs:
         run: python -m pip install -e '.[test]'
       - name: Test
         run: pytest -q
+
+  gate1-live-graphiti-bootstrap:
+    if: github.event_name == 'pull_request' && github.head_ref == 'agent/graphiti-live-smoke'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      neo4j:
+        image: neo4j:5.26
+        env:
+          NEO4J_AUTH: neo4j/fossil-gate1-pass
+        ports:
+          - 7474:7474
+          - 7687:7687
+    env:
+      NEO4J_URI: bolt://127.0.0.1:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: fossil-gate1-pass
+      GRAPHITI_LLM_BASE_URL: http://127.0.0.1:11434/v1
+      GRAPHITI_LLM_API_KEY: ollama
+      GRAPHITI_LLM_MODEL: qwen2.5:3b
+      GRAPHITI_SMALL_MODEL: qwen2.5:3b
+      GRAPHITI_EMBEDDING_MODEL: nomic-embed-text
+      GRAPHITI_EMBEDDING_DIM: "768"
+      GRAPHITI_STRUCTURED_OUTPUT_MODE: json_object
+      GRAPHITI_TELEMETRY_ENABLED: "false"
+      SEMAPHORE_LIMIT: "1"
+      FOSSIL_ONTOLOGY_VERSION: "1.0.0"
+      FOSSIL_SOFTWARE_COMMIT: ${{ github.sha }}
+      FOSSIL_PROOF_PATH: ${{ runner.temp }}/fossil-live-graphiti-proof.json
+      OLLAMA_NUM_PARALLEL: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install FOSSIL with Graphiti
+        run: python -m pip install -e '.[test,graphiti]'
+      - name: Install and start Ollama
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://ollama.com/install.sh | sh
+          ollama serve >"${RUNNER_TEMP}/ollama.log" 2>&1 &
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent http://127.0.0.1:11434/api/tags >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          cat "${RUNNER_TEMP}/ollama.log"
+          exit 1
+      - name: Pull local Graphiti models
+        run: |
+          ollama pull qwen2.5:3b
+          ollama pull nomic-embed-text
+      - name: Run durable-to-Graphiti live smoke
+        run: python scripts/live_graphiti_smoke.py
+      - name: Upload live proof
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fossil-live-graphiti-proof-bootstrap
+          path: ${{ runner.temp }}/fossil-live-graphiti-proof.json
+          if-no-files-found: warn
+      - name: Show Ollama log on failure
+        if: failure()
+        run: cat "${RUNNER_TEMP}/ollama.log" || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         run: pytest -q
 
   gate1-live-graphiti-bootstrap:
-    if: github.event_name == 'pull_request' && github.head_ref == 'agent/graphiti-live-smoke'
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'agent/graphiti-live-smoke')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     services:

--- a/.github/workflows/graphiti-live.yml
+++ b/.github/workflows/graphiti-live.yml
@@ -1,0 +1,92 @@
+name: Graphiti live integration
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/graphiti-live.yml"
+      - "scripts/live_graphiti_smoke.py"
+      - "src/dkg/event_store.py"
+      - "src/dkg/projection/**"
+      - "schemas/events/**"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  live-graphiti-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      neo4j:
+        image: neo4j:5.26
+        env:
+          NEO4J_AUTH: neo4j/fossil-gate1-pass
+        ports:
+          - 7474:7474
+          - 7687:7687
+
+    env:
+      NEO4J_URI: bolt://127.0.0.1:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: fossil-gate1-pass
+      GRAPHITI_LLM_BASE_URL: http://127.0.0.1:11434/v1
+      GRAPHITI_LLM_API_KEY: ollama
+      GRAPHITI_LLM_MODEL: qwen2.5:3b
+      GRAPHITI_SMALL_MODEL: qwen2.5:3b
+      GRAPHITI_EMBEDDING_MODEL: nomic-embed-text
+      GRAPHITI_EMBEDDING_DIM: "768"
+      GRAPHITI_STRUCTURED_OUTPUT_MODE: json_object
+      GRAPHITI_TELEMETRY_ENABLED: "false"
+      SEMAPHORE_LIMIT: "1"
+      FOSSIL_ONTOLOGY_VERSION: "1.0.0"
+      FOSSIL_SOFTWARE_COMMIT: ${{ github.sha }}
+      FOSSIL_PROOF_PATH: ${{ runner.temp }}/fossil-live-graphiti-proof.json
+      OLLAMA_NUM_PARALLEL: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install FOSSIL with Graphiti
+        run: python -m pip install -e '.[test,graphiti]'
+
+      - name: Install and start Ollama
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://ollama.com/install.sh | sh
+          ollama serve >"${RUNNER_TEMP}/ollama.log" 2>&1 &
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent http://127.0.0.1:11434/api/tags >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          cat "${RUNNER_TEMP}/ollama.log"
+          exit 1
+
+      - name: Pull local Graphiti models
+        run: |
+          ollama pull qwen2.5:3b
+          ollama pull nomic-embed-text
+
+      - name: Run durable-to-Graphiti live smoke
+        run: python scripts/live_graphiti_smoke.py
+
+      - name: Upload live proof
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fossil-live-graphiti-proof
+          path: ${{ runner.temp }}/fossil-live-graphiti-proof.json
+          if-no-files-found: warn
+
+      - name: Show Ollama log on failure
+        if: failure()
+        run: cat "${RUNNER_TEMP}/ollama.log" || true

--- a/scripts/live_graphiti_smoke.py
+++ b/scripts/live_graphiti_smoke.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.metadata
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from graphiti_core import Graphiti
+from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
+from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
+from graphiti_core.llm_client.config import LLMConfig
+from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
+from graphiti_core.nodes import EpisodeType
+from neo4j import AsyncGraphDatabase
+
+from dkg.event_store import DurableEventStore
+from dkg.projection.graphiti import GraphitiProjectionAdapter
+from dkg.projection.ledger import ProjectionLedger
+
+
+PACK_ID = "pack_269099f7b2ba43b7a99b9427d64092de"
+IDEMPOTENCY_KEY = "gate1-live-graphiti-materialization-v1"
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"required environment variable {name} is not set")
+    return value
+
+
+def software_commit() -> str:
+    configured = os.environ.get("FOSSIL_SOFTWARE_COMMIT")
+    if configured:
+        return configured
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+async def wait_for_neo4j(
+    uri: str, user: str, password: str, *, attempts: int = 60
+) -> str:
+    driver = AsyncGraphDatabase.driver(uri, auth=(user, password))
+    try:
+        for attempt in range(1, attempts + 1):
+            try:
+                await driver.verify_connectivity()
+                records, _, _ = await driver.execute_query(
+                    "CALL dbms.components() "
+                    "YIELD name, versions "
+                    "RETURN name, versions[0] AS version "
+                    "ORDER BY name LIMIT 1",
+                    database_="neo4j",
+                )
+                if not records:
+                    raise RuntimeError("Neo4j returned no component version")
+                return str(records[0]["version"])
+            except Exception:
+                if attempt == attempts:
+                    raise
+                await asyncio.sleep(2)
+    finally:
+        await driver.close()
+    raise RuntimeError("Neo4j did not become ready")
+
+
+async def observe_projection(
+    uri: str,
+    user: str,
+    password: str,
+    *,
+    group_id: str,
+    episode_name: str,
+) -> dict[str, Any]:
+    driver = AsyncGraphDatabase.driver(uri, auth=(user, password))
+    try:
+        records, _, _ = await driver.execute_query(
+            """
+            MATCH (e:Episodic {group_id: $group_id, name: $episode_name})
+            OPTIONAL MATCH (e)-[:MENTIONS]->(entity:Entity)
+            WITH e, count(DISTINCT entity) AS mentioned_entity_count
+            OPTIONAL MATCH (left:Entity {group_id: $group_id})-[fact:RELATES_TO]->(right:Entity {group_id: $group_id})
+            RETURN
+                count(DISTINCT e) AS episode_count,
+                max(mentioned_entity_count) AS mentioned_entity_count,
+                count(DISTINCT fact) AS fact_edge_count,
+                collect(DISTINCT e.uuid) AS episode_uuids,
+                collect(DISTINCT e.content) AS episode_contents
+            """,
+            group_id=group_id,
+            episode_name=episode_name,
+            database_="neo4j",
+        )
+        if not records:
+            return {
+                "episode_count": 0,
+                "mentioned_entity_count": 0,
+                "fact_edge_count": 0,
+                "episode_uuids": [],
+                "episode_contents": [],
+            }
+        record = records[0]
+        return {
+            "episode_count": int(record["episode_count"] or 0),
+            "mentioned_entity_count": int(record["mentioned_entity_count"] or 0),
+            "fact_edge_count": int(record["fact_edge_count"] or 0),
+            "episode_uuids": list(record["episode_uuids"] or []),
+            "episode_contents": list(record["episode_contents"] or []),
+        }
+    finally:
+        await driver.close()
+
+
+def build_event(commit: str) -> dict[str, Any]:
+    timestamp = "2026-08-09T19:20:00Z"
+    return {
+        "schema_version": "dkg.event.v1",
+        "event_type": "claim.proposed",
+        "occurred_at": timestamp,
+        "recorded_at": timestamp,
+        "pack_id": PACK_ID,
+        "actor": {
+            "actor_type": "system",
+            "actor_id": "fossil-gate1-live-smoke",
+        },
+        "subject_refs": ["clm_gate1_live_graphiti_projection"],
+        "idempotency_key": IDEMPOTENCY_KEY,
+        "payload": {
+            "claim_text": (
+                "FOSSIL Core uses Graphiti with Neo4j as a rebuildable knowledge "
+                "projection. Durable FOSSIL events remain the canonical record."
+            )
+        },
+        "provenance": {
+            "method": "gate1-live-graphiti-smoke",
+            "software_commit": commit,
+            "ontology_version": os.environ.get("FOSSIL_ONTOLOGY_VERSION", "1.0.0"),
+        },
+    }
+
+
+async def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    requested_root = os.environ.get("FOSSIL_SMOKE_ROOT")
+    root = (
+        Path(requested_root)
+        if requested_root
+        else Path(tempfile.mkdtemp(prefix="fossil-graphiti-smoke-"))
+    )
+    root.mkdir(parents=True, exist_ok=True)
+
+    commit = software_commit()
+    event_store = DurableEventStore(
+        root / "events",
+        repo_root / "schemas" / "events" / "v1.schema.json",
+    )
+    accepted_event = event_store.commit(build_event(commit))
+    event_id = accepted_event["event_id"]
+    if event_store.get(event_id) != accepted_event:
+        raise AssertionError("durable event was not readable before graph projection")
+
+    neo4j_uri = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+    neo4j_user = os.environ.get("NEO4J_USER", "neo4j")
+    neo4j_password = required_env("NEO4J_PASSWORD")
+
+    llm_base_url = os.environ.get(
+        "GRAPHITI_LLM_BASE_URL", "http://127.0.0.1:11434/v1"
+    )
+    llm_api_key = os.environ.get("GRAPHITI_LLM_API_KEY", "ollama")
+    llm_model = os.environ.get("GRAPHITI_LLM_MODEL", "qwen2.5:3b")
+    small_model = os.environ.get("GRAPHITI_SMALL_MODEL", llm_model)
+    embedding_model = os.environ.get(
+        "GRAPHITI_EMBEDDING_MODEL", "nomic-embed-text"
+    )
+    embedding_dim = int(os.environ.get("GRAPHITI_EMBEDDING_DIM", "768"))
+    structured_output_mode = os.environ.get(
+        "GRAPHITI_STRUCTURED_OUTPUT_MODE", "json_object"
+    )
+    if structured_output_mode not in {"json_schema", "json_object"}:
+        raise ValueError(
+            "GRAPHITI_STRUCTURED_OUTPUT_MODE must be json_schema or json_object"
+        )
+
+    neo4j_version = await wait_for_neo4j(neo4j_uri, neo4j_user, neo4j_password)
+
+    llm_config = LLMConfig(
+        api_key=llm_api_key,
+        model=llm_model,
+        small_model=small_model,
+        base_url=llm_base_url,
+    )
+    llm_client = OpenAIGenericClient(
+        config=llm_config,
+        structured_output_mode=structured_output_mode,
+        max_tokens=4096,
+    )
+    embedder = OpenAIEmbedder(
+        config=OpenAIEmbedderConfig(
+            api_key=llm_api_key,
+            embedding_model=embedding_model,
+            embedding_dim=embedding_dim,
+            base_url=llm_base_url,
+        )
+    )
+    graphiti = Graphiti(
+        neo4j_uri,
+        neo4j_user,
+        neo4j_password,
+        llm_client=llm_client,
+        embedder=embedder,
+        cross_encoder=OpenAIRerankerClient(
+            client=llm_client.client,
+            config=llm_config,
+        ),
+        max_coroutines=1,
+    )
+
+    build_manifest = {
+        "graphiti_version": importlib.metadata.version("graphiti-core"),
+        "neo4j_version": neo4j_version,
+        "llm_provider": "openai-compatible",
+        "llm_base_url": llm_base_url,
+        "model_id": llm_model,
+        "small_model_id": small_model,
+        "embedding_model_id": embedding_model,
+        "embedding_dim": embedding_dim,
+        "structured_output_mode": structured_output_mode,
+        "ontology_version": os.environ.get("FOSSIL_ONTOLOGY_VERSION", "1.0.0"),
+        "software_commit": commit,
+    }
+    projection = GraphitiProjectionAdapter(
+        client=graphiti,
+        ledger=ProjectionLedger(
+            root / "projection-ledger",
+            GraphitiProjectionAdapter.name,
+        ),
+        build_manifest=build_manifest,
+        episode_type_json=EpisodeType.json,
+    )
+
+    episode_name = f"dkg-event:{event_id}"
+    proof: dict[str, Any] = {
+        "status": "started",
+        "event_id": event_id,
+        "pack_id": PACK_ID,
+        "episode_name": episode_name,
+        "durable_event_path_exists_before_projection": True,
+        "build_manifest": build_manifest,
+    }
+
+    try:
+        await projection.initialize_async()
+
+        first = await projection.apply_event_async(accepted_event)
+        proof["first_receipt"] = {
+            "status": first.status,
+            "detail": first.detail,
+        }
+        if first.status != "applied":
+            raise AssertionError(f"first projection did not apply: {first}")
+
+        after_first = await observe_projection(
+            neo4j_uri,
+            neo4j_user,
+            neo4j_password,
+            group_id=PACK_ID,
+            episode_name=episode_name,
+        )
+        proof["after_first_projection"] = after_first
+        if after_first["episode_count"] != 1:
+            raise AssertionError(
+                "expected exactly one real Graphiti Episodic node after projection"
+            )
+        if not any(event_id in content for content in after_first["episode_contents"]):
+            raise AssertionError(
+                "projected Graphiti episode does not contain the durable event id"
+            )
+        if after_first["mentioned_entity_count"] < 1:
+            raise AssertionError(
+                "Graphiti materialized the episode but extracted no mentioned entities"
+            )
+
+        second = await projection.apply_event_async(accepted_event)
+        proof["second_receipt"] = {
+            "status": second.status,
+            "detail": second.detail,
+        }
+        if second.status != "skipped":
+            raise AssertionError(
+                f"replay should be skipped by projection ledger: {second}"
+            )
+
+        after_retry = await observe_projection(
+            neo4j_uri,
+            neo4j_user,
+            neo4j_password,
+            group_id=PACK_ID,
+            episode_name=episode_name,
+        )
+        proof["after_idempotent_retry"] = after_retry
+        if after_retry["episode_count"] != 1:
+            raise AssertionError(
+                "idempotent retry changed the Graphiti episode count"
+            )
+
+        applied_record = projection.ledger.get_applied(event_id)
+        proof["projection_ledger"] = applied_record
+        if applied_record["group_id"] != PACK_ID:
+            raise AssertionError("projection ledger did not preserve pack namespace")
+
+        proof["status"] = "passed"
+    finally:
+        await projection.close_async()
+
+    proof_path = Path(
+        os.environ.get(
+            "FOSSIL_PROOF_PATH",
+            str(root / "live-graphiti-proof.json"),
+        )
+    )
+    proof_path.parent.mkdir(parents=True, exist_ok=True)
+    proof_path.write_text(
+        json.dumps(proof, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(proof, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Closes the remaining live-integration portion of #4 once the workflow evidence passes.

This PR adds a real Gate 1 smoke path that:

- commits a schema-valid durable FOSSIL event before any graph projection;
- starts Neo4j 5.26 as a real service;
- runs Graphiti 0.29.3 against local Ollama-backed `qwen2.5:3b` and `nomic-embed-text` providers;
- initializes Graphiti indices/constraints;
- projects through the existing `GraphitiProjectionAdapter`;
- verifies a real `Episodic` node exists under `group_id == pack_id` and contains the durable event ID;
- requires Graphiti to extract at least one mentioned entity;
- replays the same accepted event and proves the projection ledger skips it without creating a duplicate episode;
- uploads a runtime proof JSON containing actual Graphiti/Neo4j/model/ontology/code versions and observations.

This deliberately uses local models rather than an external paid model API, so the integration gate does not require an application API key. The workflow is isolated from the ordinary fast contract-test workflow.