### PR TITLE
ci: execute observable live Graphiti proof

### DIFF
--- a/.github/workflows/graphiti-live.yml
+++ b/.github/workflows/graphiti-live.yml
@@ -1,3 +1,4 @@
+# Proof-run trigger: no executable behavior differs from main.
 name: Graphiti live integration
 
 on:


### PR DESCRIPTION
No-op proof trigger for Issue #4. This changes only a YAML comment so the now-default-branch `Graphiti live integration` workflow runs as a normal pull-request workflow that can be inspected through the connected GitHub tooling. The executable workflow/script behavior is identical to `main`.

Do not merge this comment unless useful; its purpose is to obtain and inspect the real Neo4j + Graphiti runtime evidence.