### PR TITLE
ci: observable Gate 1 Graphiti proof run

### DIFF
--- a/.github/workflows/graphiti-live.yml
+++ b/.github/workflows/graphiti-live.yml
@@ -1,3 +1,4 @@
+# Proof-run trigger: no executable behavior differs from main.
 name: Graphiti live integration
 
 on:


### PR DESCRIPTION
Execution-only PR for Issue #4. The branch differs from current main by a no-op comment in the live workflow. Its purpose is to trigger the temporary branch-gated `gate1-live-graphiti-proof` job that is now present in the established DKG CI workflow on main, so the connected tooling can inspect the real Neo4j/Graphiti job and logs.