### PR TITLE
ci: run final live Graphiti Neo4j proof

### DIFF
--- a/.github/workflows/graphiti-live.yml
+++ b/.github/workflows/graphiti-live.yml
@@ -1,3 +1,4 @@
+# Final observable Gate 1 proof trigger; executable behavior matches main.
 name: Graphiti live integration
 
 on:


### PR DESCRIPTION
Superseded by the zero-click scheduled Gate 1 proof on `main`. This PR was an execution-only no-op trigger and must not be merged. The live workflow now self-reports its result to Issue #4.