### PR TITLE
ci: run live Graphiti redaction proof

### DIFF
--- a/.github/workflows/graphiti-live.yml
+++ b/.github/workflows/graphiti-live.yml
@@ -1,3 +1,4 @@
+# Disposable PR-only trigger comment; do not merge this comment.
 name: Graphiti live integration
 
 on:


### PR DESCRIPTION
Disposable execution-only PR. The standalone workflow did not register because `${{ runner.temp }}` had been used in job-level `env`; that workflow bug has now been fixed permanently by moving proof paths to step scope. Final live redaction proof succeeded via trusted CI run `31346791333`. Closed unmerged.