### PR TITLE
Gate 2: persist benchmark case sets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,17 +7,20 @@ This repository is designed so another GPT/Codex/Claude session can continue the
 1. `ARCHITECTURE.md` — frozen durable invariants.
 2. `docs/HANDOFF_CURRENT.md` — exact continuation point.
 3. `docs/PROJECT_STATE.md` — completed gate/work state.
-4. `docs/handoffs/2026-08-10-chatgpt-session-handoff.md` — detailed fresh-session transfer record, proof runs, operational notes, and proposed next campaign.
+4. `docs/handoffs/2026-08-10-chatgpt-session-handoff.md` — detailed transfer record for the completed Milestone 0 / Gate 1 checkpoint and the rationale for Gate 2.
 5. `docs/DECISION_LOG.md` — accepted decisions, alternatives, and reconsideration triggers.
 6. Gate/proof documents under `docs/implementation/`.
 7. `docs/research/2026-08-09-final-research-synthesis.md` and `docs/research/2026-08-09-evidence-ledger.md` when research rationale is needed.
-8. Closed GitHub Issue #1 and child Issues #2–#10 only when detailed implementation history is useful.
+8. GitHub Gate 2 control Issue #33 and active child issues #34–#37 for current implementation state.
+9. Closed GitHub Issue #1 and child Issues #2–#10 only when detailed Gate 1 history is useful.
 
 ## Current state
 
-**Milestone 0 is complete. Gate 1 is 15/15 complete. Issues #1–#10 are closed completed. There are no open pull requests or issues at the current checkpoint.**
+**Milestone 0 is complete. Gate 1 is 15/15 complete. Issues #1–#10 are closed completed. Gate 2 — Real Corpus + Retrieval/Model Bakeoff is now active under control Issue #33 with child Issues #34–#37.**
 
-Do not reopen the completed milestone merely to continue development. A materially new campaign should get a new tracked gate/control issue.
+Current first implementation slice: Issue #34, with draft PR #38 adding a persistent/versioned benchmark case-set contract before representative pack data is seeded.
+
+Do not reopen the completed milestone merely to continue development.
 
 ## Non-negotiable rules
 
@@ -54,7 +57,7 @@ Do not reopen the completed milestone merely to continue development. A material
 
 When changing one:
 
-1. open/update the relevant new active issue;
+1. open/update the relevant active issue;
 2. record the competing theory or failure;
 3. cite evidence/benchmark results;
 4. update `docs/DECISION_LOG.md`;
@@ -69,24 +72,22 @@ GitHub issues track implementation state. Repository docs track durable decision
 
 An issue can close, but an architectural decision must not exist only in an issue comment. Conversely, durable docs should point back to the issue/benchmark that caused the change when useful.
 
-## Next campaign rule
+## Active campaign — Gate 2
 
-There is **no active next issue yet**.
+Control issue: **#33 — Gate 2: Real Corpus + Retrieval/Model Bakeoff**.
 
-The natural next campaign is described in `docs/handoffs/2026-08-10-chatgpt-session-handoff.md` as:
+Children:
 
-**Gate 2 — Real Corpus + Retrieval/Model Bakeoff**
+1. **#34** representative real corpus fixtures + versioned gold/adversarial benchmark set;
+2. **#35** a small number of materially different real retrieval/context adapters behind existing interfaces;
+3. **#36** reproducible comparative `fossil.benchmark.v1` runs and failure taxonomy;
+4. **#37** evidence-based default retrieval/routing policy.
 
-A fresh session should verify GitHub state first, confirm the user still wants to proceed, then open a new tracked control issue before materially expanding work.
+Initial Gate 2 inspection established that `fossil-common` and `fossil-ai-systems` are currently pack scaffolds with empty event/artifact payloads. Issue #34 therefore includes seeding representative canonical evidence/events into those existing stable packs before calling the benchmark corpus "real".
 
-Recommended focus:
+Draft PR #38 adds the missing persistent case-set layer. Its first trusted CI run `31356440481`, job `93356916077`, passed **60 tests in 0.69s**. Exact citation gold is being stored as full immutable citation span/hash metadata rather than citation IDs alone.
 
-1. representative `fossil-common` + `fossil-ai-systems` corpus fixtures and gold/adversarial cases;
-2. a small number of real semantic/vector/graph/long-context competitors behind existing interfaces;
-3. reproducible `fossil.benchmark.v1` comparison of quality, latency, memory, estimated cost, and failure categories;
-4. evidence-based default retrieval/routing policy selection.
-
-Current BM25/hash-embedding/token-overlap implementations are **controls**, not production winners.
+Current BM25/hash-embedding/token-overlap implementations remain **controls, not production winners**. Gate 2 provider/routing choices must be earned by measured corpus performance.
 
 ## Session continuity protocol
 

--- a/docs/HANDOFF_CURRENT.md
+++ b/docs/HANDOFF_CURRENT.md
@@ -4,17 +4,17 @@
 **Project:** **FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage**  
 **Durable substrate:** **DICS — Durable Intellectual Corpus System**  
 **Repository:** `Pukujan/fossil-core`  
-**Status:** **Milestone 0 complete. Gate 1 = 15/15. Issues #1–#10 are closed completed. No PRs or issues are open.**
+**Status:** **Milestone 0 / Gate 1 complete. Gate 2 is active under Issue #33; current work is #34 with draft PR #38.**
 
 ## Fresh-session transfer record
 
-For a new ChatGPT/Codex/Claude session, read the detailed dated transfer first after the core contracts:
+The detailed Milestone 0 transfer remains:
 
 `docs/handoffs/2026-08-10-chatgpt-session-handoff.md`
 
-That file contains the verified proof runs, code surfaces, operational quirks, do-not-change rules, and the recommended shape of the next campaign.
+That dated handoff is authoritative for completed Gate 1 proof runs, operational quirks, and frozen do-not-change rules. This file is now authoritative for the newer Gate 2 continuation point.
 
-The repository was verified immediately before the transfer at `main` commit `239335ed5a8b23fb34aa9a80afb7faf62e3caffe`; the handoff documentation commits follow that clean state.
+Milestone 0 handoff tip commit: `b87b573c9d7514787c904836b48547a10a45d6bc`.
 
 ## Repository family
 
@@ -30,10 +30,12 @@ Repository/database/graph placement is not knowledge identity. Never mint replac
 2. `ARCHITECTURE.md`
 3. this file
 4. `docs/PROJECT_STATE.md`
-5. `docs/handoffs/2026-08-10-chatgpt-session-handoff.md`
-6. `docs/DECISION_LOG.md`
-7. proof docs under `docs/implementation/`
-8. closed Issue #1 and child Issues #2–#10 when detailed issue history is useful.
+5. Gate 2 control Issue #33 and active children #34–#37
+6. current PRs, especially draft PR #38 while #34 is active
+7. `docs/DECISION_LOG.md`
+8. `docs/handoffs/2026-08-10-chatgpt-session-handoff.md` for completed Gate 1 detail
+9. proof docs under `docs/implementation/`
+10. closed Issue #1 and children #2–#10 only when detailed implementation history is useful
 
 The chat UI is source material, not the control plane.
 
@@ -62,108 +64,107 @@ Additional frozen invariants:
 
 Do not casually rename the internal `src/dkg` namespace.
 
-## Completed proof stack
+## Completed Gate 1 proof stack
 
-### Durable core / packs / lifecycle
+- **#4 live Graphiti/Neo4j:** run `31338875226` — Graphiti `0.29.3` + Neo4j `5.26.29`, stable pack namespace, durable-first materialization, projection-failure preservation, idempotent retry.
+- **#5 destructive rebuild + blue/green:** run `31339930551` — graph candidate destroyed to zero, rebuilt from durable source using a fresh build-scoped ledger, semantic comparison matched, active switch guarded.
+- **#9 conversation lineage:** run `31340924480`, job `93314435997` — immutable source bytes/spans, `verbatim` vs `reconstructed`, opposing/current/historical lineage queries.
+- **#8 Agent Skills/API/MCP:** run `31341456769`, job `93315824532` — **39 passed in 0.51s**, protocol-independent `CorpusService`, pack/Skill-gated mutations, no arbitrary graph mutation path.
+- **#10 source provenance + redaction:** deterministic run `31345462801`, job `93326450028`; live run `31346791333`, job `93330095684` — tombstone-before-delete, active Graphiti purge, zero-state fresh rebuild/non-resurrection.
+- **#7 retrieval/model benchmark contract:** run `31347744797`, job `93332738616` — **56 passed in 0.70s**; versioned cognitive interfaces and benchmark result contract.
 
-Issues #2, #3, #6: atomic immutable publication, deterministic idempotency, content-addressed evidence, pack read/write boundaries/dependencies, provenance-preserving promotion, disagreement/supersession/staleness replay.
+The current BM25/hash-embedding/token-overlap stack is a **control**, not a production winner.
 
-### #4 live Graphiti/Neo4j
+## Gate 2 — active campaign
 
-Run `31338875226`: Graphiti `0.29.3` + Neo4j `5.26.29`, stable pack namespace, durable-first materialization, build metadata, projection-failure preservation, idempotent retry.
+Control: **#33 — Real Corpus + Retrieval/Model Bakeoff**.
 
-`json_schema` is the proven local structured-output mode; an earlier `json_object` attempt allowed malformed structured field names.
+Children:
 
-### #5 destructive rebuild + blue/green
+1. **#34** representative real corpus fixtures + versioned gold/adversarial benchmark set;
+2. **#35** real retrieval/context adapters behind existing interfaces;
+3. **#36** reproducible comparative bakeoff + failure taxonomy;
+4. **#37** evidence-based default retrieval/routing policy.
 
-Run `31339930551`: candidate destroyed to zero, rebuilt from the same durable source with a fresh build-scoped ledger, semantic comparison matched, active switch recorded only after checks.
+Do not reopen Issues #1–#10 for this work.
 
-Critical invariant: **new/rebuilt physical projection => fresh build-scoped applied ledger**.
+### #34 discovery: the pack repositories are scaffolds
 
-### #9 conversation lineage
+Verified `fossil-common` and `fossil-ai-systems` before writing benchmark fixtures.
 
-Run `31340924480` / job `93314435997`: immutable source bytes/spans, stable message ordering/parentage, explicit `verbatim` vs `reconstructed`, derived intellectual lineage with exact provenance, opposing/current/historical queries.
+- `fossil-common` current seed commit `94fd576286ee359f1929b31bbba99e0ca54d4b41` contains the stable pack manifest, contract/policy pointers, empty `artifacts/manifest.jsonl`, and `events/.gitkeep`.
+- `fossil-ai-systems` current seed commit `cfd03e08c36f00a5eb25c8de4c1463d06877e015` has the same scaffold-only shape.
 
-Recovered chat-loss material remains reconstructed, never a verbatim transcript.
+Therefore Gate 2A must **seed representative canonical evidence/events into the existing stable packs first**, then derive gold/adversarial cases from those durable objects. Do not fabricate benchmark-only prose and call it real corpus material.
 
-### #8 Agent Skills/API/MCP
+The AI-systems pack may read common + itself and write only itself. The common pack reads/writes itself. Use this real dependency boundary in cross-pack benchmark cases.
 
-Run `31341456769` / job `93315824532`: **39 passed in 0.51s**. Six progressive-disclosure Skills, protocol-independent `CorpusService`, pack/Skill-gated mutations, actor/model/harness/skill provenance, no arbitrary Cypher/Graphiti mutation path.
+### #34 implementation checkpoint: draft PR #38
 
-### #10 source provenance + redaction
+Branch: `agent/gate2-benchmark-case-set`.
 
-Deterministic run `31345462801` / job `93326450028`: **51 passed in 1.40s**.
+PR: **#38 — Gate 2: persist benchmark case sets**.
 
-Live run `31346791333` / job `93330095684`: exceptional tombstone-before-delete removed canonical event bytes, blocked same-ID resurrection, purged active Graphiti episode/entity state to zero, and remained absent on a fresh rebuild. Proof artifact `9047631921`.
+Purpose: Gate 1 versioned benchmark results but kept gold cases as Python fixtures. Gate 2 needs a persistent case-set contract so every provider runs against the same pinned corpus and evidence targets.
 
-Normal intellectual revision remains append-only. Privacy/legal erasure is an explicit exceptional path.
+Current PR contents:
 
-### #7 retrieval/model benchmark contract
+- `schemas/benchmark/case-set-v1.schema.json` — `fossil.benchmark-case-set.v1`;
+- `src/dkg/benchmark_cases.py` — schema/semantic loader + conversion into existing benchmark case types;
+- `tests/test_benchmark_case_set.py` — contract coverage;
+- case-set corpus entries pin exact repository commit SHAs;
+- retrieval cases cannot mount packs not pinned by the case set;
+- duplicate case IDs are rejected;
+- gold metadata stores exact `fossil.citation.v1` citation objects, including byte span and passage hash, plus declared source snapshots;
+- citation gold referring to an undeclared snapshot is rejected.
 
-Run `31347744797` / job `93332738616`: **56 passed in 0.70s**.
+First trusted PR CI run before the citation follow-up:
 
-Versioned service controls:
+- run `31356440481`
+- job `93356916077`
+- **60 passed in 0.69s**
 
-- `BM25Retriever`
-- `HashEmbeddingProvider`
-- `EmbeddingRetriever`
-- `TokenOverlapReranker`
-- `BudgetedContextProvider`
-- `CallableCandidateModelService`
-- `RiskEscalationPolicy`
-- `PolicyVerificationService`
+The branch has follow-up citation-contract and continuity-doc commits after that run. **Check the latest PR CI before merging.**
 
-The benchmark schema/harness measures quality, latency, peak Python allocation memory, estimated provider cost, and category-specific failure rates. Provider/model/runtime/benchmark provenance can be committed to review events.
+### Next implementation step
 
-These are **controls, not production winners**. Future providers must compete behind the interfaces.
+After PR #38 is current/green:
 
-## CI / workflow state
+1. seed a modest representative evidence set into `fossil-common` and `fossil-ai-systems` through the existing artifact/source/event contracts rather than hand-written ad hoc objects;
+2. use immutable `repository_ref` locators and exact source commit SHAs for imported FOSSIL proof/policy material;
+3. derive exact citations from source bytes and persist those citation objects in Gate 2 gold cases;
+4. include cases for source/citation recovery, lineage, historical/current distinction, disagreement, stale/superseded assumptions, cross-pack boundaries, obscure evidence, conversation lineage, and insufficient evidence;
+5. only then proceed to #35 provider competitors.
 
-Final clean Gate 1 run `31347457485` / job `93331933728`: **51 passed in 0.82s**.
+Good initial source material already inspected in `fossil-core` includes:
 
-Expanded post-#7 run `31347744797` / job `93332738616`: **56 passed in 0.70s**.
+- `policies/source-quality-v1.md` for shared/common source methodology;
+- `docs/implementation/2026-08-10-retrieval-model-benchmark-contract-proof.md` for provider/control and authority boundaries;
+- `docs/implementation/2026-08-09-gate1-rebuild-blue-green-proof.md` for rebuild/ledger/history semantics;
+- other Gate 1 lineage/redaction proofs as needed for difficult cases.
 
-`.github/workflows/ci.yml` is the normal fast suite.
+Do not assign fake universal quality tiers. Source snapshots preserve independent quality dimensions and exact repository version metadata.
 
-`.github/workflows/graphiti-live.yml` contains reusable real Graphiti/Neo4j materialization + redaction/non-resurrection coverage. Runner-dependent temporary paths are step-scoped; the earlier invalid job-level `${{ runner.temp }}` usage is fixed.
+## Gate 2 exit criteria
 
-Operational nuance: the permanent live workflow currently names `deepseek-r1:7b`; the successful final live redaction proof used `qwen2.5:3b`. Model choice in this workflow is replaceable test/runtime configuration, not architecture.
-
-## Milestone closure
-
-All original children #2–#10 and control Issue #1 are closed completed. At this checkpoint GitHub has **zero open issues and zero open pull requests**.
-
-Do not reopen those completed issues just to start the next development phase.
-
-## Natural next phase — intentionally not opened automatically
-
-Recommended next campaign:
-
-**Gate 2 — Real Corpus + Retrieval/Model Bakeoff**
-
-Goal: use representative `fossil-common` and `fossil-ai-systems` material to compare the current controls against selected real semantic/vector/graph/long-context providers under the existing benchmark contract.
-
-A fresh session should first verify current GitHub state, then—if the user still wants to proceed—open a **new tracked Gate 2 control issue** and a small set of child issues rather than extending closed Milestone 0.
-
-Suggested Gate 2 work:
-
-1. representative real corpus + gold/adversarial benchmark cases;
-2. a few materially different real retrieval/context adapters behind existing interfaces;
-3. reproducible comparative benchmark runs for quality, latency, memory, estimated cost, and failure categories;
-4. evidence-based default routing/retrieval policy selection.
-
-Do not build a model zoo. Do not choose providers by novelty. Let measured corpus performance choose adapters.
-
-See `docs/handoffs/2026-08-10-chatgpt-session-handoff.md` for proposed Gate 2 exit criteria and a ready-to-paste continuation prompt.
+- representative real corpus fixtures exist using both stable packs;
+- versioned gold/adversarial benchmark set exists;
+- at least two materially different real retrieval strategies are compared with controls;
+- reproducible `fossil.benchmark.v1` outputs record provider/runtime/model/implementation identity;
+- quality, latency, memory, estimated cost, and category-specific failures are captured;
+- failure taxonomy is documented;
+- one default routing/retrieval policy is selected from measured evidence;
+- canonical FOSSIL identity/durability does not change merely to suit a benchmark winner;
+- `docs/DECISION_LOG.md`, `docs/PROJECT_STATE.md`, and this handoff reflect the Gate 2 result.
 
 ## End-of-session rule
 
 After substantial future work:
 
 - update this file;
-- update `docs/PROJECT_STATE.md` when the gate changes;
-- update the active GitHub issue(s);
+- update `docs/PROJECT_STATE.md` when gate/work state changes;
+- update active GitHub issues;
 - commit material benchmark/proof evidence;
-- update `docs/DECISION_LOG.md` when a decision changes;
+- update `docs/DECISION_LOG.md` when an actual architectural/default decision changes;
 - preserve prior reasoning rather than rewriting history;
 - never rely on the chat UI as the only durable project record.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -2,8 +2,8 @@
 
 **Project:** **FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage**  
 **Durable substrate:** **DICS — Durable Intellectual Corpus System**  
-**Current phase:** **Milestone 0 complete; Gate 1 = 15/15; Issues #1–#10 closed completed**  
-**Next phase:** not yet opened; natural next campaign is corpus-scale comparison of real retrieval/model providers behind the benchmark interfaces  
+**Current phase:** **Milestone 0 / Gate 1 complete; Gate 2 active under Issue #33**  
+**Active work:** **#34 representative real corpus + versioned gold/adversarial benchmark set; draft PR #38**  
 **Control plane:** GitHub issues + durable repository docs  
 **Last updated:** 2026-08-10
 
@@ -21,9 +21,10 @@ Repository/database/graph placement is physical placement, not knowledge identit
 2. `ARCHITECTURE.md`
 3. `docs/HANDOFF_CURRENT.md`
 4. this file
-5. `docs/DECISION_LOG.md`
-6. proof docs under `docs/implementation/`
-7. closed Milestone #1 and child Issues #2–#10
+5. Gate 2 control Issue #33 and active children #34–#37
+6. `docs/DECISION_LOG.md`
+7. proof docs under `docs/implementation/`
+8. closed Milestone 0 Issue #1 and child Issues #2–#10 when detailed history is useful
 
 The chat UI is source material, not the control plane.
 
@@ -62,14 +63,49 @@ Final cleaned Gate 1 run `31347457485`, job `93331933728`: **51 passed in 0.82s*
 - **#9 conversation lineage:** run `31340924480`, job `93314435997` — exact source spans, durable `verbatim` vs `reconstructed`, opposing/current/historical lineage queries.
 - **#8 agent boundary:** run `31341456769`, job `93315824532` — progressive-disclosure Skills, protocol-independent corpus service, no arbitrary graph mutation.
 - **#10 provenance/redaction:** deterministic run `31345462801`, job `93326450028`; live run `31346791333`, job `93330095684` — tombstone-before-delete, active Graphiti purge, zero-state fresh rebuild/non-resurrection.
+- **#7 cognitive-service contract:** run `31347744797`, job `93332738616` — **56 passed in 0.70s**; versioned replaceable cognitive-service interfaces and `fossil.benchmark.v1` result contract.
 
-## #7 cognitive-service benchmark contract — complete
+## Gate 2 — active
 
-Trusted run `31347744797`, job `93332738616`: **56 passed in 0.70s**.
+Control issue: **#33 — Real Corpus + Retrieval/Model Bakeoff**.
 
-Versioned interfaces: `Retriever`, `EmbeddingProvider`, `Reranker`, `ContextProvider`, `ModelService`, `VerificationService`.
+Children:
 
-Initial inspectable controls:
+- [ ] #34 representative corpus fixtures + gold/adversarial benchmark set
+- [ ] #35 real retrieval/context adapters behind existing interfaces
+- [ ] #36 reproducible comparative bakeoff + failure taxonomy
+- [ ] #37 evidence-based default retrieval/routing policy
+
+### Current #34 checkpoint
+
+Initial repository inspection found both physical pack repositories are still scaffolds:
+
+- `fossil-common` initial commit `94fd576286ee359f1929b31bbba99e0ca54d4b41` contains the stable manifest/policy pointers plus empty event/artifact payloads;
+- `fossil-ai-systems` initial commit `cfd03e08c36f00a5eb25c8de4c1463d06877e015` likewise contains only the stable pack scaffold.
+
+Therefore Gate 2A must seed representative canonical evidence/events into the existing stable packs before deriving a benchmark and calling it a real corpus.
+
+Draft PR **#38 — `Gate 2: persist benchmark case sets`** adds the missing portable case-set layer:
+
+- `fossil.benchmark-case-set.v1`;
+- exact repository commit pins for each participating pack;
+- persistent retrieval/model cases converted into the existing Gate 1 benchmark case types;
+- exact citation span/hash gold metadata plus source snapshot references;
+- semantic rejection of duplicate case IDs, unpinned retrieval pack scopes, and citation gold that references undeclared source snapshots.
+
+First trusted PR run `31356440481`, job `93356916077`: **60 passed in 0.69s**. The branch received follow-up exact-citation validation changes after that run; re-check current PR CI before merging.
+
+### Gate 2 exit target
+
+- representative real corpus fixtures from both stable packs;
+- versioned gold/adversarial benchmark set;
+- at least two materially different real retrieval strategies compared against controls;
+- reproducible benchmark evidence for quality, latency, memory, estimated cost, and failure categories;
+- documented failure taxonomy;
+- one evidence-based default retrieval/routing policy;
+- no canonical identity/durability change merely to suit a benchmark winner.
+
+## Current cognitive-service controls
 
 - `BM25Retriever`
 - `HashEmbeddingProvider`
@@ -80,26 +116,7 @@ Initial inspectable controls:
 - `RiskEscalationPolicy`
 - `PolicyVerificationService`
 
-`schemas/benchmark/v1.schema.json` + `src/dkg/benchmark.py` measure retrieval/model quality, mean/p95 latency, peak Python allocation bytes, estimated provider cost, and failures by domain category. Provider/model/runtime/benchmark identity can be persisted in review event provenance.
-
-These implementations are **baselines/controls, not chosen production winners**. Future semantic/vector/graph/long-context/model candidates must compete behind the interfaces.
-
-Small/local model output is `candidate_only`. Truth-changing commit eligibility comes from a separate evidence/risk policy, not model consensus.
-
-Evidence: `docs/implementation/2026-08-10-retrieval-model-benchmark-contract-proof.md`.
-
-## Closed issue map
-
-- #1 Milestone 0 control — **complete**
-- #2 durable event + artifact store — **complete**
-- #3 pack boundaries/mounts/promotion — **complete**
-- #4 Graphiti + Neo4j projection — **complete**
-- #5 destructive rebuild + blue/green — **complete**
-- #6 lifecycle/disagreement/supersession/staleness — **complete**
-- #7 pluggable retrieval/model services + benchmark contract — **complete**
-- #8 Agent Skills + thin corpus API/MCP — **complete**
-- #9 conversation ingestion + intellectual lineage — **complete**
-- #10 source snapshots/citation/redaction — **complete**
+These remain **baselines/controls, not chosen production winners**. Small/local model output remains `candidate_only`; truth-changing eligibility comes from the separate evidence/risk policy.
 
 ## Frozen invariants from Milestone 0
 
@@ -125,8 +142,4 @@ Evidence: `docs/implementation/2026-08-10-retrieval-model-benchmark-contract-pro
 
 `.github/workflows/graphiti-live.yml` contains reusable live materialization plus redaction/non-resurrection smoke coverage. Runner-dependent proof paths are step-scoped; the invalid job-level `runner.temp` usage found during Gate 1 is fixed.
 
-There are no open Issues or pull requests in `Pukujan/fossil-core` at this checkpoint.
-
-## Natural next phase — not yet opened
-
-Use representative `fossil-common` and `fossil-ai-systems` material to compare the current controls against selected real semantic/vector/graph/long-context providers under the existing benchmark contract. Open a new tracked gate before materially expanding that campaign.
+GitHub currently has active Gate 2 Issues #33–#37 and draft PR #38. Do not use the old "zero open issues/PRs" Milestone 0 checkpoint as current state.

--- a/schemas/benchmark/case-set-v1.schema.json
+++ b/schemas/benchmark/case-set-v1.schema.json
@@ -55,19 +55,76 @@
     }
   },
   "$defs": {
+    "hash": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "digest"],
+      "properties": {
+        "algorithm": {"const": "sha256"},
+        "digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+      }
+    },
+    "citation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "citation_id",
+        "snapshot_id",
+        "artifact_id",
+        "byte_start",
+        "byte_end",
+        "passage_hash"
+      ],
+      "properties": {
+        "schema_version": {"const": "fossil.citation.v1"},
+        "citation_id": {
+          "type": "string",
+          "pattern": "^cite_[A-Za-z0-9_-]{12,}$"
+        },
+        "snapshot_id": {
+          "type": "string",
+          "pattern": "^snap_[A-Za-z0-9_-]{12,}$"
+        },
+        "artifact_id": {
+          "type": "string",
+          "pattern": "^art_[A-Za-z0-9_-]{16,}$"
+        },
+        "byte_start": {"type": ["integer", "null"], "minimum": 0},
+        "byte_end": {"type": ["integer", "null"], "minimum": 1},
+        "passage_hash": {
+          "oneOf": [
+            {"type": "null"},
+            {"$ref": "#/$defs/hash"}
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"byte_start": {"type": "integer"}}},
+          "then": {
+            "properties": {
+              "byte_end": {"type": "integer"},
+              "passage_hash": {"$ref": "#/$defs/hash"}
+            }
+          }
+        },
+        {
+          "if": {"properties": {"byte_end": {"type": "integer"}}},
+          "then": {"properties": {"byte_start": {"type": "integer"}}}
+        }
+      ]
+    },
     "gold": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "answerable": {"type": "boolean"},
         "expected_answer": {"type": ["string", "null"]},
-        "citation_ids": {
+        "citations": {
           "type": "array",
           "uniqueItems": true,
-          "items": {
-            "type": "string",
-            "pattern": "^cite_[A-Za-z0-9_-]{12,}$"
-          }
+          "items": {"$ref": "#/$defs/citation"}
         },
         "source_snapshot_ids": {
           "type": "array",

--- a/schemas/benchmark/case-set-v1.schema.json
+++ b/schemas/benchmark/case-set-v1.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pukujan.github.io/fossil-core/schemas/benchmark/case-set-v1.schema.json",
+  "title": "FOSSIL Benchmark Case Set v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "case_set_id",
+    "title",
+    "description",
+    "created_at",
+    "corpus",
+    "cases"
+  ],
+  "properties": {
+    "schema_version": {"const": "fossil.benchmark-case-set.v1"},
+    "case_set_id": {
+      "type": "string",
+      "pattern": "^caseset_[A-Za-z0-9_-]{12,}$"
+    },
+    "title": {"type": "string", "minLength": 1},
+    "description": {"type": "string", "minLength": 1},
+    "created_at": {"type": "string", "format": "date-time"},
+    "corpus": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["pack_id", "repository", "commit_sha"],
+        "properties": {
+          "pack_id": {
+            "type": "string",
+            "pattern": "^pack_[A-Za-z0-9_-]{16,}$"
+          },
+          "repository": {"type": "string", "minLength": 3},
+          "commit_sha": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{40}$"
+          }
+        }
+      }
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {"$ref": "#/$defs/retrieval_case"},
+          {"$ref": "#/$defs/model_case"}
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "gold": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "answerable": {"type": "boolean"},
+        "expected_answer": {"type": ["string", "null"]},
+        "citation_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^cite_[A-Za-z0-9_-]{12,}$"
+          }
+        },
+        "source_snapshot_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^snap_[A-Za-z0-9_-]{12,}$"
+          }
+        },
+        "notes": {"type": ["string", "null"]}
+      }
+    },
+    "retrieval_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "case_id",
+        "category",
+        "query",
+        "pack_ids",
+        "relevant_ids",
+        "gold"
+      ],
+      "properties": {
+        "kind": {"const": "retrieval"},
+        "case_id": {"type": "string", "minLength": 1},
+        "category": {"type": "string", "minLength": 1},
+        "query": {"type": "string", "minLength": 1},
+        "pack_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^pack_[A-Za-z0-9_-]{16,}$"
+          }
+        },
+        "relevant_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "gold": {"$ref": "#/$defs/gold"},
+        "tags": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "model_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "case_id",
+        "category",
+        "task",
+        "expected_output",
+        "gold"
+      ],
+      "properties": {
+        "kind": {"const": "model"},
+        "case_id": {"type": "string", "minLength": 1},
+        "category": {"type": "string", "minLength": 1},
+        "task": {"type": "object"},
+        "expected_output": {
+          "type": "object",
+          "minProperties": 1
+        },
+        "gold": {"$ref": "#/$defs/gold"},
+        "tags": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    }
+  }
+}

--- a/src/dkg/benchmark_cases.py
+++ b/src/dkg/benchmark_cases.py
@@ -21,8 +21,9 @@ def load_benchmark_case_set(
     """Load and validate a persistent benchmark case set.
 
     JSON Schema owns the portable data shape. These semantic checks cover the
-    relationships JSON Schema cannot express compactly: case IDs are unique and
-    retrieval cases may only mount packs pinned by the case-set corpus manifest.
+    relationships JSON Schema cannot express compactly: case IDs are unique,
+    retrieval cases may only mount packs pinned by the case-set corpus, and
+    exact citation gold must resolve to source snapshots declared by the case.
     """
 
     candidate = json.loads(Path(path).read_text(encoding="utf-8"))
@@ -35,14 +36,31 @@ def load_benchmark_case_set(
 
     corpus_pack_ids = {str(entry["pack_id"]) for entry in candidate["corpus"]}
     for case in candidate["cases"]:
-        if case["kind"] != "retrieval":
-            continue
-        requested = {str(pack_id) for pack_id in case["pack_ids"]}
-        unavailable = requested - corpus_pack_ids
-        if unavailable:
+        if case["kind"] == "retrieval":
+            requested = {str(pack_id) for pack_id in case["pack_ids"]}
+            unavailable = requested - corpus_pack_ids
+            if unavailable:
+                raise BenchmarkCaseSetError(
+                    "retrieval case references packs not pinned by the case-set corpus: "
+                    + ", ".join(sorted(unavailable))
+                )
+
+        gold = dict(case.get("gold", {}))
+        citations = list(gold.get("citations", []))
+        citation_ids = [str(citation["citation_id"]) for citation in citations]
+        if len(citation_ids) != len(set(citation_ids)):
             raise BenchmarkCaseSetError(
-                "retrieval case references packs not pinned by the case-set corpus: "
-                + ", ".join(sorted(unavailable))
+                f"benchmark case {case['case_id']} contains duplicate citation IDs"
+            )
+        declared_snapshots = {
+            str(snapshot_id) for snapshot_id in gold.get("source_snapshot_ids", [])
+        }
+        cited_snapshots = {str(citation["snapshot_id"]) for citation in citations}
+        undeclared = cited_snapshots - declared_snapshots
+        if undeclared:
+            raise BenchmarkCaseSetError(
+                f"benchmark case {case['case_id']} citations reference undeclared source snapshots: "
+                + ", ".join(sorted(undeclared))
             )
 
     return copy.deepcopy(candidate)

--- a/src/dkg/benchmark_cases.py
+++ b/src/dkg/benchmark_cases.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+from .benchmark import ModelBenchmarkCase, RetrievalBenchmarkCase
+
+
+class BenchmarkCaseSetError(ValueError):
+    pass
+
+
+def load_benchmark_case_set(
+    path: Path,
+    schema_path: Path,
+) -> dict[str, Any]:
+    """Load and validate a persistent benchmark case set.
+
+    JSON Schema owns the portable data shape. These semantic checks cover the
+    relationships JSON Schema cannot express compactly: case IDs are unique and
+    retrieval cases may only mount packs pinned by the case-set corpus manifest.
+    """
+
+    candidate = json.loads(Path(path).read_text(encoding="utf-8"))
+    schema = json.loads(Path(schema_path).read_text(encoding="utf-8"))
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(candidate)
+
+    case_ids = [str(case["case_id"]) for case in candidate["cases"]]
+    if len(case_ids) != len(set(case_ids)):
+        raise BenchmarkCaseSetError("benchmark case IDs must be unique within a case set")
+
+    corpus_pack_ids = {str(entry["pack_id"]) for entry in candidate["corpus"]}
+    for case in candidate["cases"]:
+        if case["kind"] != "retrieval":
+            continue
+        requested = {str(pack_id) for pack_id in case["pack_ids"]}
+        unavailable = requested - corpus_pack_ids
+        if unavailable:
+            raise BenchmarkCaseSetError(
+                "retrieval case references packs not pinned by the case-set corpus: "
+                + ", ".join(sorted(unavailable))
+            )
+
+    return copy.deepcopy(candidate)
+
+
+def retrieval_cases_from_case_set(
+    case_set: Mapping[str, Any],
+) -> list[RetrievalBenchmarkCase]:
+    return [
+        RetrievalBenchmarkCase(
+            case_id=str(case["case_id"]),
+            query=str(case["query"]),
+            pack_ids=tuple(str(pack_id) for pack_id in case["pack_ids"]),
+            relevant_ids=frozenset(str(identifier) for identifier in case["relevant_ids"]),
+            category=str(case["category"]),
+        )
+        for case in case_set["cases"]
+        if case["kind"] == "retrieval"
+    ]
+
+
+def model_cases_from_case_set(
+    case_set: Mapping[str, Any],
+) -> list[ModelBenchmarkCase]:
+    return [
+        ModelBenchmarkCase(
+            case_id=str(case["case_id"]),
+            task=copy.deepcopy(dict(case["task"])),
+            expected_output=copy.deepcopy(dict(case["expected_output"])),
+            category=str(case["category"]),
+        )
+        for case in case_set["cases"]
+        if case["kind"] == "model"
+    ]

--- a/tests/test_benchmark_case_set.py
+++ b/tests/test_benchmark_case_set.py
@@ -28,6 +28,21 @@ def schema() -> Path:
     return root() / "schemas" / "benchmark" / "case-set-v1.schema.json"
 
 
+def fixture_citation() -> dict:
+    return {
+        "schema_version": "fossil.citation.v1",
+        "citation_id": "cite_fixture_source_quality_001",
+        "snapshot_id": "snap_fixture_source_quality_001",
+        "artifact_id": "art_fixture_source_quality_00000001",
+        "byte_start": 12,
+        "byte_end": 36,
+        "passage_hash": {
+            "algorithm": "sha256",
+            "digest": "a" * 64,
+        },
+    }
+
+
 def fixture() -> dict:
     return {
         "schema_version": "fossil.benchmark-case-set.v1",
@@ -58,7 +73,7 @@ def fixture() -> dict:
                 "gold": {
                     "answerable": True,
                     "expected_answer": "Source usefulness is claim-specific and dimensions remain canonical.",
-                    "citation_ids": ["cite_fixture_source_quality_001"],
+                    "citations": [fixture_citation()],
                     "source_snapshot_ids": ["snap_fixture_source_quality_001"],
                     "notes": "IDs are fixture-shaped here; Gate 2 corpus seeding will replace them with generated stable IDs.",
                 },
@@ -76,7 +91,7 @@ def fixture() -> dict:
                 "gold": {
                     "answerable": False,
                     "expected_answer": None,
-                    "citation_ids": [],
+                    "citations": [],
                     "source_snapshot_ids": [],
                     "notes": "The benchmark baseline explicitly does not select a production winner.",
                 },
@@ -97,9 +112,10 @@ def test_case_set_pins_corpus_and_loads_existing_benchmark_case_types(tmp_path):
 
     assert loaded["corpus"][0]["pack_id"] == COMMON
     assert loaded["corpus"][1]["pack_id"] == AI
-    assert loaded["cases"][0]["gold"]["citation_ids"] == [
-        "cite_fixture_source_quality_001"
-    ]
+    citation = loaded["cases"][0]["gold"]["citations"][0]
+    assert citation["citation_id"] == "cite_fixture_source_quality_001"
+    assert citation["byte_start"] == 12
+    assert citation["passage_hash"]["digest"] == "a" * 64
 
     retrieval = retrieval_cases_from_case_set(loaded)
     assert len(retrieval) == 1
@@ -127,6 +143,16 @@ def test_case_set_rejects_retrieval_pack_not_pinned_by_corpus(tmp_path):
     payload["cases"][0]["pack_ids"] = [OTHER]
 
     with pytest.raises(BenchmarkCaseSetError, match="not pinned by the case-set corpus"):
+        load_benchmark_case_set(write_case_set(tmp_path, payload), schema())
+
+
+def test_case_set_rejects_citation_snapshot_not_declared_by_gold(tmp_path):
+    payload = fixture()
+    payload["cases"][0]["gold"]["source_snapshot_ids"] = [
+        "snap_different_source_snapshot_001"
+    ]
+
+    with pytest.raises(BenchmarkCaseSetError, match="undeclared source snapshots"):
         load_benchmark_case_set(write_case_set(tmp_path, payload), schema())
 
 

--- a/tests/test_benchmark_case_set.py
+++ b/tests/test_benchmark_case_set.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import ValidationError
+
+from dkg.benchmark_cases import (
+    BenchmarkCaseSetError,
+    load_benchmark_case_set,
+    model_cases_from_case_set,
+    retrieval_cases_from_case_set,
+)
+
+
+COMMON = "pack_269099f7b2ba43b7a99b9427d64092de"
+AI = "pack_f024177f89a5442db84171c3dd7f58e5"
+OTHER = "pack_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+
+def root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def schema() -> Path:
+    return root() / "schemas" / "benchmark" / "case-set-v1.schema.json"
+
+
+def fixture() -> dict:
+    return {
+        "schema_version": "fossil.benchmark-case-set.v1",
+        "case_set_id": "caseset_gate2_fixture_001",
+        "title": "Gate 2 fixture contract",
+        "description": "Persistent gold cases pin their corpus commits and exact evidence targets.",
+        "created_at": "2026-08-10T04:45:00Z",
+        "corpus": [
+            {
+                "pack_id": COMMON,
+                "repository": "Pukujan/fossil-common",
+                "commit_sha": "94fd576286ee359f1929b31bbba99e0ca54d4b41",
+            },
+            {
+                "pack_id": AI,
+                "repository": "Pukujan/fossil-ai-systems",
+                "commit_sha": "cfd03e08c36f00a5eb25c8de4c1463d06877e015",
+            },
+        ],
+        "cases": [
+            {
+                "kind": "retrieval",
+                "case_id": "source_quality_dimensions",
+                "category": "source-citation-recovery",
+                "query": "Why must source quality dimensions remain separate?",
+                "pack_ids": [COMMON],
+                "relevant_ids": ["doc_common_source_quality"],
+                "gold": {
+                    "answerable": True,
+                    "expected_answer": "Source usefulness is claim-specific and dimensions remain canonical.",
+                    "citation_ids": ["cite_fixture_source_quality_001"],
+                    "source_snapshot_ids": ["snap_fixture_source_quality_001"],
+                    "notes": "IDs are fixture-shaped here; Gate 2 corpus seeding will replace them with generated stable IDs.",
+                },
+                "tags": ["exact-citation", "common-pack"],
+            },
+            {
+                "kind": "model",
+                "case_id": "insufficient_evidence_negative",
+                "category": "insufficient-evidence",
+                "task": {
+                    "query": "Which permanent semantic retriever has FOSSIL selected?",
+                    "pack_ids": [COMMON, AI],
+                },
+                "expected_output": {"answerable": False},
+                "gold": {
+                    "answerable": False,
+                    "expected_answer": None,
+                    "citation_ids": [],
+                    "source_snapshot_ids": [],
+                    "notes": "The benchmark baseline explicitly does not select a production winner.",
+                },
+                "tags": ["negative", "authority-boundary"],
+            },
+        ],
+    }
+
+
+def write_case_set(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "case-set.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_case_set_pins_corpus_and_loads_existing_benchmark_case_types(tmp_path):
+    loaded = load_benchmark_case_set(write_case_set(tmp_path, fixture()), schema())
+
+    assert loaded["corpus"][0]["pack_id"] == COMMON
+    assert loaded["corpus"][1]["pack_id"] == AI
+    assert loaded["cases"][0]["gold"]["citation_ids"] == [
+        "cite_fixture_source_quality_001"
+    ]
+
+    retrieval = retrieval_cases_from_case_set(loaded)
+    assert len(retrieval) == 1
+    assert retrieval[0].case_id == "source_quality_dimensions"
+    assert retrieval[0].pack_ids == (COMMON,)
+    assert retrieval[0].relevant_ids == frozenset({"doc_common_source_quality"})
+
+    model = model_cases_from_case_set(loaded)
+    assert len(model) == 1
+    assert model[0].case_id == "insufficient_evidence_negative"
+    assert model[0].task["pack_ids"] == [COMMON, AI]
+    assert model[0].expected_output == {"answerable": False}
+
+
+def test_case_set_rejects_duplicate_case_ids(tmp_path):
+    payload = fixture()
+    payload["cases"][1]["case_id"] = payload["cases"][0]["case_id"]
+
+    with pytest.raises(BenchmarkCaseSetError, match="case IDs must be unique"):
+        load_benchmark_case_set(write_case_set(tmp_path, payload), schema())
+
+
+def test_case_set_rejects_retrieval_pack_not_pinned_by_corpus(tmp_path):
+    payload = fixture()
+    payload["cases"][0]["pack_ids"] = [OTHER]
+
+    with pytest.raises(BenchmarkCaseSetError, match="not pinned by the case-set corpus"):
+        load_benchmark_case_set(write_case_set(tmp_path, payload), schema())
+
+
+def test_case_set_schema_rejects_unpinned_corpus_commit_format(tmp_path):
+    payload = copy.deepcopy(fixture())
+    payload["corpus"][0]["commit_sha"] = "main"
+
+    with pytest.raises(ValidationError):
+        load_benchmark_case_set(write_case_set(tmp_path, payload), schema())


### PR DESCRIPTION
## What changed

Starts #34 with the durable/reproducible case-set layer needed before real corpus seeding and provider bakeoffs.

- adds `fossil.benchmark-case-set.v1` JSON Schema;
- pins each case set to exact pack repository commit SHAs;
- supports retrieval and bounded-model cases plus exact `fossil.citation.v1` gold objects (snapshot/artifact/span/passage hash);
- adds a loader that rejects duplicate case IDs, retrieval pack scopes not pinned by the corpus manifest, duplicate citation IDs, and citation gold that points at undeclared source snapshots;
- converts persistent cases into the existing `RetrievalBenchmarkCase` / `ModelBenchmarkCase` types without changing the existing `fossil.benchmark.v1` result contract;
- updates `AGENTS.md`, `docs/PROJECT_STATE.md`, and `docs/HANDOFF_CURRENT.md` so continuation state reflects active Gate 2 rather than the retired zero-open-work checkpoint.

## Why

Gate 1 versioned benchmark **results**, but its cases are hard-coded Python fixtures. Gate 2 requires a gold/adversarial set that survives sessions and can be replayed against multiple providers with the exact corpus version and exact evidence target recorded.

Initial Gate 2 inspection also found that `fossil-common` and `fossil-ai-systems` currently contain pack scaffolds only (empty event/artifact payloads). This PR deliberately does not fabricate benchmark-only documents. The next #34 slice will seed representative canonical source snapshots/events into the existing stable packs and then commit real case sets pointing at those generated stable targets.

## Invariants preserved

- no pack IDs changed;
- no canonical durability/provenance semantics changed;
- no provider is selected or made canonical;
- existing `fossil.benchmark.v1` result schema remains unchanged;
- existing cognitive-service interfaces remain unchanged;
- exact citations still bind to immutable observed bytes/spans.

## Validation

Initial trusted PR CI run `31356440481`, job `93356916077`: **60 passed in 0.69s**. Follow-up exact-citation and continuity-doc commits trigger the same normal PR suite; merge only after the latest head is green.

Refs #34
Parent: #33