### PR TITLE
Gate 2: finalize closed-state handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,11 @@ This repository is designed so another GPT/Codex/Claude session can continue the
 
 ## Current state
 
-**Milestone 0 is complete. Gate 1 is 15/15 complete. Gate 2 — Real Corpus + Retrieval/Model Bakeoff is complete once the final Gate 2D documentation PR lands and Issues #37/#33 are closed.**
+**Milestone 0 is complete. Gate 1 is 15/15 complete. Gate 2 — Real Corpus + Retrieval/Model Bakeoff is complete. Issues #33–#37 are closed/completed.**
 
 Gate 2 decision D021 selects revision-pinned BGE dense retrieval as the normal primary, with explicit BM25 degraded availability fallback and mandatory lifecycle/lineage/citation safeguards. Do not treat this replaceable policy as canonical truth.
 
-After Gate 2 closes, do not invent a new Gate 3 from old chat context. Open a new explicit issue/campaign for new work.
+There is no active post-Gate-2 campaign. Do not invent a new Gate 3 from old chat context. Open a new explicit issue/campaign for new work.
 
 ## Non-negotiable rules
 
@@ -74,20 +74,22 @@ An issue can close, but an architectural decision must not exist only in an issu
 
 ## Completed campaign — Gate 2
 
-Control issue: **#33 — Gate 2: Real Corpus + Retrieval/Model Bakeoff**.
+Control issue: **#33 — Gate 2: Real Corpus + Retrieval/Model Bakeoff** — closed/completed.
 
 Children:
 
-1. **#34** representative real corpus fixtures + versioned gold/adversarial benchmark set;
-2. **#35** real retrieval/context adapters behind existing interfaces;
-3. **#36** reproducible comparative `fossil.benchmark.v1` runs and failure taxonomy;
-4. **#37** evidence-based default retrieval/routing policy.
+1. **#34** representative real corpus fixtures + versioned gold/adversarial benchmark set — closed/completed;
+2. **#35** real retrieval/context adapters behind existing interfaces — closed/completed;
+3. **#36** reproducible comparative `fossil.benchmark.v1` runs and failure taxonomy — closed/completed;
+4. **#37** evidence-based default retrieval/routing policy — closed/completed.
 
 Gate 2 established a 21-case history-rich real corpus and compared four strategies in one semantic-capable environment. Exact-head proof run `31364039745`, artifact `9053475462`, digest `sha256:23c95b46f47cec5a16e0a8c0926a4f13532f283d8f4fbcc0de12ceb63db63c41`.
 
 BGE dense was the only compared strategy with zero full retrieval misses and had the best mean recall@5 (`0.98413`). It still exhibited current-state ranking leakage and incomplete multi-target lineage recall. The hybrid had the best MRR but fully missed the key current-architecture case.
 
 D021 therefore selects pinned BGE dense as the normal primary and BM25 as an explicit degraded availability fallback. Current/history and lineage-sensitive tasks must resolve durable lifecycle/lineage rather than treating retrieval rank or top-k absence as truth. Exact citation/source semantics and model-authority boundaries remain unchanged.
+
+Gate 2D landed in PR #45 / squash commit `2d22dee9e6b176956d30005f4d7877baf68b0a3c`; final branch-independent CI was run `31366800697`, job `93386832166`, **86 passed in 1.02s**.
 
 Evidence:
 

--- a/docs/HANDOFF_CURRENT.md
+++ b/docs/HANDOFF_CURRENT.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-10  
 **Project:** **FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage**  
 **Repository:** `Pukujan/fossil-core`  
-**Status:** **Gate 1 complete. Gate 2 complete once the Gate 2D docs PR lands and #37/#33 close.**
+**Status:** **Gate 1 complete. Gate 2 complete and formally closed.**
 
 ## Fresh-session transfer
 
@@ -18,7 +18,7 @@ For the Gate 2 midpoint and completed Gate 1 history, retain:
 
 ## Gate 2 result
 
-Gate 2A–2C are complete and landed. Gate 2D selects an evidence-based retrieval/routing policy in D021:
+Gate 2A–2D are complete, landed, and closed. Decision D021 selects the evidence-based retrieval/routing policy:
 
 - normal primary: revision-pinned BGE dense retrieval;
 - semantic-runtime availability fallback: BM25, explicitly degraded;
@@ -33,26 +33,27 @@ Policy proof:
 Comparative proof:
 
 - PR #44 squash commit `38aac6325cdb5b738c8a6ac5e55959affb3acfb5`;
-- final normal CI run `31366259213`, job `93385174741`, **86 passed in 1.25s**;
+- final Gate 2C normal CI run `31366259213`, job `93385174741`, **86 passed in 1.25s**;
 - semantic proof run `31364039745`;
 - artifact `9053475462`;
 - digest `sha256:23c95b46f47cec5a16e0a8c0926a4f13532f283d8f4fbcc0de12ceb63db63c41`.
+
+Gate 2D landed in PR #45 / squash commit `2d22dee9e6b176956d30005f4d7877baf68b0a3c`; final branch-independent CI run `31366800697`, job `93386832166`, **86 passed in 1.02s**.
 
 BGE dense was selected because it was the only compared strategy with zero full retrieval misses and had the best mean recall@5 (`0.98413`). It still requires explicit temporal/current-state and multi-target-lineage safeguards. The hybrid had better MRR but fully missed the key current-architecture case.
 
 ## Repository control state
 
-At the moment this handoff was prepared:
+Verified on 2026-08-10:
 
 - #34 — closed/completed;
 - #35 — closed/completed;
 - #36 — closed/completed;
-- #37 — being completed by the Gate 2D documentation PR;
-- #33 — closes after #37 and Gate 2 exit criteria are reconciled.
+- #37 — closed/completed;
+- #33 — closed/completed;
+- open GitHub issues after Gate 2 closure: **0**.
 
-After that PR lands, close #37 and #33 and verify there are no open Gate 2 issues before considering the campaign finished on GitHub.
-
-Do not invent or start a new Gate 3 merely from this handoff. New work should start with an explicit issue/campaign.
+There is no active post-Gate-2 campaign. Do not invent or start a new Gate 3 merely from this handoff. New work should start with an explicit issue/campaign.
 
 ## Frozen invariants
 
@@ -67,4 +68,4 @@ Do not reopen Issues #1–#10 or Gate 2 children merely to continue development.
 
 ## Suggested next-session prompt
 
-> Continue my FOSSIL project from `Pukujan/fossil-core`. Read `AGENTS.md`, `ARCHITECTURE.md`, `docs/HANDOFF_CURRENT.md`, and `docs/handoffs/2026-08-10-chatgpt-session-handoff-gate2-complete.md` first. Verify GitHub state before changing anything. Gate 1 and Gate 2 are completed campaigns; preserve stable pack IDs and D021's evidence-based retrieval policy unless new committed benchmark evidence justifies reconsideration. Start new work through a new explicit issue/campaign rather than reopening old Gate 1 or Gate 2 issues.
+> Continue my FOSSIL project from `Pukujan/fossil-core`. Read `AGENTS.md`, `ARCHITECTURE.md`, `docs/HANDOFF_CURRENT.md`, and `docs/handoffs/2026-08-10-chatgpt-session-handoff-gate2-complete.md` first. Verify GitHub state before changing anything. Gate 1 and Gate 2 are completed campaigns; preserve stable pack IDs and D021's evidence-based retrieval policy unless new committed benchmark evidence justifies reconsideration. There is no active post-Gate-2 campaign, so start new work through a new explicit issue/campaign rather than reopening old Gate 1 or Gate 2 issues.

--- a/docs/handoffs/2026-08-10-chatgpt-session-handoff-gate2-complete.md
+++ b/docs/handoffs/2026-08-10-chatgpt-session-handoff-gate2-complete.md
@@ -6,7 +6,7 @@
 
 ## Status
 
-Gate 1 remains complete. Gate 2 is complete once #37's documentation PR is merged and Issues #37 and #33 are closed.
+Gate 1 remains complete. Gate 2 is fully complete and formally closed. Control Issue #33 and children #34–#37 are all closed/completed.
 
 Do not reopen Gate 1 / Issues #1–#10 or Gate 2 children #34–#37 merely to continue development. Open a new issue/campaign for new work.
 
@@ -91,6 +91,16 @@ Stable qualitative conclusions:
 
 ## Gate 2D — default policy
 
+Issue #37 is closed completed. PR #45 merged as squash commit:
+
+`2d22dee9e6b176956d30005f4d7877baf68b0a3c`
+
+Final branch-independent CI:
+
+- run `31366800697`
+- job `93386832166`
+- **86 passed in 1.02s**
+
 Durable decision: D021 in `docs/DECISION_LOG.md`.
 
 Policy proof: `docs/implementation/2026-08-10-gate2-default-retrieval-policy.md`.
@@ -112,9 +122,18 @@ Reconsider D021 when the corpus changes materially, BGE/runtime identity changes
 
 ## Current repository control state
 
-After the Gate 2D documentation PR lands and #37/#33 close, there should be **zero open Gate 2 issues**. At the start of a future session, verify GitHub rather than assuming this handoff is still current.
+Verified after formal Gate 2 closure on 2026-08-10:
 
-Do not invent a Gate 3 from chat context alone. New work should begin with an explicit issue/campaign and should cite D021/Gate 2 evidence when changing retrieval policy.
+- #33 — closed/completed;
+- #34 — closed/completed;
+- #35 — closed/completed;
+- #36 — closed/completed;
+- #37 — closed/completed;
+- open GitHub issues: **0**.
+
+At the start of a future session, verify GitHub rather than assuming this handoff is still current.
+
+There is no active post-Gate-2 campaign. Do not invent a Gate 3 from chat context alone. New work should begin with an explicit issue/campaign and should cite D021/Gate 2 evidence when changing retrieval policy.
 
 ## Start order for the next session
 


### PR DESCRIPTION
## What changed

Final closeout-only reconciliation after Gate 2 control Issue #33 and children #34–#37 were formally closed.

- `AGENTS.md` now says Gate 2 is fully complete/closed and there is no active post-Gate-2 campaign.
- `docs/HANDOFF_CURRENT.md` records #33–#37 closed/completed, zero open issues, PR #45's landing commit, and final CI proof.
- `docs/handoffs/2026-08-10-chatgpt-session-handoff-gate2-complete.md` now reflects the formally closed state rather than the pre-merge/pending-closure checkpoint.

No architecture, code, benchmark, or retrieval-policy semantics change here. D021 and the Gate 2 evidence remain unchanged.

Gate 2D landed in PR #45 / `2d22dee9e6b176956d30005f4d7877baf68b0a3c`; CI run `31366800697`, job `93386832166` — 86 passed in 1.02s.