### PR TITLE
Post-Gate-2: record production RAG hardening research and activate campaign

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,25 +6,42 @@ This repository is designed so another GPT/Codex/Claude session can continue the
 
 1. `ARCHITECTURE.md` — frozen durable invariants.
 2. `docs/HANDOFF_CURRENT.md` — exact continuation point.
-3. `docs/PROJECT_STATE.md` — completed gate/work state.
-4. `docs/handoffs/2026-08-10-chatgpt-session-handoff-gate2-complete.md` — detailed Gate 2 completion transfer.
-5. `docs/DECISION_LOG.md` — accepted decisions, alternatives, and reconsideration triggers.
-6. Gate/proof documents under `docs/implementation/`.
-7. `docs/research/2026-08-09-final-research-synthesis.md` and `docs/research/2026-08-09-evidence-ledger.md` when research rationale is needed.
-8. Closed Gate 2 control Issue #33 and child Issues #34–#37 when detailed Gate 2 history is useful.
-9. Closed GitHub Issue #1 and child Issues #2–#10 only when detailed Gate 1 history is useful.
+3. `docs/PROJECT_STATE.md` — work/campaign state.
+4. `docs/research/2026-08-10-production-rag-hardening-research-trace.md` — current post-Gate-2 research basis.
+5. GitHub Issue #48 — active production RAG hardening campaign.
+6. GitHub Issue #47 — embedding/reranker/model-scale candidate workstream.
+7. `docs/handoffs/2026-08-10-chatgpt-session-handoff-gate2-complete.md` — completed Gate 2 transfer when history is needed.
+8. `docs/DECISION_LOG.md` — accepted decisions, alternatives, and reconsideration triggers.
+9. Gate/proof documents under `docs/implementation/`.
+10. Closed Gate 2 Issue #33 and children #34–#37 only when detailed Gate 2 history is useful.
 
 ## Current state
 
-**Milestone 0 is complete. Gate 1 is 15/15 complete. Gate 2 — Real Corpus + Retrieval/Model Bakeoff is complete. Issues #33–#37 are closed/completed.**
+**Milestone 0 / Gate 1 is complete. Gate 2 is complete and formally closed. Issue #48 is the active post-Gate-2 production RAG hardening campaign.**
 
-Gate 2 decision D021 selects revision-pinned BGE dense retrieval as the normal primary, with explicit BM25 degraded availability fallback and mandatory lifecycle/lineage/citation safeguards. Do not treat this replaceable policy as canonical truth.
+Gate 2 decision D021 remains active: revision-pinned BGE dense retrieval is the normal primary, BM25 is an explicit degraded availability fallback, and current/history/lineage/citation safeguards remain mandatory. D021 is replaceable policy, not canonical truth.
 
-There is no active post-Gate-2 campaign. Do not invent a new Gate 3 from old chat context. Open a new explicit issue/campaign for new work.
+Issue #47 records future embedding/model-scale/reranker comparison work. Treat it as a workstream feeding #48 rather than permission to replace D021 based on model novelty or public leaderboard scores.
+
+## Active campaign — #48
+
+The campaign is evidence-driven hardening, **not a GraphRAG rewrite and not an invented Gate 3**.
+
+Current workstreams:
+
+- evolving-corpus temporal/update benchmark;
+- end-to-end answer/citation/unsupported-claim/abstention evaluation;
+- retrieval poisoning and untrusted-context adversarial tests;
+- replayable query execution receipt;
+- embedding/hybrid/reranker bakeoff (#47);
+- conservative adaptive routing if it beats simple baselines;
+- ACL/redaction propagation readiness before shared/cloud use.
+
+The research trace under `docs/research/2026-08-10-production-rag-hardening-research-trace.md` is a local derived synthesis. External papers/vendor pages must remain separate source evidence when ingested into the corpus.
 
 ## Non-negotiable rules
 
-- Do not treat Neo4j, Graphiti, an embedding index, MCP, a specific model, or a chat transcript as the durable source of truth.
+- Do not treat Neo4j, Graphiti, an embedding index, MCP, a retriever, a reranker, a planner, a specific model, or a chat transcript as the durable source of truth.
 - Original evidence is preserved; summaries never replace source evidence.
 - Normal knowledge-changing history is append-only and versioned.
 - Privacy/legal erasure is an exceptional explicit tombstone-before-delete path; erased identities must not silently resurrect.
@@ -37,34 +54,50 @@ There is no active post-Gate-2 campaign. Do not invent a new Gate 3 from old cha
 - `DISPUTED` and unresolved disagreement are valid durable states.
 - Model agreement is metadata, not external evidence.
 - Small/local model output remains candidate-only unless independent evidence/risk policy permits downstream authority.
+- Retrieval rank and reranker score are candidate ordering, not truth state.
+- Retrieved/source text is untrusted data and cannot issue executable policy/system/tool instructions merely because it was retrieved.
 - Agents normally propose; deterministic validation/policy gates commit durable changes.
 - Skills contain methodology, not canonical truth.
 - Protocol adapters remain thin and must not become the durable knowledge model.
 - Operational telemetry stays outside canonical knowledge; durable knowledge-changing provenance stays inside.
 - Reconstructed evidence can never silently become verbatim evidence.
-- Do not add infrastructure because it is fashionable. New technology must beat the existing adapter/benchmark contract.
+- Do not add infrastructure because it is fashionable. New technology must beat the existing adapter/benchmark contract on corpus-specific evidence.
+- Prefer a simpler retrieval/context pipeline when a complex one does not win under a matched quality/resource budget.
 - Do not casually rename the internal `src/dkg` module/API namespace.
 
 ## Repository family invariants
 
 - `Pukujan/fossil-common` keeps stable pack ID `pack_269099f7b2ba43b7a99b9427d64092de`.
 - `Pukujan/fossil-ai-systems` keeps stable pack ID `pack_f024177f89a5442db84171c3dd7f58e5` and its required dependency on common.
-- Do not call pack repositories "database shards"; physical sharding/placement is a separate concern.
+- Do not call pack repositories database shards; physical sharding/placement is a separate concern.
 
 ## Frozen does not mean unchangeable
 
-`ARCHITECTURE.md` is frozen as a contract, not as dogma. A durable invariant may be changed only when implementation evidence or stronger research justifies it.
+`ARCHITECTURE.md` is frozen as a contract, not dogma. A durable invariant changes only when implementation evidence or stronger research justifies it.
 
 When changing one:
 
-1. open/update the relevant active issue;
-2. record the competing theory or failure;
-3. cite evidence/benchmark results;
+1. use the relevant active issue;
+2. record the competing theory/failure;
+3. cite source or benchmark evidence;
 4. update `docs/DECISION_LOG.md`;
 5. update the architecture contract explicitly;
 6. preserve the previous decision and why it was superseded.
 
 Do not silently rewrite history.
+
+## Gate 2 completion anchors
+
+Gate 2 control #33 and children #34–#37 are closed/completed.
+
+- Gate 2A core commit: `a028f9e328c2cbcde0185930e90b5eeb4c4efcb8`.
+- Gate 2B core commit: `2affde923acf196319d90bfa63f206e4a5e2f25f`.
+- Gate 2C PR #44 / squash `38aac6325cdb5b738c8a6ac5e55959affb3acfb5`.
+- Gate 2C semantic proof run `31364039745`, artifact `9053475462`, digest `sha256:23c95b46f47cec5a16e0a8c0926a4f13532f283d8f4fbcc0de12ceb63db63c41`.
+- Gate 2D PR #45 / squash `2d22dee9e6b176956d30005f4d7877baf68b0a3c`.
+- Gate 2 closed-state reconciliation PR #46 / squash `a614936249ff0ab201756fa54a1e89699d7b924f`.
+
+BGE dense was the only compared Gate 2 strategy with zero full retrieval misses and had mean recall@5 `0.98413`; it still exhibited current-state ranking leakage and incomplete multi-target lineage recall. D021 therefore requires durable lifecycle/lineage resolution rather than trusting rank/top-k absence.
 
 ## Work-state rule
 
@@ -72,42 +105,16 @@ GitHub issues track implementation state. Repository docs track durable decision
 
 An issue can close, but an architectural decision must not exist only in an issue comment. Conversely, durable docs should point back to the issue/benchmark that caused the change when useful.
 
-## Completed campaign — Gate 2
-
-Control issue: **#33 — Gate 2: Real Corpus + Retrieval/Model Bakeoff** — closed/completed.
-
-Children:
-
-1. **#34** representative real corpus fixtures + versioned gold/adversarial benchmark set — closed/completed;
-2. **#35** real retrieval/context adapters behind existing interfaces — closed/completed;
-3. **#36** reproducible comparative `fossil.benchmark.v1` runs and failure taxonomy — closed/completed;
-4. **#37** evidence-based default retrieval/routing policy — closed/completed.
-
-Gate 2 established a 21-case history-rich real corpus and compared four strategies in one semantic-capable environment. Exact-head proof run `31364039745`, artifact `9053475462`, digest `sha256:23c95b46f47cec5a16e0a8c0926a4f13532f283d8f4fbcc0de12ceb63db63c41`.
-
-BGE dense was the only compared strategy with zero full retrieval misses and had the best mean recall@5 (`0.98413`). It still exhibited current-state ranking leakage and incomplete multi-target lineage recall. The hybrid had the best MRR but fully missed the key current-architecture case.
-
-D021 therefore selects pinned BGE dense as the normal primary and BM25 as an explicit degraded availability fallback. Current/history and lineage-sensitive tasks must resolve durable lifecycle/lineage rather than treating retrieval rank or top-k absence as truth. Exact citation/source semantics and model-authority boundaries remain unchanged.
-
-Gate 2D landed in PR #45 / squash commit `2d22dee9e6b176956d30005f4d7877baf68b0a3c`; final branch-independent CI was run `31366800697`, job `93386832166`, **86 passed in 1.02s**.
-
-Evidence:
-
-- `benchmarks/gate2/results/2026-08-10-comparative/comparison-summary.json`;
-- `docs/implementation/2026-08-10-gate2-comparative-bakeoff-proof.md`;
-- `docs/implementation/2026-08-10-gate2-default-retrieval-policy.md`;
-- D021 in `docs/DECISION_LOG.md`.
-
 ## Session continuity protocol
 
-At the end of any substantial work session:
+At the end of substantial work:
 
 - update `docs/HANDOFF_CURRENT.md`;
-- update `docs/PROJECT_STATE.md` if the gate changed;
+- update `docs/PROJECT_STATE.md` if the campaign/gate state changed;
 - update the relevant active GitHub issue checklist/status;
 - commit benchmark/test results that materially justify a decision;
 - record architectural changes in `docs/DECISION_LOG.md`;
 - add/update a dated handoff when a long session is being retired;
 - never rely on the chat UI as the only record of a decision.
 
-If a chat history is missing or ambiguous, label reconstructed material as reconstructed rather than presenting it as verbatim evidence.
+If chat history is missing or ambiguous, label reconstructed material as reconstructed rather than presenting it as verbatim evidence.

--- a/docs/HANDOFF_CURRENT.md
+++ b/docs/HANDOFF_CURRENT.md
@@ -3,57 +3,78 @@
 **Date:** 2026-08-10  
 **Project:** **FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage**  
 **Repository:** `Pukujan/fossil-core`  
-**Status:** **Gate 1 complete. Gate 2 complete and formally closed.**
+**Status:** **Gate 1 complete. Gate 2 complete and formally closed. Post-Gate-2 production hardening campaign #48 active.**
 
 ## Fresh-session transfer
 
-Read this detailed completion checkpoint next:
+Read, in order:
 
-`docs/handoffs/2026-08-10-chatgpt-session-handoff-gate2-complete.md`
+1. `AGENTS.md`
+2. `ARCHITECTURE.md`
+3. this file
+4. `docs/PROJECT_STATE.md`
+5. `docs/research/2026-08-10-production-rag-hardening-research-trace.md`
+6. Issue #48 — production RAG hardening campaign
+7. Issue #47 — future embedding/reranker/model-scale bakeoff workstream
+8. `docs/handoffs/2026-08-10-chatgpt-session-handoff-gate2-complete.md` when Gate 2 history is needed
+9. `docs/DECISION_LOG.md`
 
-For the Gate 2 midpoint and completed Gate 1 history, retain:
+## Completed foundation
 
-- `docs/handoffs/2026-08-10-chatgpt-session-handoff-gate2-midpoint.md`
-- `docs/handoffs/2026-08-10-chatgpt-session-handoff.md`
+Gate 1 and Gate 2 remain closed/completed. Do not reopen them merely to continue development.
 
-## Gate 2 result
-
-Gate 2A–2D are complete, landed, and closed. Decision D021 selects the evidence-based retrieval/routing policy:
+Decision D021 remains the approved retrieval/routing policy until new committed benchmark evidence supersedes it:
 
 - normal primary: revision-pinned BGE dense retrieval;
 - semantic-runtime availability fallback: BM25, explicitly degraded;
-- current/latest/accepted queries must resolve durable lifecycle/provenance rather than treating rank as truth;
+- current/latest/accepted queries resolve durable lifecycle/provenance rather than treating rank as truth;
 - decision-lineage, supersession, disagreement, and multi-target historical/current questions use durable `lineage`/read resolution in addition to retrieval;
-- citation/source identity and model-authority invariants are unchanged.
+- citation/source identity and model-authority invariants remain unchanged.
 
-Policy proof:
+Gate 2 evidence anchors:
 
-`docs/implementation/2026-08-10-gate2-default-retrieval-policy.md`
+- Gate 2A core commit `a028f9e328c2cbcde0185930e90b5eeb4c4efcb8`;
+- Gate 2B core commit `2affde923acf196319d90bfa63f206e4a5e2f25f`;
+- Gate 2C PR #44 / squash commit `38aac6325cdb5b738c8a6ac5e55959affb3acfb5`;
+- Gate 2C final CI run `31366259213`, job `93385174741`, **86 passed in 1.25s**;
+- semantic proof run `31364039745`, artifact `9053475462`, digest `sha256:23c95b46f47cec5a16e0a8c0926a4f13532f283d8f4fbcc0de12ceb63db63c41`;
+- Gate 2D PR #45 / squash commit `2d22dee9e6b176956d30005f4d7877baf68b0a3c`;
+- Gate 2D CI run `31366800697`, job `93386832166`, **86 passed in 1.02s**;
+- final Gate 2 closed-state handoff PR #46 / squash commit `a614936249ff0ab201756fa54a1e89699d7b924f`.
 
-Comparative proof:
+BGE dense was selected because it was the only compared Gate 2 strategy with zero full retrieval misses and had the best mean recall@5 (`0.98413`). It still requires temporal/current-state and multi-target-lineage safeguards.
 
-- PR #44 squash commit `38aac6325cdb5b738c8a6ac5e55959affb3acfb5`;
-- final Gate 2C normal CI run `31366259213`, job `93385174741`, **86 passed in 1.25s**;
-- semantic proof run `31364039745`;
-- artifact `9053475462`;
-- digest `sha256:23c95b46f47cec5a16e0a8c0926a4f13532f283d8f4fbcc0de12ceb63db63c41`.
+## Active campaign — #48 production RAG hardening
 
-Gate 2D landed in PR #45 / squash commit `2d22dee9e6b176956d30005f4d7877baf68b0a3c`; final branch-independent CI run `31366800697`, job `93386832166`, **86 passed in 1.02s**.
+Issue #48 is the first explicit post-Gate-2 campaign. It was created from a new review of current production RAG systems and 2025–2026 research.
 
-BGE dense was selected because it was the only compared strategy with zero full retrieval misses and had the best mean recall@5 (`0.98413`). It still requires explicit temporal/current-state and multi-target-lineage safeguards. The hybrid had better MRR but fully missed the key current-architecture case.
+Durable research trace:
 
-## Repository control state
+`docs/research/2026-08-10-production-rag-hardening-research-trace.md`
 
-Verified on 2026-08-10:
+The campaign focuses on:
 
-- #34 — closed/completed;
-- #35 — closed/completed;
-- #36 — closed/completed;
-- #37 — closed/completed;
-- #33 — closed/completed;
-- open GitHub issues after Gate 2 closure: **0**.
+1. an evolving-corpus benchmark that exercises supersession/retraction/disagreement through time;
+2. end-to-end answer, citation, unsupported-claim, contradiction, and abstention evaluation;
+3. retrieval-poisoning / untrusted-context adversarial tests;
+4. a compact replayable query execution receipt;
+5. embedding/hybrid/reranker comparisons, with #47 as the candidate-model workstream;
+6. conservative adaptive routing only when it beats simpler policies under matched budgets;
+7. ACL/redaction propagation tests before multi-user/shared/cloud use.
 
-There is no active post-Gate-2 campaign. Do not invent or start a new Gate 3 merely from this handoff. New work should start with an explicit issue/campaign.
+The research supports **hardening the existing durable core rather than redesigning it**. No GraphRAG/planner/reranker/model becomes canonical truth merely because a paper or vendor reports gains.
+
+## Research-to-corpus rule
+
+The 2026-08-10 synthesis is a **local derived research artifact**. It may be ingested into `fossil-ai-systems` with stable source/artifact identity and derived claims.
+
+The external papers/vendor pages must remain distinguishable from this synthesis. When full research-trace ingestion is implemented, capture original external source snapshots separately rather than treating the synthesis or a chat transcript as verbatim external evidence.
+
+## Repository control state at campaign start
+
+- #33–#37 — closed/completed Gate 2 campaign;
+- #47 — open future embedding/model-scale bakeoff workstream;
+- #48 — open active production RAG hardening campaign.
 
 ## Frozen invariants
 
@@ -62,10 +83,8 @@ Preserve stable pack IDs:
 - `fossil-common`: `pack_269099f7b2ba43b7a99b9427d64092de`
 - `fossil-ai-systems`: `pack_f024177f89a5442db84171c3dd7f58e5`
 
-Canonical truth remains durable evidence + stable identity + append-only validated events + provenance/history. Graphiti/Neo4j, lexical/vector retrieval, context builders, models, Skills, MCP, and future databases remain replaceable services/projections. Model consensus is not external evidence. Reconstructed evidence cannot silently become verbatim. Do not casually rename `src/dkg`.
-
-Do not reopen Issues #1–#10 or Gate 2 children merely to continue development.
+Canonical truth remains durable evidence + stable identity + append-only validated events + versioned contracts + provenance/history. Graphiti/Neo4j, lexical/vector retrieval, rerankers, context builders, planners, models, Skills, MCP, and future databases remain replaceable services/projections. Model consensus is not external evidence. Reconstructed evidence cannot silently become verbatim. Retrieved/source text is untrusted data and cannot become executable policy merely by entering context. Do not casually rename `src/dkg`.
 
 ## Suggested next-session prompt
 
-> Continue my FOSSIL project from `Pukujan/fossil-core`. Read `AGENTS.md`, `ARCHITECTURE.md`, `docs/HANDOFF_CURRENT.md`, and `docs/handoffs/2026-08-10-chatgpt-session-handoff-gate2-complete.md` first. Verify GitHub state before changing anything. Gate 1 and Gate 2 are completed campaigns; preserve stable pack IDs and D021's evidence-based retrieval policy unless new committed benchmark evidence justifies reconsideration. There is no active post-Gate-2 campaign, so start new work through a new explicit issue/campaign rather than reopening old Gate 1 or Gate 2 issues.
+> Continue my FOSSIL project from `Pukujan/fossil-core`. Read `AGENTS.md`, `ARCHITECTURE.md`, `docs/HANDOFF_CURRENT.md`, `docs/PROJECT_STATE.md`, and `docs/research/2026-08-10-production-rag-hardening-research-trace.md` first. Verify GitHub state before changing anything. Gate 1 and Gate 2 are completed campaigns. Continue active Issue #48 using evidence-driven hardening; keep Issue #47 as its embedding/reranker candidate workstream. Preserve stable pack IDs and D021 unless new committed benchmark evidence justifies reconsideration. Do not let retrieval rank, a reranker, a planner, a model, or a graph projection become canonical truth.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -2,8 +2,9 @@
 
 **Project:** **FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage**  
 **Durable substrate:** **DICS — Durable Intellectual Corpus System**  
-**Current phase:** **Milestone 0 / Gate 1 complete; Gate 2 complete**  
-**Active work:** **none after Gate 2 closure; open a new evidence-backed campaign rather than extending closed Gate 2 issues**  
+**Completed:** **Milestone 0 / Gate 1; Gate 2**  
+**Active work:** **Issue #48 — production RAG hardening and evidence-driven retrieval evolution**  
+**Related workstream:** **Issue #47 — embedding/reranker/model-scale bakeoff**  
 **Control plane:** GitHub issues + durable repository docs  
 **Last updated:** 2026-08-10
 
@@ -21,10 +22,11 @@ Repository/database/graph placement is physical placement, not knowledge identit
 2. `ARCHITECTURE.md`
 3. `docs/HANDOFF_CURRENT.md`
 4. this file
-5. `docs/DECISION_LOG.md`
-6. Gate 2 proof/policy documents under `docs/implementation/`
-7. closed Gate 2 control Issue #33 and children #34–#37 when detailed campaign history is useful
-8. closed Milestone 0 Issue #1 and child Issues #2–#10 when detailed Gate 1 history is useful
+5. `docs/research/2026-08-10-production-rag-hardening-research-trace.md`
+6. Issue #48
+7. Issue #47
+8. `docs/DECISION_LOG.md`
+9. completed Gate 2 proof/policy docs under `docs/implementation/`
 
 The chat UI is source material, not the control plane.
 
@@ -32,153 +34,100 @@ The chat UI is source material, not the control plane.
 
 Canonical FOSSIL knowledge is **immutable evidence + stable corpus IDs + append-only validated knowledge events + versioned pack/ontology contracts + provenance/history**.
 
-Graphiti/Neo4j, lexical/vector indexes, context construction, models, Skills, MCP, and future databases remain replaceable projections/services.
+Graphiti/Neo4j, lexical/vector indexes, embedding models, rerankers, context construction, planners, model services, Skills, MCP, and future databases remain replaceable projections/services.
 
-A graph deletion must never delete irreplaceable intellectual history.
+A graph deletion or embedding replacement must never delete irreplaceable intellectual history.
 
-## Gate 1 — complete (15/15)
+## Completed foundation
 
-1. [x] immutable validated events
-2. [x] deterministic invalid/duplicate rejection
-3. [x] content-addressed immutable artifacts
-4. [x] knowledge-pack boundaries/dependencies
-5. [x] provenance-preserving cross-pack promotion
-6. [x] claim/relation lifecycle, disagreement, supersession, staleness
-7. [x] replaceable Graphiti adapter
-8. [x] projection retry/failure ledger
-9. [x] projection build metadata
-10. [x] live Graphiti + Neo4j materialization
-11. [x] destructive rebuild from durable data
-12. [x] second projection comparison + guarded blue/green switch
-13. [x] conversation ingestion + intellectual-lineage reconstruction
-14. [x] source snapshots, exact citations, quality/lifecycle/redaction integrity
-15. [x] safe Agent Skill/API/MCP boundary
+### Gate 1
 
-Final cleaned Gate 1 run `31347457485`, job `93331933728`: **51 passed in 0.82s**.
+Gate 1 is complete: durable events/artifacts, pack boundaries, lifecycle/disagreement/supersession, replaceable graph projection, rebuild/migration, conversation lineage, exact source/citation integrity, redaction/non-resurrection, cognitive-service contracts, and safe Agent Skill/API/MCP boundaries were proven.
 
-## Major Gate 1 proof checkpoints
+Final cleaned Gate 1 run `31347457485`, job `93331933728`: **51 passed in 0.82s**. Cognitive-service contract run `31347744797`, job `93332738616`: **56 passed in 0.70s**.
 
-- **#4 live projection:** run `31338875226` — Graphiti `0.29.3` + Neo4j `5.26.29`, stable pack namespace, durable-first projection, failure preservation, idempotent replay.
-- **#5 rebuild/migration:** run `31339930551` — candidate destroy/rebuild with fresh build ledger, semantic comparison, guarded blue/green switch.
-- **#9 conversation lineage:** run `31340924480`, job `93314435997` — exact source spans, durable `verbatim` vs `reconstructed`, opposing/current/historical lineage queries.
-- **#8 agent boundary:** run `31341456769`, job `93315824532` — progressive-disclosure Skills, protocol-independent corpus service, no arbitrary graph mutation.
-- **#10 provenance/redaction:** deterministic run `31345462801`, job `93326450028`; live run `31346791333`, job `93330095684` — tombstone-before-delete, active Graphiti purge, zero-state fresh rebuild/non-resurrection.
-- **#7 cognitive-service contract:** run `31347744797`, job `93332738616` — **56 passed in 0.70s**; versioned replaceable cognitive-service interfaces and `fossil.benchmark.v1` result contract.
+### Gate 2
 
-## Gate 2 — complete
+Gate 2 control #33 and children #34–#37 are closed/completed.
 
-Control issue: **#33 — Real Corpus + Retrieval/Model Bakeoff**.
+Evidence anchors:
 
-Children:
+- Gate 2A real history-rich corpus core commit `a028f9e328c2cbcde0185930e90b5eeb4c4efcb8`;
+- Gate 2B real retrieval/context adapters core commit `2affde923acf196319d90bfa63f206e4a5e2f25f`;
+- Gate 2C PR #44 / squash `38aac6325cdb5b738c8a6ac5e55959affb3acfb5`;
+- Gate 2C final CI run `31366259213`, job `93385174741` — **86 passed in 1.25s**;
+- semantic proof run `31364039745`, artifact `9053475462`, digest `sha256:23c95b46f47cec5a16e0a8c0926a4f13532f283d8f4fbcc0de12ceb63db63c41`;
+- Gate 2D PR #45 / squash `2d22dee9e6b176956d30005f4d7877baf68b0a3c`;
+- Gate 2D CI run `31366800697`, job `93386832166` — **86 passed in 1.02s**;
+- closed-state reconciliation PR #46 / squash `a614936249ff0ab201756fa54a1e89699d7b924f`.
 
-- [x] #34 representative corpus fixtures + gold/adversarial benchmark set
-- [x] #35 real retrieval/context adapters behind existing interfaces
-- [x] #36 reproducible comparative bakeoff + failure taxonomy
-- [x] #37 evidence-based default retrieval/routing policy
+The 21-case history-rich corpus compared BM25, a hash embedding control, revision-pinned BGE dense, and BM25+BGE hybrid/lifecycle reranking. BGE dense was the only compared strategy with zero full retrieval misses and had mean recall@5 `0.98413`. It still showed current-state ranking leakage and incomplete multi-target lineage recall.
 
-### Gate 2A — real history-rich corpus
+Decision D021 therefore selects revision-pinned `BAAI/bge-small-en-v1.5@5c38ec7c405ec4b44b94cc5a9bb96e735b38267a` as the normal primary retriever and BM25 as an explicit degraded availability fallback.
 
-Pinned source pack commits:
+Mandatory D021 safeguards remain:
 
-- `Pukujan/fossil-common` — `d583005dce06dbb499c3c0de5c22b899655eb8d2`;
-- `Pukujan/fossil-ai-systems` — `cf7cf4087bde543cb247a978de2a7252b1b8e4de`.
-
-`benchmarks/gate2/real-corpus-history-v2.json` contains 21 cases covering exact lookup, source/citation recovery, decision lineage, current/history, disagreement, stale/superseded state, cross-pack isolation, deep evidence, conversation lineage, and insufficient-evidence negatives.
-
-Gate 2A landed at core commit `a028f9e328c2cbcde0185930e90b5eeb4c4efcb8`.
-
-### Gate 2B — real retrieval adapters
-
-Core commit `2affde923acf196319d90bfa63f206e4a5e2f25f` added:
-
-- revision-pinned BGE dense retrieval;
-- BM25+BGE reciprocal-rank fusion;
-- lifecycle-intent reranking;
-- context integration;
-- optional semantic runtime behavior with provider/model/runtime provenance.
-
-Approved semantic identity tested in Gate 2:
-
-- model `BAAI/bge-small-en-v1.5`;
-- revision `5c38ec7c405ec4b44b94cc5a9bb96e735b38267a`;
-- Sentence Transformers `5.2.2`;
-- Torch `2.13.0`;
-- Transformers `5.14.1`;
-- normalized embeddings enabled.
-
-### Gate 2C — comparative evidence
-
-PR #44 landed as squash commit `38aac6325cdb5b738c8a6ac5e55959affb3acfb5`.
-
-Final branch-independent CI before landing: run `31366259213`, job `93385174741` — **86 passed in 1.25s**.
-
-Exact-head semantic proof:
-
-- run `31364039745`;
-- artifact `9053475462` (`gate2-comparative-results`);
-- digest `sha256:23c95b46f47cec5a16e0a8c0926a4f13532f283d8f4fbcc0de12ceb63db63c41`.
-
-Exact-head comparison:
-
-| Strategy | Hit rate | Recall@5 | MRR | Mean latency | p95 | Peak Python alloc |
-|---|---:|---:|---:|---:|---:|---:|
-| BM25 | 0.95238 | 0.95238 | 0.81746 | 3.270 ms | 4.566 ms | 58,844 B |
-| Hash control | 0.95238 | 0.92063 | 0.83730 | 1.283 ms | 1.558 ms | 34,100 B |
-| **BGE dense** | **1.00000** | **0.98413** | 0.85873 | 36.201 ms | 38.535 ms | 81,779 B |
-| Hybrid | 0.95238 | 0.95238 | **0.86667** | 58.658 ms | 66.023 ms | 183,065 B |
-
-All estimated provider cost was `$0` in the local proof. No strategy violated pack isolation, and the tested context probes stayed below the 4,000-character reference budget without truncation/overload.
-
-Important stable failures:
-
-- BM25, hash, and hybrid fully miss `current_architecture_after_reconsideration`;
-- BGE dense is the only strategy with zero full retrieval misses, but the current architecture is only rank 5 behind rejected/history material;
-- BGE retrieves 2/3 targets for `historical_current_supersession_bundle` at `k=5`;
-- hybrid has the best MRR but its decision-critical current-architecture full miss disqualifies it as the Gate 2 default.
-
-Durable evidence:
-
-- `benchmarks/gate2/results/2026-08-10-comparative/comparison-summary.json`;
-- `docs/implementation/2026-08-10-gate2-comparative-bakeoff-proof.md`.
-
-### Gate 2D — selected retrieval/routing policy
-
-Decision D021 selects **revision-pinned BGE dense as the normal primary retriever** because it is the only compared strategy with zero full misses and has the best mean recall.
-
-**Explicit availability fallback:** BM25, marked degraded. The hash control is not the fallback. BM25 is not quality-equivalent to BGE; quality/configuration rollback returns to the last known benchmark-passing BGE profile.
-
-Mandatory safeguards:
-
-- current/latest/accepted queries resolve durable lifecycle/provenance before presenting a current conclusion;
-- rejected/superseded/retracted/stale/disputed history cannot become current because of retrieval rank;
-- decision-lineage, disagreement, supersession, and multi-target historical/current tasks use durable `lineage`/read resolution in addition to retrieval;
+- current/latest/accepted questions resolve lifecycle/provenance;
+- lineage/history/disagreement questions use durable lineage/read resolution;
 - top-k absence is not evidence of nonexistence;
-- citation-bearing answers still resolve immutable source snapshot/span/hash identity;
-- retrieval/model output does not receive truth-changing authority merely from confidence or agreement.
+- citation-bearing answers resolve immutable source snapshot/span/hash identity;
+- retrieval/model output does not receive truth authority from score, confidence, or agreement.
 
 Policy proof: `docs/implementation/2026-08-10-gate2-default-retrieval-policy.md`.
 
-## Current cognitive-service posture
+## Active campaign #48 — production RAG hardening
 
-Normal primary retrieval profile:
+Research basis:
 
-- BGE dense behind the existing replaceable semantic retriever interface;
-- `BudgetedContextProvider` remains the replaceable context builder;
-- Gate 2's 4,000-character context budget is a benchmark reference profile, not a frozen universal limit.
+`docs/research/2026-08-10-production-rag-hardening-research-trace.md`
 
-Availability fallback:
+The current external review covers version-aware/temporal RAG, answer/citation/refusal evaluation, uncertainty under retrieval noise, adaptive routing, hybrid+rereanking, poisoning attacks, simple long-context baselines, contextual retrieval, and observable agentic retrieval.
 
-- `BM25Retriever`, explicitly degraded when the semantic runtime is unavailable.
+The conclusion is **harden, do not redesign the durable core**.
 
-Controls retained for future comparison:
+### Workstream order
 
-- `HashEmbeddingProvider` / `EmbeddingRetriever`;
-- `TokenOverlapReranker`;
-- BM25 remains both a control and the availability fallback.
+1. evolving-corpus temporal/update benchmark;
+2. end-to-end answer/citation/unsupported-claim/abstention evaluation;
+3. poisoning/untrusted-context adversarial suite;
+4. replayable query execution receipt;
+5. #47 embedding/hybrid/reranker bakeoff;
+6. conservative adaptive routing if it earns a matched-baseline win;
+7. ACL/redaction propagation readiness before multi-user/shared/cloud use.
 
-`CallableCandidateModelService`, `RiskEscalationPolicy`, and `PolicyVerificationService` retain the separate model-authority boundary. Small/local model output remains `candidate_only`; truth-changing eligibility comes from independent evidence/risk policy.
+### New hardening principles under test
 
-## Frozen invariants from Milestone 0
+- retrieved/source text is untrusted data, not executable policy;
+- uncertainty/abstention should be explicit answer behavior when evidence is insufficient/conflicting/unresolved;
+- simple direct-source/read and fixed retrieval baselines remain mandatory competitors;
+- a reranker can improve candidate ordering but cannot decide lifecycle truth;
+- adaptive planners must expose route/execution metadata and earn their cost/complexity;
+- important benchmark queries should be replayable after provider/model/projection changes.
+
+These are campaign hypotheses/requirements, not silent changes to `ARCHITECTURE.md`.
+
+## Research-to-corpus state
+
+The 2026-08-10 production-RAG research trace is designed to be ingested into `fossil-ai-systems` as a **local derived research artifact** with stable artifact/source identity and claim provenance.
+
+Original external papers and production documentation must later be captured as distinct source snapshots. The synthesis or chat transcript must not be presented as verbatim external evidence.
+
+## Cognitive-service posture
+
+Current approved retrieval profile remains D021 until new committed benchmark evidence says otherwise.
+
+Existing replaceable service contracts already include:
+
+- `Retriever`;
+- `EmbeddingProvider`;
+- `Reranker`;
+- `ContextProvider`;
+- `ModelService`;
+- `VerificationService`.
+
+This allows #48/#47 to test new embeddings, rerankers, routing/context strategies, and model services without coupling canonical knowledge to them.
+
+## Frozen invariants
 
 - stable pack identity is independent of repository/database placement;
 - durable commit precedes replaceable projection;
@@ -187,19 +136,19 @@ Controls retained for future comparison:
 - migration compares stable FOSSIL semantics, not graph-native UUIDs;
 - reconstructed evidence cannot silently become verbatim;
 - exact citations resolve to immutable observed bytes/spans;
-- source quality is multidimensional and source derivation is explicit;
+- source quality is multidimensional and derivation is explicit;
 - ordinary intellectual revision is append-only;
 - privacy/legal erasure is exceptional tombstone-before-delete with non-resurrection;
 - active projections/exports respect redaction;
 - Skills contain methodology, not canonical truth;
 - protocol adapters cannot become the durable knowledge model;
 - cognitive services expose provider/version metadata and compete behind interfaces;
-- model agreement is not evidence; local/small models remain candidate-only until evidence/policy permits downstream authority.
+- model agreement is not evidence; model output remains bounded by evidence/risk policy.
 
 ## Workflow state
 
-`.github/workflows/ci.yml` is the normal fast contract suite.
+`.github/workflows/ci.yml` remains the normal fast contract suite.
 
 `.github/workflows/graphiti-live.yml` contains reusable live materialization plus redaction/non-resurrection smoke coverage.
 
-Gate 2 temporary proof workflows were removed before their PRs landed. After #37/#33 close, there are no active Gate 2 issues. Future work should start a new issue/campaign and preserve the completed Gate 2 evidence rather than rewriting it.
+Gate 2 temporary proof workflows were removed before landing. Issue #48 is now the active campaign; do not extend closed Gate 2 issues to implement it.

--- a/docs/research/2026-08-10-production-rag-hardening-research-trace.md
+++ b/docs/research/2026-08-10-production-rag-hardening-research-trace.md
@@ -1,0 +1,254 @@
+# Production RAG Hardening Research Trace
+
+**Date:** 2026-08-10  
+**Campaign:** #48 — Post-Gate-2 production RAG hardening  
+**State:** `accepted_for_campaign_planning`  
+**Evidence posture:** external research/production documentation + FOSSIL-specific synthesis. The synthesis below is **derived analysis**, not a substitute for the original external sources.
+
+## Research question
+
+After Gate 2 established FOSSIL's durable knowledge contracts and an evidence-backed default retriever, what failure modes and design tradeoffs from current production RAG systems and 2025–2026 research should influence the next hardening campaign?
+
+## FOSSIL baseline being evaluated
+
+FOSSIL already treats the following as durable/canonical:
+
+- immutable original evidence;
+- corpus-owned stable identities;
+- append-only validated knowledge-changing events;
+- versioned ontology/contracts;
+- explicit provenance;
+- explicit history of disagreement, revision, supersession, retraction, and unresolved claims;
+- pack-scoped read/write boundaries.
+
+Graphiti/Neo4j, lexical/vector retrieval, embedding models, rerankers, context builders, model services, planners, Skills/MCP, and future databases remain replaceable projections/services.
+
+Gate 2 decision D021 currently routes normal semantic retrieval through revision-pinned BGE dense retrieval with explicit degraded BM25 availability fallback. Current/latest/accepted questions must resolve lifecycle/provenance; lineage/history questions must use durable lineage/read operations; retrieval rank is not truth.
+
+## External evidence reviewed
+
+### 1. VersionRAG — version-aware retrieval over evolving documents
+
+**Source:** Daniel Huwiler, Kurt Stockinger, Jonathan Fürst, *VersionRAG: Version-Aware Retrieval-Augmented Generation for Evolving Documents* (2025).  
+**URL:** https://arxiv.org/abs/2510.08109
+
+Reported benchmark result on VersionQA:
+
+- naive RAG: 58% accuracy on version-sensitive questions;
+- GraphRAG: 64%;
+- VersionRAG: 90%;
+- VersionRAG reports 60% on implicit change detection where compared baselines reached 0–10%;
+- the paper reports substantially lower indexing-token use than its GraphRAG comparison.
+
+**FOSSIL implication:** this supports keeping version/history/lifecycle state outside retrieval rank. It also motivates an **evolving-corpus benchmark** that measures correctness before and after knowledge changes rather than only testing a frozen final corpus.
+
+**Limit:** this is one framework and one purpose-built benchmark. Its exact graph design is not automatically a better implementation for FOSSIL.
+
+### 2. TG-RAG — temporal graphs and incremental updates
+
+**Source:** Jiale Han et al., *RAG Meets Temporal Graphs: Time-Sensitive Modeling and Retrieval for Evolving Knowledge* (2025).  
+**URL:** https://arxiv.org/abs/2510.13590
+
+The paper argues two recurring blind spots in conventional RAG:
+
+1. same or similar facts valid at different times are difficult to distinguish with ordinary embeddings or conventional static graphs;
+2. most RAG evaluation assumes a static corpus and therefore misses incremental-update cost and retrieval stability as knowledge evolves.
+
+TG-RAG explicitly represents temporal facts and evaluates incremental updates.
+
+**FOSSIL implication:** the canonical lifecycle/event model is aligned with the problem statement. The missing piece is a benchmark that exercises **incremental change, rebuild, and historical reconstruction** as a sequence.
+
+**Limit:** temporal graph machinery is one possible projection strategy. FOSSIL should benchmark it behind replaceable interfaces rather than adopt it as canonical storage.
+
+### 3. CReSt — practical RAG requires more than retrieval metrics
+
+**Source:** Minsoo Khang, Sangjun Park, Teakgyu Hong, Dawoon Jung, *CReSt: A Comprehensive Benchmark for Retrieval-Augmented Generation with Complex Reasoning over Structured Documents* (2025).  
+**URL:** https://arxiv.org/abs/2505.17503
+
+CReSt contains 2,245 human-annotated English/Korean examples and evaluates dimensions including:
+
+- complex reasoning;
+- appropriate refusal when an answer should not be produced;
+- precise citations;
+- document-layout/structure understanding.
+
+The authors report that advanced LLMs still struggle to perform consistently across these dimensions.
+
+**FOSSIL implication:** Gate 2 retrieval metrics are necessary but insufficient. The next benchmark layer should measure **final answer correctness, citation correctness, unsupported claims, completeness, contradiction handling, and appropriate abstention**.
+
+**Limit:** CReSt targets structured-document QA and two languages. FOSSIL should borrow evaluation dimensions, not assume benchmark scores transfer to its corpus.
+
+### 4. URAG — retrieval noise can create confident errors
+
+**Source:** Vinh Nguyen et al., *URAG: A Benchmark for Uncertainty Quantification in Retrieval-Augmented Large Language Models* (2026).  
+**URL:** https://arxiv.org/abs/2603.19281
+
+URAG evaluates eight standard RAG methods across multiple domains and reports:
+
+- accuracy improvement often correlates with lower uncertainty, but the relationship breaks under retrieval noise;
+- simpler modular RAG methods can offer better accuracy–uncertainty tradeoffs than more complex reasoning pipelines;
+- no single RAG approach is universally reliable across domains;
+- deeper retrieval, dependence on parametric knowledge, and exposure to confidence cues can amplify confident errors/hallucinations.
+
+**FOSSIL implication:** uncertainty should be an output state, not merely an internal model score. Important answer paths should support explicit outcomes such as `insufficient evidence`, `conflicting evidence`, and `current state unresolved` rather than rewarding confident completion.
+
+**Limit:** the benchmark reformulates tasks for principled uncertainty measurement; its exact metrics do not need to become FOSSIL's universal calibration method.
+
+### 5. RAGRouter-Bench — no single retrieval paradigm wins everywhere
+
+**Source:** Ziqi Wang et al., *RAGRouter-Bench: A Dataset and Benchmark for Adaptive RAG Routing* (2026).  
+**URL:** https://arxiv.org/abs/2602.00296
+
+RAGRouter-Bench standardizes five RAG paradigms across 7,727 queries and 21,460 documents and evaluates generation quality plus resource use. The paper reports that:
+
+- no single RAG paradigm is universally optimal;
+- applicability depends strongly on query–corpus interaction;
+- adding more advanced mechanisms does not necessarily improve the effectiveness/efficiency tradeoff.
+
+**FOSSIL implication:** routing is worth testing, but should start with **interpretable query classes** and a simple fixed baseline. LLM-planned retrieval should earn its additional latency, cost, and failure surface.
+
+### 6. Text-and-table retrieval benchmark — hybrid + reranking can win, BM25 can still matter
+
+**Source:** Meftun Akarsu, Recep Kaan Karaman, Christopher Mierbach, *From BM25 to Corrective RAG: Benchmarking Retrieval Strategies for Text-and-Table Documents* (2026).  
+**URL:** https://arxiv.org/abs/2604.01733
+
+The study compares ten retrieval strategies over 23,088 financial QA queries and 7,318 mixed text/table documents. It reports:
+
+- two-stage hybrid retrieval + neural reranking: Recall@5 0.816 and MRR@3 0.605, best among its compared single/two-stage strategies;
+- BM25 outperforms the tested state-of-the-art dense retrieval on this financial corpus;
+- query expansion/adaptive retrieval provides limited benefit for precise numerical questions;
+- contextual retrieval provides consistent gains in that evaluation.
+
+**FOSSIL implication:** D021 should remain corpus-specific rather than being generalized into “dense is always better.” #47 should include real reranking and retain BM25/hybrid controls. Exact/identifier/numeric-style questions may deserve a lexical or hybrid route if FOSSIL's own benchmark proves it.
+
+**Limit:** financial text/table QA differs materially from FOSSIL's current history-rich technical corpus.
+
+### 7. Poisoning benchmark — advanced RAG does not remove ingestion/retrieval security risk
+
+**Source:** Baolei Zhang et al., *Benchmarking Poisoning Attacks against Retrieval-Augmented Generation* (2025).  
+**URL:** https://arxiv.org/abs/2505.18543
+
+The benchmark covers 13 poisoning attacks and seven defenses across standard and expanded QA settings. The authors report that multiple advanced RAG architectures—including sequential, branching, conditional, looping, conversational, multimodal, and agentic RAG—remain susceptible, and that the evaluated defenses do not provide robust general protection.
+
+**FOSSIL implication:** retrieved content must be treated as **untrusted data**, never executable system/policy instructions. FOSSIL needs adversarial cases for malicious documents, authority spoofing, fake supersession, duplicated poisoned passages, and conflicting evidence. Proposal-before-commit, pack boundaries, source identity, and evidence authority should be exercised under attack.
+
+**Limit:** no single defense should be represented as solving poisoning. Residual risk must remain explicit.
+
+### 8. Stronger long-context baselines — complexity needs to earn itself
+
+**Source:** Alex Laitenberger, Christopher D. Manning, Nelson F. Liu, *Stronger Baselines for Retrieval-Augmented Generation with Long-Context Language Models* (2025; EMNLP 2025).  
+**URL:** https://arxiv.org/abs/2506.03989
+
+The paper compares multi-stage systems with simpler baselines under scaled token budgets. Its DOS RAG baseline preserves original document structure/order and consistently matches or outperforms the more intricate compared methods on multiple long-context QA benchmarks.
+
+**FOSSIL implication:** every future graph/planner/query-expansion layer should be compared against strong **simple retrieve-then-read and direct-source-read baselines under matched context budgets**. Complexity is not a goal.
+
+### 9. Anthropic Contextual Retrieval — contextual hybrid + reranking as a production pattern
+
+**Source:** Anthropic, *Contextual Retrieval in AI Systems*.  
+**URL:** https://www.anthropic.com/engineering/contextual-retrieval
+
+Anthropic reports on its evaluated domains/configurations that:
+
+- contextual embeddings reduced top-20 retrieval failure from 5.7% to 3.7%;
+- contextual embeddings + contextual BM25 reduced it to 2.9% (49% relative reduction from the baseline);
+- adding reranking reduced it to 1.9% (67% relative reduction from the baseline).
+
+The article also explicitly notes the latency/cost tradeoff from reranking more candidates and recommends corpus-specific experimentation.
+
+**FOSSIL implication:** a real contextualization/reranking bakeoff is justified, but it should remain a replaceable retrieval policy experiment. The existing `Reranker` interface means this does not require a canonical-storage redesign.
+
+**Limit:** vendor-reported experiments are useful production evidence but are not independent proof that the same gains occur on FOSSIL.
+
+### 10. Azure AI Search agentic retrieval — observable multi-query production orchestration
+
+**Source:** Microsoft, *Agentic Retrieval Overview — Azure AI Search* and related 2026 documentation.  
+**URLs:**
+
+- https://learn.microsoft.com/en-us/azure/search/search-agentic-retrieval-concept
+- https://learn.microsoft.com/en-us/azure/search/search-features-list
+
+Current documented production pattern includes:
+
+- conversation-aware query planning;
+- decomposition into focused subqueries;
+- parallel execution across knowledge sources;
+- keyword, vector, and hybrid retrieval;
+- semantic reranking;
+- source references for citations;
+- optional execution/activity details exposing the retrieval plan and runtime use.
+
+**FOSSIL implication:** the useful architectural idea is not “let an agent search however it wants”; it is **observable routing with a reproducible execution record**. FOSSIL should retain a compact receipt for important queries containing service identities, candidate stable IDs, lifecycle/lineage resolution, context/citations, and outcome while leaving verbose telemetry outside canonical knowledge.
+
+**Limit:** Azure's managed pipeline has different security, cost, and operational assumptions; it is an implementation reference, not a target architecture.
+
+### 11. GraphRAG-Bench — evaluate the whole graph pipeline, not graph novelty
+
+**Source:** Yilin Xiao et al., *GraphRAG-Bench: Challenging Domain-Specific Reasoning for Evaluating Graph Retrieval-Augmented Generation* (2025).  
+**URL:** https://arxiv.org/abs/2506.02404
+
+GraphRAG-Bench evaluates nine GraphRAG methods and explicitly separates graph construction, retrieval, answer generation, and reasoning quality across multi-hop domain questions.
+
+**FOSSIL implication:** if a graph retrieval strategy is introduced, measure **construction cost, retrieval quality, answer quality, and reasoning behavior separately**. Graph-based retrieval remains a projection/service choice, not evidence that the graph should become canonical truth.
+
+## Cross-source synthesis
+
+### Findings that reinforce the existing architecture
+
+1. **Temporal/version state must not be inferred from semantic similarity alone.**
+   - Strong agreement with FOSSIL's explicit lifecycle/supersession/provenance design.
+2. **No retriever, graph, planner, or model should become canonical truth.**
+   - The research shows significant domain/query dependence and failure variation.
+3. **Simple baselines must remain in every bakeoff.**
+   - BM25 and straightforward long-context strategies continue to win in some settings.
+4. **Reranking is worth serious evaluation.**
+   - Multiple external sources show gains, but cost/latency and first-stage recall remain limiting factors.
+5. **Final-answer reliability must be evaluated independently from retrieval.**
+   - Retrieval can succeed while generation/citation/refusal fails.
+6. **Uncertainty and abstention are product behavior, not model decoration.**
+   - Noisy retrieval can increase confident error.
+7. **Security does not disappear with more elaborate RAG.**
+   - Poisoning remains a distinct ingestion/retrieval threat model.
+
+### Gaps in current FOSSIL evidence
+
+1. Gate 2 uses a history-rich corpus but does not yet execute a full **evolving-corpus sequence benchmark**.
+2. Current benchmark contracts emphasize retrieval quality/resource metrics more than **end-to-end answer faithfulness/citation/abstention**.
+3. Poisoning/untrusted-context behavior is not yet represented by a dedicated adversarial suite.
+4. The `Reranker` interface exists, but Gate 2 did not benchmark a strong real neural/API reranker.
+5. D021 routes lifecycle/lineage-sensitive questions explicitly, but broader **adaptive query routing** has not been benchmarked.
+6. Important queries do not yet have a standardized **replayable execution receipt** covering route → candidates → rerank → lifecycle/lineage → context/citations → outcome.
+7. Permission/redaction contracts exist conceptually, but shared/cloud deployment should wait for route-level ACL/redaction propagation tests.
+
+## Recommended campaign order
+
+1. **Evolving-corpus benchmark** — prove current/history correctness through actual knowledge changes.
+2. **End-to-end answer/citation/abstention benchmark** — detect failures retrieval metrics cannot see.
+3. **Poisoning/untrusted-context suite** — harden before broad automatic ingestion.
+4. **Query execution receipt + replay proof** — make failures diagnosable and future model changes comparable.
+5. **#47 embedding/reranker bakeoff** — BGE/BM25/hybrid plus current embedding candidates and a real reranker.
+6. **Conservative adaptive routing** — only after the above evidence reveals stable query classes worth routing.
+7. **ACL/redaction readiness** — required before multi-user/shared/cloud ingestion becomes a production goal.
+
+## Explicit non-recommendations
+
+Do **not**:
+
+- replace the durable event/evidence model with a graph database;
+- adopt a large GraphRAG pipeline merely because it is graph-based;
+- equate top retrieval/reranker score with current truth;
+- replace D021 based on a public leaderboard or aggregate embedding score;
+- let retrieved text issue system/tool instructions;
+- treat model consensus as evidence;
+- hide provider/model/runtime substitution;
+- allow a complex adaptive planner to become default without a matched simple-baseline win.
+
+## Decision status
+
+The research supports **hardening the existing architecture rather than redesigning its durable core**.
+
+Campaign #48 should treat every proposed retrieval/planning/security technique as an evidence-driven competitor behind current contracts. Architectural invariants remain unchanged unless a later explicit decision with committed evidence supersedes them.
+
+## Provenance / reconstruction note
+
+This document is a 2026-08-10 FOSSIL-specific synthesis produced from the external sources listed above and the committed FOSSIL architecture/D021 state. It is intentionally suitable for later ingestion as a **local derived research artifact**. The original external papers/pages should be captured as their own source snapshots when the campaign implements full research-trace ingestion; this synthesis must not be misrepresented as verbatim source evidence.


### PR DESCRIPTION
Starts Issue #48 as the explicit post-Gate-2 production hardening campaign without reopening Gate 1/2 or changing D021.

Changes:
- adds `docs/research/2026-08-10-production-rag-hardening-research-trace.md` with current 2025–2026 RAG papers and production-system evidence;
- records temporal/evolving-corpus, answer/citation/abstention, poisoning, reranking, adaptive routing, long-context/simple-baseline, and query-execution-receipt implications;
- updates `AGENTS.md`, `docs/HANDOFF_CURRENT.md`, and `docs/PROJECT_STATE.md` so fresh sessions see #48 as active and #47 as the embedding/reranker workstream;
- preserves Gate 1/2 closed state, stable pack IDs, and D021 until new committed benchmark evidence justifies reconsideration.

The research trace is explicitly a local derived synthesis. Original external papers/vendor docs remain distinct evidence and should be captured as separate source snapshots during full corpus ingestion.

Refs #48 and #47.