### PR TITLE
Post-Gate-2: add evolving-corpus temporal benchmark

### DIFF
--- a/benchmarks/post-gate2/evolving-corpus-temporal-v1.json
+++ b/benchmarks/post-gate2/evolving-corpus-temporal-v1.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "fossil.temporal-benchmark-plan.v1",
+  "benchmark_id": "post-gate2-evolving-corpus-v1",
+  "purpose": "Rebuild the real FOSSIL corpus at successive durable-event cutoffs and verify current-state correctness, historical reconstruction, dependent staleness propagation, and stability after unrelated corpus growth.",
+  "pack_pins": {
+    "fossil-common": "d583005dce06dbb499c3c0de5c22b899655eb8d2",
+    "fossil-ai-systems": "84accd2ee895663990e82ca5b79b592cb503db24"
+  },
+  "authority_rule": "durable lifecycle/lineage state outranks retrieval score",
+  "phases": [
+    {
+      "phase_id": "sqlite-premise-current",
+      "as_of_recorded_at": "2026-08-10T05:26:04Z",
+      "expected_states": {
+        "clm_643b698b7e9e6aee6a16c48c": "supported",
+        "clm_a047d79b8604fadbd44efdf4": "supported",
+        "rel_0996c7d4b845cf3a3fc6bdf8": "active"
+      },
+      "queries": [
+        {
+          "case_id": "current-sqlite-before-supersession",
+          "query": "What is the current canonical corpus database SQLite premise?",
+          "pack_ids": ["pack_f024177f89a5442db84171c3dd7f58e5"],
+          "relevant_ids": ["clm_643b698b7e9e6aee6a16c48c"],
+          "limit": 5
+        }
+      ]
+    },
+    {
+      "phase_id": "durable-core-after-supersession",
+      "as_of_recorded_at": "2026-08-10T05:26:08Z",
+      "expected_states": {
+        "clm_643b698b7e9e6aee6a16c48c": "superseded",
+        "clm_a047d79b8604fadbd44efdf4": "stale_pending_review",
+        "clm_7f5c691c564c30e1b61f8dc0": "supported",
+        "rel_0996c7d4b845cf3a3fc6bdf8": "active",
+        "rel_e0102ade0b5fad5cc2668ccd": "active"
+      },
+      "queries": [
+        {
+          "case_id": "current-durable-core",
+          "query": "What is the current durable truth using immutable evidence and append-only knowledge events?",
+          "pack_ids": ["pack_f024177f89a5442db84171c3dd7f58e5"],
+          "relevant_ids": ["clm_7f5c691c564c30e1b61f8dc0"],
+          "limit": 5
+        },
+        {
+          "case_id": "historical-sqlite",
+          "query": "What was the former canonical corpus database SQLite premise?",
+          "pack_ids": ["pack_f024177f89a5442db84171c3dd7f58e5"],
+          "relevant_ids": ["clm_643b698b7e9e6aee6a16c48c"],
+          "limit": 5
+        }
+      ]
+    },
+    {
+      "phase_id": "latest-after-rag-research-growth",
+      "as_of_recorded_at": null,
+      "expected_states": {
+        "clm_643b698b7e9e6aee6a16c48c": "superseded",
+        "clm_a047d79b8604fadbd44efdf4": "stale_pending_review",
+        "clm_7f5c691c564c30e1b61f8dc0": "supported",
+        "rel_0996c7d4b845cf3a3fc6bdf8": "active",
+        "rel_e0102ade0b5fad5cc2668ccd": "active",
+        "clm_b9cec2a2d1753db24f59ff1309d31656": "supported"
+      },
+      "queries": [
+        {
+          "case_id": "current-durable-core",
+          "query": "What is the current durable truth using immutable evidence and append-only knowledge events?",
+          "pack_ids": ["pack_f024177f89a5442db84171c3dd7f58e5"],
+          "relevant_ids": ["clm_7f5c691c564c30e1b61f8dc0"],
+          "limit": 5
+        },
+        {
+          "case_id": "historical-sqlite",
+          "query": "What was the former canonical corpus database SQLite premise?",
+          "pack_ids": ["pack_f024177f89a5442db84171c3dd7f58e5"],
+          "relevant_ids": ["clm_643b698b7e9e6aee6a16c48c"],
+          "limit": 5
+        }
+      ]
+    }
+  ]
+}

--- a/docs/implementation/2026-08-10-post-gate2-temporal-benchmark-proof.md
+++ b/docs/implementation/2026-08-10-post-gate2-temporal-benchmark-proof.md
@@ -1,0 +1,119 @@
+# Post-Gate-2 Evolving-Corpus / Temporal Benchmark Proof
+
+**Date:** 2026-08-10  
+**Campaign:** Issue #48 — production RAG hardening  
+**Workstream:** A — evolving-corpus / temporal benchmark  
+**Status:** PASS
+
+## Scope
+
+This proof exercises FOSSIL's real durable corpus through historical cutoffs instead of evaluating only a frozen final snapshot.
+
+The benchmark rebuilds a retrieval projection from durable events at each phase, then checks lifecycle state and retrieval behavior. Retrieval rank is never allowed to become truth authority; durable lifecycle/lineage state remains authoritative under D021.
+
+The baseline intentionally uses dependency-free BM25 plus the existing lifecycle-intent reranker. Hosted embedding/reranker/model comparisons remain a separate #47 / Workstream D concern.
+
+## Exact corpus inputs
+
+- `Pukujan/fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`
+- `Pukujan/fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`
+
+The runner verifies these Git heads before execution.
+
+## Durable transition under test
+
+The benchmark replays the real architecture-history sequence already present in the AI-systems pack:
+
+- former SQLite canonical premise: `clm_643b698b7e9e6aee6a16c48c`;
+- SQLite-dependent prototype claim: `clm_a047d79b8604fadbd44efdf4`;
+- accepted durable-core claim: `clm_7f5c691c564c30e1b61f8dc0`;
+- active dependency relation: `rel_0996c7d4b845cf3a3fc6bdf8`;
+- active supersession relation: `rel_e0102ade0b5fad5cc2668ccd`.
+
+The durable history records the SQLite premise as supported before the replacement architecture arrives. The accepted durable-core claim is later supported, the SQLite premise is explicitly superseded, and the active dependent claim becomes `stale_pending_review` through lifecycle replay.
+
+## Execution proof
+
+Execution-only core PR #55 was closed without merge after the proof.
+
+Workflow run `31431113829`, job `93594491275`:
+
+- core suite: **88 passed in 0.84s**;
+- temporal benchmark ID: `post-gate2-evolving-corpus-v1`;
+- phase count: **3**;
+- overall result: **PASS**.
+
+### Phase 1 — SQLite premise current
+
+Cutoff: `2026-08-10T05:26:04Z`
+
+- projected documents: **11**;
+- projection rebuild: **25.28 ms** on this runner;
+- SQLite premise: `supported`;
+- SQLite-dependent prototype: `supported`;
+- dependency relation: `active`;
+- current SQLite query: relevant claim rank **1**, recall@5 **1.0**.
+
+### Phase 2 — durable core after supersession
+
+Cutoff: `2026-08-10T05:26:08Z`
+
+- projected documents: **13**;
+- projection rebuild: **23.77 ms**;
+- SQLite premise: `superseded`;
+- SQLite-dependent prototype: `stale_pending_review`;
+- accepted durable-core claim: `supported`;
+- dependency relation: `active`;
+- supersession relation: `active`;
+- current durable-core query: relevant claim rank **1**, recall@5 **1.0**;
+- historical SQLite query: relevant claim rank **1**, recall@5 **1.0**;
+- no stale/superseded result appeared ahead of the current relevant result.
+
+The phase transition added two projected objects and correctly changed the old premise and its dependent claim without deleting history.
+
+### Phase 3 — later corpus growth
+
+Cutoff: latest landed corpus
+
+- projected documents: **27**;
+- projection rebuild: **23.68 ms**;
+- document count increased by **14** after later history/research ingestion;
+- SQLite premise remained `superseded`;
+- dependent prototype remained `stale_pending_review`;
+- accepted durable-core claim remained `supported`;
+- the ingested production-RAG research claim `clm_b9cec2a2d1753db24f59ff1309d31656` is `supported`;
+- current durable-core query remained rank **1**, recall@5 **1.0**;
+- historical SQLite query remained rank **1**, recall@5 **1.0**;
+- repeated-query stability reported full recall with no current-state leakage.
+
+## Update stability / cost observations
+
+The benchmark records rebuild and query latency for every evolving-corpus phase rather than reporting frozen-corpus retrieval alone.
+
+On this GitHub runner:
+
+- projection rebuild stayed approximately **23.68–25.28 ms** across 11–27 projected documents;
+- the current durable-core query measured about **0.94 ms** at 13 documents and **2.66 ms** at 27 documents;
+- the historical SQLite query measured about **0.67 ms** at 13 documents and **2.04 ms** at 27 documents;
+- correctness remained stable while the corpus more than doubled from the post-supersession phase.
+
+These timings are baseline observations from one CI runner, not provider-selection evidence and not a reason to revise D021. Future hosted retrieval/reranker bakeoffs should use the same versioned corpus and matched measurement contract.
+
+## Contract landed by PR #54
+
+- historical/as-of projection support in `dkg.pack_corpus`;
+- reusable `dkg.temporal_benchmark` phased runner;
+- versioned plan `benchmarks/post-gate2/evolving-corpus-temporal-v1.json`;
+- CLI `scripts/run_post_gate2_temporal_benchmark.py` with exact Git pin verification;
+- deterministic unit tests for lifecycle transitions, current/history retrieval, dependent staleness, and later-corpus stability.
+
+## Conclusion
+
+Workstream A's initial exit requirements are satisfied for the real pinned FOSSIL corpus:
+
+1. the benchmark executes a knowledge transition through time;
+2. current-state correctness and historical reconstruction are both verified;
+3. corpus-growth stability and baseline rebuild/query cost are measured;
+4. D021 lifecycle/lineage authority is preserved.
+
+This does **not** prove hosted embedding/reranker superiority, final-answer reliability, poisoning resistance, adaptive routing, or multi-user security readiness. Those remain later Issue #48 workstreams.

--- a/scripts/run_post_gate2_temporal_benchmark.py
+++ b/scripts/run_post_gate2_temporal_benchmark.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from dkg.temporal_benchmark import TemporalPhase, run_temporal_evolution_benchmark
+
+
+def _git_head(root: Path) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _load_plan(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("temporal benchmark plan must be a JSON object")
+    if value.get("schema_version") != "fossil.temporal-benchmark-plan.v1":
+        raise ValueError("unsupported temporal benchmark plan schema")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the post-Gate-2 evolving-corpus benchmark")
+    parser.add_argument("--common-root", type=Path, required=True)
+    parser.add_argument("--ai-root", type=Path, required=True)
+    parser.add_argument(
+        "--plan",
+        type=Path,
+        default=Path("benchmarks/post-gate2/evolving-corpus-temporal-v1.json"),
+    )
+    parser.add_argument("--schemas-root", type=Path, default=Path("schemas"))
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    plan = _load_plan(args.plan)
+    expected_pins = dict(plan["pack_pins"])
+    observed_pins = {
+        "fossil-common": _git_head(args.common_root),
+        "fossil-ai-systems": _git_head(args.ai_root),
+    }
+    if observed_pins != expected_pins:
+        raise SystemExit(
+            "pack pin mismatch: "
+            + json.dumps({"expected": expected_pins, "observed": observed_pins}, sort_keys=True)
+        )
+
+    phases = [TemporalPhase.from_mapping(item) for item in plan["phases"]]
+    report = run_temporal_evolution_benchmark(
+        [args.common_root, args.ai_root],
+        schemas_root=args.schemas_root,
+        phases=phases,
+        benchmark_id=str(plan["benchmark_id"]),
+    )
+    report["pack_pins"] = observed_pins
+    report["plan_schema_version"] = plan["schema_version"]
+
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dkg/pack_corpus.py
+++ b/src/dkg/pack_corpus.py
@@ -16,12 +16,20 @@ def _load_json(path: Path) -> dict[str, Any]:
     return value
 
 
-def _events_for_pack(root: Path, manifest: dict[str, Any]) -> list[dict[str, Any]]:
+def _events_for_pack(
+    root: Path,
+    manifest: dict[str, Any],
+    *,
+    as_of_recorded_at: str | None = None,
+) -> list[dict[str, Any]]:
     events: list[dict[str, Any]] = []
     for relative in manifest["event_roots"]:
         event_root = root / str(relative)
         for path in sorted(event_root.glob("*/*.json")):
-            events.append(_load_json(path))
+            event = _load_json(path)
+            if as_of_recorded_at is not None and str(event["recorded_at"]) > as_of_recorded_at:
+                continue
+            events.append(event)
     return sorted(events, key=lambda event: (str(event["recorded_at"]), str(event["event_id"])))
 
 
@@ -29,11 +37,16 @@ def retrieval_documents_from_pack_fixtures(
     pack_roots: Iterable[Path],
     *,
     schemas_root: Path,
+    as_of_recorded_at: str | None = None,
 ) -> list[dict[str, Any]]:
     """Build deterministic retrieval documents from validated durable packs.
 
     This is a rebuildable benchmark/search projection. Claim and relation IDs remain
     the durable corpus identities; generated document text is never canonical truth.
+
+    When ``as_of_recorded_at`` is supplied, the projection replays only events whose
+    durable ``recorded_at`` timestamp is at or before that cutoff. The complete pack is
+    still validated first, so historical reconstruction never bypasses fixture integrity.
     """
 
     roots = [Path(root) for root in pack_roots]
@@ -50,7 +63,11 @@ def retrieval_documents_from_pack_fixtures(
         manifest = _load_json(root / "manifest.json")
         pack_id = str(manifest["pack_id"])
         manifests[pack_id] = manifest
-        events = _events_for_pack(root, manifest)
+        events = _events_for_pack(
+            root,
+            manifest,
+            as_of_recorded_at=as_of_recorded_at,
+        )
         events_by_pack[pack_id] = events
         state_by_pack[pack_id] = KnowledgeState.replay(events)
         for event in events:

--- a/src/dkg/temporal_benchmark.py
+++ b/src/dkg/temporal_benchmark.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from .pack_corpus import retrieval_documents_from_pack_fixtures
+from .real_retrieval import LifecycleIntentReranker, RerankedRetriever
+from .services import BM25Retriever
+
+
+NONCURRENT_STATES = frozenset(
+    {
+        "disputed",
+        "invalidated",
+        "rejected",
+        "retracted",
+        "stale_pending_review",
+        "superseded",
+    }
+)
+
+
+@dataclass(frozen=True)
+class TemporalQueryCase:
+    case_id: str
+    query: str
+    pack_ids: tuple[str, ...]
+    relevant_ids: frozenset[str]
+    limit: int = 5
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "TemporalQueryCase":
+        return cls(
+            case_id=str(value["case_id"]),
+            query=str(value["query"]),
+            pack_ids=tuple(str(item) for item in value["pack_ids"]),
+            relevant_ids=frozenset(str(item) for item in value["relevant_ids"]),
+            limit=int(value.get("limit", 5)),
+        )
+
+    def __post_init__(self) -> None:
+        if not self.case_id or not self.query or not self.pack_ids or not self.relevant_ids:
+            raise ValueError("temporal query cases require id/query/packs/relevant ids")
+        if self.limit < 1:
+            raise ValueError("temporal query limit must be positive")
+
+
+@dataclass(frozen=True)
+class TemporalPhase:
+    phase_id: str
+    as_of_recorded_at: str | None
+    expected_states: Mapping[str, str]
+    queries: tuple[TemporalQueryCase, ...]
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "TemporalPhase":
+        cutoff = value.get("as_of_recorded_at")
+        return cls(
+            phase_id=str(value["phase_id"]),
+            as_of_recorded_at=str(cutoff) if cutoff is not None else None,
+            expected_states={str(key): str(state) for key, state in value["expected_states"].items()},
+            queries=tuple(TemporalQueryCase.from_mapping(item) for item in value.get("queries", [])),
+        )
+
+    def __post_init__(self) -> None:
+        if not self.phase_id or not self.expected_states:
+            raise ValueError("temporal phases require an id and expected states")
+
+
+def _documents_by_id(documents: Iterable[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {str(document["id"]): dict(document) for document in documents}
+
+
+def _state_checks(
+    expected_states: Mapping[str, str],
+    documents_by_id: Mapping[str, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    for identifier, expected in expected_states.items():
+        document = documents_by_id.get(identifier)
+        observed = str(document.get("current_state")) if document else None
+        checks.append(
+            {
+                "id": identifier,
+                "expected_state": expected,
+                "observed_state": observed,
+                "passed": observed == expected,
+            }
+        )
+    return checks
+
+
+def _query_observation(
+    retriever: Any,
+    case: TemporalQueryCase,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    results = retriever.search(
+        case.query,
+        pack_ids=list(case.pack_ids),
+        limit=case.limit,
+    )
+    latency_ms = (time.perf_counter() - started) * 1000.0
+    returned_ids = [str(result["id"]) for result in results]
+    relevant_found = case.relevant_ids & set(returned_ids)
+    recall = len(relevant_found) / len(case.relevant_ids)
+    first_relevant_rank = next(
+        (rank for rank, identifier in enumerate(returned_ids, start=1) if identifier in case.relevant_ids),
+        None,
+    )
+    intent = LifecycleIntentReranker.intent_for_query(case.query)
+    leakage: list[dict[str, Any]] = []
+    if intent == "current" and first_relevant_rank is not None:
+        for rank, result in enumerate(results, start=1):
+            if rank >= first_relevant_rank:
+                break
+            state = str(result.get("current_state", ""))
+            if state in NONCURRENT_STATES:
+                leakage.append({"id": str(result["id"]), "rank": rank, "state": state})
+
+    return {
+        "case_id": case.case_id,
+        "query": case.query,
+        "intent": intent,
+        "returned_ids": returned_ids,
+        "returned_states": [str(result.get("current_state", "")) for result in results],
+        "relevant_ids": sorted(case.relevant_ids),
+        "recall_at_k": recall,
+        "first_relevant_rank": first_relevant_rank,
+        "stale_before_current_relevant": leakage,
+        "latency_ms": latency_ms,
+        "passed": recall == 1.0 and not leakage,
+    }
+
+
+def run_temporal_evolution_benchmark(
+    pack_roots: Iterable[Path],
+    *,
+    schemas_root: Path,
+    phases: Iterable[TemporalPhase],
+    benchmark_id: str = "post-gate2-evolving-corpus-v1",
+) -> dict[str, Any]:
+    """Replay durable packs at successive cutoffs and test temporal retrieval behavior.
+
+    Every phase rebuilds the search projection from durable events. This intentionally
+    measures correctness independently of any hosted embedding/reranker service and
+    keeps lifecycle state as the authority path rather than allowing retrieval rank to
+    manufacture current truth.
+    """
+
+    roots = [Path(root) for root in pack_roots]
+    phase_list = list(phases)
+    if not roots or not phase_list:
+        raise ValueError("temporal benchmark requires pack roots and phases")
+
+    phase_results: list[dict[str, Any]] = []
+    previous_documents: dict[str, dict[str, Any]] | None = None
+
+    for phase in phase_list:
+        build_started = time.perf_counter()
+        documents = retrieval_documents_from_pack_fixtures(
+            roots,
+            schemas_root=schemas_root,
+            as_of_recorded_at=phase.as_of_recorded_at,
+        )
+        projection_build_ms = (time.perf_counter() - build_started) * 1000.0
+        documents_by_id = _documents_by_id(documents)
+
+        base = BM25Retriever(documents)
+        retriever = RerankedRetriever(
+            base,
+            LifecycleIntentReranker(),
+            candidate_multiplier=4,
+            version="temporal-baseline-v1",
+        )
+        state_checks = _state_checks(phase.expected_states, documents_by_id)
+        query_observations = [_query_observation(retriever, case) for case in phase.queries]
+
+        transition: dict[str, Any] | None = None
+        if previous_documents is not None:
+            changed_states: list[dict[str, Any]] = []
+            for identifier in sorted(set(previous_documents) | set(documents_by_id)):
+                before = previous_documents.get(identifier)
+                after = documents_by_id.get(identifier)
+                before_state = str(before.get("current_state")) if before else None
+                after_state = str(after.get("current_state")) if after else None
+                if before_state != after_state:
+                    changed_states.append(
+                        {
+                            "id": identifier,
+                            "before_state": before_state,
+                            "after_state": after_state,
+                        }
+                    )
+            transition = {
+                "document_count_delta": len(documents_by_id) - len(previous_documents),
+                "state_changes": changed_states,
+            }
+
+        phase_passed = all(check["passed"] for check in state_checks) and all(
+            observation["passed"] for observation in query_observations
+        )
+        phase_results.append(
+            {
+                "phase_id": phase.phase_id,
+                "as_of_recorded_at": phase.as_of_recorded_at,
+                "document_count": len(documents),
+                "projection_build_ms": projection_build_ms,
+                "state_checks": state_checks,
+                "queries": query_observations,
+                "transition_from_previous": transition,
+                "passed": phase_passed,
+            }
+        )
+        previous_documents = documents_by_id
+
+    repeated_cases: dict[str, list[dict[str, Any]]] = {}
+    for phase in phase_results:
+        for observation in phase["queries"]:
+            repeated_cases.setdefault(str(observation["case_id"]), []).append(observation)
+    stability = {
+        case_id: {
+            "observations": len(observations),
+            "all_full_recall": all(float(item["recall_at_k"]) == 1.0 for item in observations),
+            "no_current_state_leakage": all(not item["stale_before_current_relevant"] for item in observations),
+        }
+        for case_id, observations in sorted(repeated_cases.items())
+        if len(observations) > 1
+    }
+
+    return {
+        "schema_version": "fossil.temporal-benchmark.v1",
+        "benchmark_id": benchmark_id,
+        "projection": "durable-event-replay->in-memory-bm25+lifecycle-intent-reranker",
+        "authority_rule": "durable lifecycle/lineage state outranks retrieval score",
+        "phase_count": len(phase_results),
+        "phases": phase_results,
+        "repeated_query_stability": stability,
+        "passed": all(phase["passed"] for phase in phase_results)
+        and all(
+            item["all_full_recall"] and item["no_current_state_leakage"]
+            for item in stability.values()
+        ),
+    }

--- a/tests/test_temporal_benchmark.py
+++ b/tests/test_temporal_benchmark.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dkg.temporal_benchmark import TemporalPhase, TemporalQueryCase, run_temporal_evolution_benchmark
+
+
+AI = "pack_f024177f89a5442db84171c3dd7f58e5"
+OLD = "clm_old_sqlite_000000000001"
+DEPENDENT = "clm_sqlite_proto_0000000001"
+NEW = "clm_durable_core_000000000001"
+UNRELATED = "clm_unrelated_rag_00000000001"
+DEPENDS = "rel_depends_sqlite_000000001"
+SUPERSEDES = "rel_durable_supersedes_000001"
+
+
+def _write_event(root: Path, event: dict) -> None:
+    event_id = str(event["event_id"])
+    suffix = event_id.removeprefix("evt_")
+    path = root / "events" / suffix[:2] / f"{event_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(event), encoding="utf-8")
+
+
+def _event(
+    event_id: str,
+    event_type: str,
+    subject_refs: list[str],
+    payload: dict,
+    recorded_at: str,
+) -> dict:
+    return {
+        "schema_version": "dkg.event.v1",
+        "event_id": event_id,
+        "event_type": event_type,
+        "occurred_at": recorded_at,
+        "recorded_at": recorded_at,
+        "pack_id": AI,
+        "actor": {"actor_type": "importer", "actor_id": "temporal-test"},
+        "subject_refs": subject_refs,
+        "payload": payload,
+    }
+
+
+def _fixture(tmp_path: Path) -> Path:
+    root = tmp_path / "ai"
+    root.mkdir()
+    (root / "manifest.json").write_text(
+        json.dumps({"pack_id": AI, "event_roots": ["events"]}),
+        encoding="utf-8",
+    )
+
+    events = [
+        _event(
+            "evt_000000000000000000000001",
+            "claim.proposed",
+            [OLD],
+            {"claim_text": "SQLite is the canonical corpus database."},
+            "2026-08-10T05:26:00Z",
+        ),
+        _event(
+            "evt_000000000000000000000002",
+            "claim.state_changed",
+            [OLD],
+            {"from_state": "proposed", "to_state": "supported"},
+            "2026-08-10T05:26:01Z",
+        ),
+        _event(
+            "evt_000000000000000000000003",
+            "claim.proposed",
+            [DEPENDENT],
+            {"claim_text": "The SQLite prototype depends on the canonical SQLite premise."},
+            "2026-08-10T05:26:02Z",
+        ),
+        _event(
+            "evt_000000000000000000000004",
+            "claim.state_changed",
+            [DEPENDENT],
+            {"from_state": "proposed", "to_state": "supported"},
+            "2026-08-10T05:26:03Z",
+        ),
+        _event(
+            "evt_000000000000000000000005",
+            "relation.proposed",
+            [DEPENDS, DEPENDENT, OLD],
+            {
+                "relation_id": DEPENDS,
+                "relation_type": "DEPENDS_ON",
+                "source_ref": DEPENDENT,
+                "target_ref": OLD,
+                "state": "active",
+            },
+            "2026-08-10T05:26:04Z",
+        ),
+        _event(
+            "evt_000000000000000000000006",
+            "claim.proposed",
+            [NEW],
+            {
+                "claim_text": (
+                    "Immutable evidence plus append-only knowledge events are durable truth; "
+                    "retrieval systems are rebuildable projections."
+                )
+            },
+            "2026-08-10T05:26:05Z",
+        ),
+        _event(
+            "evt_000000000000000000000007",
+            "claim.state_changed",
+            [NEW],
+            {"from_state": "proposed", "to_state": "supported"},
+            "2026-08-10T05:26:06Z",
+        ),
+        _event(
+            "evt_000000000000000000000008",
+            "relation.proposed",
+            [SUPERSEDES, NEW, OLD],
+            {
+                "relation_id": SUPERSEDES,
+                "relation_type": "SUPERSEDES",
+                "source_ref": NEW,
+                "target_ref": OLD,
+                "state": "active",
+            },
+            "2026-08-10T05:26:07Z",
+        ),
+        _event(
+            "evt_000000000000000000000009",
+            "claim.superseded",
+            [OLD],
+            {"from_state": "supported", "superseded_by": NEW},
+            "2026-08-10T05:26:08Z",
+        ),
+        _event(
+            "evt_000000000000000000000010",
+            "claim.proposed",
+            [UNRELATED],
+            {"claim_text": "Retrieved content is untrusted data."},
+            "2026-08-10T14:02:00Z",
+        ),
+        _event(
+            "evt_000000000000000000000011",
+            "claim.state_changed",
+            [UNRELATED],
+            {"from_state": "proposed", "to_state": "supported"},
+            "2026-08-10T14:02:01Z",
+        ),
+    ]
+    for event in events:
+        _write_event(root, event)
+    return root
+
+
+def test_temporal_benchmark_replays_current_and_historical_truth(tmp_path, monkeypatch):
+    root = _fixture(tmp_path)
+    monkeypatch.setattr("dkg.pack_corpus.validate_pack_fixtures", lambda *args, **kwargs: None)
+
+    current_new = TemporalQueryCase(
+        case_id="current-durable-core",
+        query="What is the current durable truth using immutable evidence and append-only knowledge events?",
+        pack_ids=(AI,),
+        relevant_ids=frozenset({NEW}),
+    )
+    historical_old = TemporalQueryCase(
+        case_id="historical-sqlite",
+        query="What was the former canonical corpus database SQLite premise?",
+        pack_ids=(AI,),
+        relevant_ids=frozenset({OLD}),
+    )
+    phases = [
+        TemporalPhase(
+            phase_id="sqlite-current",
+            as_of_recorded_at="2026-08-10T05:26:04Z",
+            expected_states={OLD: "supported", DEPENDENT: "supported", DEPENDS: "active"},
+            queries=(
+                TemporalQueryCase(
+                    case_id="current-sqlite",
+                    query="What is the current canonical corpus database SQLite premise?",
+                    pack_ids=(AI,),
+                    relevant_ids=frozenset({OLD}),
+                ),
+            ),
+        ),
+        TemporalPhase(
+            phase_id="durable-core-current",
+            as_of_recorded_at="2026-08-10T05:26:08Z",
+            expected_states={
+                OLD: "superseded",
+                DEPENDENT: "stale_pending_review",
+                NEW: "supported",
+                SUPERSEDES: "active",
+            },
+            queries=(current_new, historical_old),
+        ),
+        TemporalPhase(
+            phase_id="later-corpus-growth",
+            as_of_recorded_at=None,
+            expected_states={
+                OLD: "superseded",
+                DEPENDENT: "stale_pending_review",
+                NEW: "supported",
+                UNRELATED: "supported",
+            },
+            queries=(current_new, historical_old),
+        ),
+    ]
+
+    report = run_temporal_evolution_benchmark(
+        [root],
+        schemas_root=tmp_path / "schemas",
+        phases=phases,
+    )
+
+    assert report["passed"] is True
+    assert report["phase_count"] == 3
+    assert report["authority_rule"] == "durable lifecycle/lineage state outranks retrieval score"
+
+    second = report["phases"][1]
+    changes = {item["id"]: item for item in second["transition_from_previous"]["state_changes"]}
+    assert changes[OLD]["before_state"] == "supported"
+    assert changes[OLD]["after_state"] == "superseded"
+    assert changes[DEPENDENT]["before_state"] == "supported"
+    assert changes[DEPENDENT]["after_state"] == "stale_pending_review"
+
+    stability = report["repeated_query_stability"]
+    assert stability["current-durable-core"]["all_full_recall"] is True
+    assert stability["current-durable-core"]["no_current_state_leakage"] is True
+    assert stability["historical-sqlite"]["all_full_recall"] is True
+
+
+def test_temporal_benchmark_rejects_wrong_expected_state(tmp_path, monkeypatch):
+    root = _fixture(tmp_path)
+    monkeypatch.setattr("dkg.pack_corpus.validate_pack_fixtures", lambda *args, **kwargs: None)
+
+    report = run_temporal_evolution_benchmark(
+        [root],
+        schemas_root=tmp_path / "schemas",
+        phases=[
+            TemporalPhase(
+                phase_id="bad-expectation",
+                as_of_recorded_at="2026-08-10T05:26:08Z",
+                expected_states={OLD: "supported"},
+                queries=(),
+            )
+        ],
+    )
+
+    assert report["passed"] is False
+    check = report["phases"][0]["state_checks"][0]
+    assert check["observed_state"] == "superseded"
+    assert check["passed"] is False


### PR DESCRIPTION
Implements Issue #48 Workstream A without depending on hosted models.

## What changed

- adds as-of durable-event replay to `retrieval_documents_from_pack_fixtures` so search projections can be rebuilt at historical `recorded_at` cutoffs while still validating the complete pack first;
- adds `dkg.temporal_benchmark` for phased evolving-corpus evaluation using the dependency-free BM25 baseline plus the existing lifecycle-intent reranker;
- adds a versioned real-corpus benchmark plan under `benchmarks/post-gate2/`;
- adds a CLI runner that verifies exact Git pack pins before execution;
- adds deterministic tests covering supported -> superseded transitions, dependent `stale_pending_review` propagation, current-vs-history retrieval, and stability after unrelated later corpus growth.

## Authority / architecture constraints

The benchmark deliberately does not give retrieval score truth authority. Each phase rebuilds from durable events, and lifecycle/lineage state remains authoritative. Hosted embeddings/rerankers are intentionally not required for this Workstream A baseline; they remain future #47 / Workstream D competitors.

## Real corpus pins

- `Pukujan/fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`
- `Pukujan/fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`

The committed plan replays the real SQLite -> durable-core transition at multiple cutoffs and then repeats the same current/history queries after the later production-RAG research ingestion to detect temporal instability.

After normal CI is green, I will run an execution-only proof against those exact external pack revisions and record the result before reconciling Issue #48.

Refs #48.