### PR TITLE
Post-Gate-2: add end-to-end answer reliability benchmark

### DIFF
--- a/benchmarks/post-gate2/answer-reliability-v1.json
+++ b/benchmarks/post-gate2/answer-reliability-v1.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": "fossil.answer-reliability-plan.v1",
+  "benchmark_id": "post-gate2-answer-reliability-v1",
+  "description": "Provider-independent end-to-end answer/citation/unsupported-claim/abstention baseline over the landed FOSSIL packs.",
+  "pack_pins": {
+    "fossil-common": "d583005dce06dbb499c3c0de5c22b899655eb8d2",
+    "fossil-ai-systems": "84accd2ee895663990e82ca5b79b592cb503db24"
+  },
+  "authority_rule": "Durable evidence, lifecycle/lineage state, and exact citation identity outrank retrieval/model confidence.",
+  "cases": [
+    {
+      "case_id": "current-durable-core",
+      "category": "current-answer",
+      "query": "What is the current durable truth using immutable evidence and append-only knowledge events?",
+      "pack_ids": ["pack_f024177f89a5442db84171c3dd7f58e5"],
+      "expected_outcome": "answer",
+      "required_claim_ids": ["clm_7f5c691c564c30e1b61f8dc0"],
+      "allowed_claim_ids": ["clm_7f5c691c564c30e1b61f8dc0"],
+      "forbidden_claim_ids": [
+        "clm_643b698b7e9e6aee6a16c48c",
+        "clm_a047d79b8604fadbd44efdf4"
+      ],
+      "required_citation_ids": ["cite_94733f286d230834c9cf63ac"],
+      "limit": 8
+    },
+    {
+      "case_id": "historical-sqlite-premise",
+      "category": "historical-answer",
+      "query": "What was the former canonical corpus database SQLite premise?",
+      "pack_ids": ["pack_f024177f89a5442db84171c3dd7f58e5"],
+      "expected_outcome": "answer",
+      "required_claim_ids": ["clm_643b698b7e9e6aee6a16c48c"],
+      "allowed_claim_ids": ["clm_643b698b7e9e6aee6a16c48c"],
+      "required_citation_ids": ["cite_b4e13e4e1a809f76527311ba"],
+      "limit": 8
+    },
+    {
+      "case_id": "current-stale-sqlite-prototype",
+      "category": "current-unresolved",
+      "query": "Is the first SQLite prototype the current canonical architecture implementation?",
+      "pack_ids": ["pack_f024177f89a5442db84171c3dd7f58e5"],
+      "expected_outcome": "current_state_unresolved",
+      "required_claim_ids": ["clm_a047d79b8604fadbd44efdf4"],
+      "allowed_claim_ids": ["clm_a047d79b8604fadbd44efdf4"],
+      "required_citation_ids": ["cite_b4e13e4e1a809f76527311ba"],
+      "limit": 8
+    },
+    {
+      "case_id": "current-graph-projection-not-canonical",
+      "category": "resolved-contradiction",
+      "query": "What is the current truth about Graphiti Neo4j being the deepest source of truth?",
+      "pack_ids": ["pack_f024177f89a5442db84171c3dd7f58e5"],
+      "expected_outcome": "answer",
+      "required_claim_ids": ["clm_f69dd23d961d485db1c53f0b"],
+      "allowed_claim_ids": ["clm_f69dd23d961d485db1c53f0b"],
+      "forbidden_claim_ids": ["clm_bdf2ed41fb11e6b1808d3df4"],
+      "required_citation_ids": ["cite_5b49c675e5e0d086e7b5dd46"],
+      "limit": 8
+    },
+    {
+      "case_id": "historical-rejected-graph-canonical",
+      "category": "historical-rejected",
+      "query": "What was the rejected graph database canonical storage claim?",
+      "pack_ids": ["pack_f024177f89a5442db84171c3dd7f58e5"],
+      "expected_outcome": "answer",
+      "required_claim_ids": ["clm_bdf2ed41fb11e6b1808d3df4"],
+      "allowed_claim_ids": ["clm_bdf2ed41fb11e6b1808d3df4"],
+      "required_citation_ids": ["cite_a7a3bfd1996a33857e073335"],
+      "limit": 8
+    },
+    {
+      "case_id": "insufficient-evidence-control",
+      "category": "insufficient-evidence",
+      "query": "quasar zebrafish magnetotail authorization",
+      "pack_ids": [
+        "pack_269099f7b2ba43b7a99b9427d64092de",
+        "pack_f024177f89a5442db84171c3dd7f58e5"
+      ],
+      "expected_outcome": "insufficient_evidence",
+      "required_claim_ids": [],
+      "allowed_claim_ids": [],
+      "required_citation_ids": [],
+      "limit": 8
+    }
+  ]
+}

--- a/docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md
+++ b/docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md
@@ -1,0 +1,107 @@
+# Post-Gate-2 Workstream B — Answer Reliability Proof
+
+**Date:** 2026-08-10  
+**Campaign:** Issue #48 — production RAG hardening  
+**Workstream:** B — end-to-end answer/citation/abstention evaluation
+
+## Scope
+
+This proof establishes a provider-independent answer-level baseline above retrieval. It does **not** grant model output truth authority and it does not replace D021.
+
+The committed evaluator measures:
+
+- final-answer correctness;
+- exact citation identity including source snapshot, artifact, byte span, and passage hash;
+- unsupported-claim rate;
+- answer completeness;
+- contradiction handling;
+- explicit `insufficient_evidence`, `conflicting_evidence`, and `current_state_unresolved` outcomes;
+- appropriate abstention / over-abstention;
+- confidence calibration through Brier error and high-confidence error rate;
+- latency and provider cost metadata.
+
+The deterministic baseline can only emit durable claim/citation objects supplied through FOSSIL context. It cannot manufacture a new knowledge claim.
+
+## Exact corpus pins
+
+- `Pukujan/fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`
+- `Pukujan/fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`
+
+The combined validated projection contained **27 retrieval documents**.
+
+## Initial proof — intentionally failed
+
+Execution-only PR #58 ran the unchanged six-case real-corpus plan before durable lineage-context expansion.
+
+- workflow run: `31433165782`
+- job: `93601155740`
+- core suite: **92 passed in 8.68s**
+- answer benchmark result: **FAIL**
+- final-answer correctness: `0.8333333333333334`
+- citation correctness: `0.8333333333333334`
+- unsupported-claim mean: `0.16666666666666666`
+- appropriate abstention: `0.5`
+- Brier score: `0.16666666666666666`
+- high-confidence error rate: `0.16666666666666666`
+
+The failed case was `current-stale-sqlite-prototype`. BM25 + lifecycle reranking retrieved the durable `DEPENDS_ON` relation but the stale dependent claim itself fell outside top-k. The answerer then selected an unrelated supported research-hardening claim and answered with confidence `1.0`.
+
+That failure is evidence for D021 rather than a reason to weaken the benchmark: **top-k absence is not evidence of nonexistence**, and current/history questions must resolve durable lifecycle/lineage state.
+
+PR #58 was closed without merge.
+
+## Fix
+
+The base implementation added `fossil-lineage-context-v1`, a deterministic relation-endpoint resolver that runs between retrieval and model execution.
+
+When a retrieved durable relation carries stable `source_ref` / `target_ref` IDs, the resolver loads those referenced documents from the already mounted, validated packs before answer generation. Retrieval remains candidate ordering; durable IDs and lifecycle/lineage remain the authority path.
+
+The resolver is wrapped around the `ModelService` boundary, so future LiteLLM/Cortex/frontier/OSS model competitors can receive the same corrected context while retaining their underlying provider/model metadata.
+
+Regression tests were added for the exact observed failure: relation retrieved, stale endpoint absent from top-k, endpoint recovered by stable ID, final outcome correctly becomes `current_state_unresolved`.
+
+Normal PR #57 CI after the fix:
+
+- workflow run: `31433377445`
+- job: `93601846449`
+- result: **94 passed in 1.24s**
+
+## Final real-corpus proof — PASS
+
+Execution-only PR #59 reran the **same unchanged six-case plan** against the same exact corpus pins after the lineage fix.
+
+- workflow run: `31433427436`
+- job: `93602011104`
+- core suite inside proof: **94 passed in 1.04s**
+- answer benchmark: **PASS**
+- cases: `6`
+- final-answer correctness: `1.0`
+- outcome accuracy: `1.0`
+- citation correctness: `1.0`
+- mean unsupported-claim rate: `0.0`
+- completeness: `1.0`
+- appropriate abstention: `1.0`
+- over-abstention: `0.0`
+- Brier score: `0.0`
+- high-confidence error rate: `0.0`
+- estimated model cost: `$0.0`
+- mean answer-service latency in this local baseline: approximately `0.863 ms`
+
+The stale SQLite dependent case now resolves to:
+
+- outcome: `current_state_unresolved`;
+- claim: `clm_a047d79b8604fadbd44efdf4`;
+- exact citation: `cite_b4e13e4e1a809f76527311ba`;
+- unsupported claims: none.
+
+PR #59 was closed without merge after proof.
+
+## Interpretation
+
+Workstream B now has a deterministic, provider-independent answer reliability floor. A hosted/frontier/OSS model is allowed to beat this baseline on synthesis quality, language quality, breadth, or matched complex-answer cases, but it must not silently regress exact citation identity, unsupported-claim behavior, abstention, lifecycle resolution, or provider/model provenance.
+
+LiteLLM/Cortex integration belongs behind this same `ModelService` boundary. Requested model, actual model, fallback attempts, privacy warnings, provider/model/runtime identity, latency, and cost must be recorded for live model evidence. A fallback response is not proof that the originally requested model succeeded.
+
+## Authority conclusion
+
+D021 remains unchanged. Durable evidence + lifecycle/lineage + exact citation identity outrank retrieval score and model confidence. The failed first proof strengthened this requirement with direct FOSSIL evidence.

--- a/scripts/run_post_gate2_answer_reliability.py
+++ b/scripts/run_post_gate2_answer_reliability.py
@@ -10,6 +10,7 @@ from dkg.answer_eval import (
     DeterministicEvidenceAnswerService,
     run_answer_reliability_benchmark,
 )
+from dkg.answer_pipeline import LineageResolvedModelService
 from dkg.pack_corpus import retrieval_documents_from_pack_fixtures
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -57,8 +58,12 @@ def main() -> int:
         schemas_root=ROOT / "schemas",
     )
     cases = [AnswerReliabilityCase.from_mapping(item) for item in plan["cases"]]
-    report = run_answer_reliability_benchmark(
+    service = LineageResolvedModelService(
         DeterministicEvidenceAnswerService(),
+        documents=documents,
+    )
+    report = run_answer_reliability_benchmark(
+        service,
         documents=documents,
         cases=cases,
         benchmark_id=str(plan["benchmark_id"]),
@@ -67,7 +72,8 @@ def main() -> int:
     report["pack_pins"] = observed_pins
     report["corpus_document_count"] = len(documents)
     report["baseline"] = (
-        "provider-independent BM25+lifecycle context -> deterministic durable-evidence answerer"
+        "provider-independent BM25+lifecycle retrieval -> durable relation-endpoint "
+        "resolution -> deterministic durable-evidence answerer"
     )
 
     rendered = json.dumps(report, indent=2, sort_keys=True)

--- a/scripts/run_post_gate2_answer_reliability.py
+++ b/scripts/run_post_gate2_answer_reliability.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+from dkg.answer_eval import (
+    AnswerReliabilityCase,
+    DeterministicEvidenceAnswerService,
+    run_answer_reliability_benchmark,
+)
+from dkg.pack_corpus import retrieval_documents_from_pack_fixtures
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PLAN = ROOT / "benchmarks" / "post-gate2" / "answer-reliability-v1.json"
+
+
+def _git_head(root: Path) -> str:
+    return subprocess.check_output(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+
+
+def _load_plan(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("answer reliability plan must be a JSON object")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the post-Gate-2 provider-independent answer reliability benchmark."
+    )
+    parser.add_argument("--common-root", type=Path, required=True)
+    parser.add_argument("--ai-root", type=Path, required=True)
+    parser.add_argument("--plan", type=Path, default=DEFAULT_PLAN)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    plan = _load_plan(args.plan)
+    expected_pins = {str(key): str(value) for key, value in plan["pack_pins"].items()}
+    observed_pins = {
+        "fossil-common": _git_head(args.common_root),
+        "fossil-ai-systems": _git_head(args.ai_root),
+    }
+    if observed_pins != expected_pins:
+        raise SystemExit(
+            "pack pin mismatch: "
+            + json.dumps({"expected": expected_pins, "observed": observed_pins}, sort_keys=True)
+        )
+
+    documents = retrieval_documents_from_pack_fixtures(
+        [args.common_root, args.ai_root],
+        schemas_root=ROOT / "schemas",
+    )
+    cases = [AnswerReliabilityCase.from_mapping(item) for item in plan["cases"]]
+    report = run_answer_reliability_benchmark(
+        DeterministicEvidenceAnswerService(),
+        documents=documents,
+        cases=cases,
+        benchmark_id=str(plan["benchmark_id"]),
+    )
+    report["plan_schema_version"] = str(plan["schema_version"])
+    report["pack_pins"] = observed_pins
+    report["corpus_document_count"] = len(documents)
+    report["baseline"] = (
+        "provider-independent BM25+lifecycle context -> deterministic durable-evidence answerer"
+    )
+
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    return 0 if report["passed"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dkg/answer_eval.py
+++ b/src/dkg/answer_eval.py
@@ -1,0 +1,521 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+from .real_retrieval import LifecycleIntentReranker, RerankedRetriever
+from .services import BM25Retriever, ServiceMetadata, tokenize
+
+ANSWER_OUTCOMES = frozenset(
+    {"answer", "insufficient_evidence", "conflicting_evidence", "current_state_unresolved"}
+)
+CURRENT_STATES = frozenset({"supported", "open"})
+HISTORICAL_STATES = frozenset(
+    {"superseded", "rejected", "retracted", "stale_pending_review", "disputed"}
+)
+UNRESOLVED_STATES = frozenset({"disputed", "stale_pending_review"})
+LIVE_CONFLICT_STATES = frozenset({"supported", "open", "disputed"})
+_CITATION_KEYS = (
+    "schema_version",
+    "citation_id",
+    "snapshot_id",
+    "artifact_id",
+    "byte_start",
+    "byte_end",
+    "passage_hash",
+)
+
+
+@dataclass(frozen=True)
+class AnswerReliabilityCase:
+    case_id: str
+    query: str
+    pack_ids: tuple[str, ...]
+    expected_outcome: str
+    required_claim_ids: frozenset[str] = frozenset()
+    allowed_claim_ids: frozenset[str] = frozenset()
+    forbidden_claim_ids: frozenset[str] = frozenset()
+    required_citation_ids: frozenset[str] = frozenset()
+    category: str = "general"
+    limit: int = 8
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "AnswerReliabilityCase":
+        required = frozenset(str(item) for item in value.get("required_claim_ids", []))
+        allowed_raw = value.get("allowed_claim_ids")
+        allowed = (
+            frozenset(str(item) for item in allowed_raw)
+            if allowed_raw is not None
+            else required
+        )
+        return cls(
+            case_id=str(value["case_id"]),
+            query=str(value["query"]),
+            pack_ids=tuple(str(item) for item in value["pack_ids"]),
+            expected_outcome=str(value["expected_outcome"]),
+            required_claim_ids=required,
+            allowed_claim_ids=allowed,
+            forbidden_claim_ids=frozenset(
+                str(item) for item in value.get("forbidden_claim_ids", [])
+            ),
+            required_citation_ids=frozenset(
+                str(item) for item in value.get("required_citation_ids", [])
+            ),
+            category=str(value.get("category", "general")),
+            limit=int(value.get("limit", 8)),
+        )
+
+    def __post_init__(self) -> None:
+        if not self.case_id or not self.query or not self.pack_ids:
+            raise ValueError("answer reliability cases require id/query/packs")
+        if self.expected_outcome not in ANSWER_OUTCOMES:
+            raise ValueError(f"invalid expected answer outcome: {self.expected_outcome}")
+        if self.limit < 1:
+            raise ValueError("answer reliability case limit must be positive")
+        if self.expected_outcome == "answer" and not self.required_claim_ids:
+            raise ValueError("answer cases require at least one required claim")
+
+
+def _documents_by_id(documents: Iterable[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {str(document["id"]): dict(document) for document in documents}
+
+
+def _canonical_citation(value: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    return {key: value.get(key) for key in _CITATION_KEYS}
+
+
+def _candidate_claims(candidate: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw = candidate.get("claims", [])
+    if not isinstance(raw, list):
+        return []
+    return [dict(item) for item in raw if isinstance(item, Mapping)]
+
+
+def _claim_payload(document: Mapping[str, Any]) -> dict[str, Any]:
+    payload = {
+        "claim_id": str(document["id"]),
+        "text": str(document.get("text", "")),
+    }
+    citation = _canonical_citation(document.get("citation"))
+    if citation is not None:
+        payload["citation"] = citation
+    return payload
+
+
+def evaluate_answer_candidate(
+    candidate: Mapping[str, Any],
+    *,
+    case: AnswerReliabilityCase,
+    documents: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    document_by_id = _documents_by_id(documents)
+    observed_outcome = str(candidate.get("outcome", "invalid"))
+    claims = _candidate_claims(candidate)
+    claim_ids = [str(item.get("claim_id", "")) for item in claims if item.get("claim_id")]
+    claim_id_set = set(claim_ids)
+
+    unsupported_ids = sorted(
+        {
+            identifier
+            for identifier in claim_id_set
+            if identifier not in case.allowed_claim_ids
+            or identifier not in document_by_id
+            or str(document_by_id[identifier].get("document_type", "")) != "claim"
+        }
+    )
+    forbidden_present = sorted(claim_id_set & set(case.forbidden_claim_ids))
+    required_present = set(case.required_claim_ids) <= claim_id_set
+    completeness = (
+        len(set(case.required_claim_ids) & claim_id_set) / len(case.required_claim_ids)
+        if case.required_claim_ids
+        else 1.0
+    )
+
+    citation_checks: list[dict[str, Any]] = []
+    observed_citation_ids: set[str] = set()
+    for claim in claims:
+        identifier = str(claim.get("claim_id", ""))
+        expected_document = document_by_id.get(identifier)
+        expected = _canonical_citation(
+            expected_document.get("citation") if expected_document else None
+        )
+        observed = _canonical_citation(claim.get("citation"))
+        if observed and observed.get("citation_id"):
+            observed_citation_ids.add(str(observed["citation_id"]))
+        exact = expected is not None and observed == expected
+        citation_checks.append(
+            {
+                "claim_id": identifier,
+                "expected_citation_id": (
+                    str(expected.get("citation_id")) if expected else None
+                ),
+                "observed_citation_id": (
+                    str(observed.get("citation_id")) if observed else None
+                ),
+                "exact_match": exact,
+            }
+        )
+
+    required_citations_present = set(case.required_citation_ids) <= observed_citation_ids
+    citation_correct = all(item["exact_match"] for item in citation_checks) and (
+        required_citations_present
+    )
+    if not claims and not case.required_citation_ids:
+        citation_correct = True
+
+    outcome_match = observed_outcome == case.expected_outcome
+    contradiction_handled = (
+        outcome_match and required_present and citation_correct
+        if case.expected_outcome == "conflicting_evidence"
+        else True
+    )
+    appropriate_abstention = (
+        outcome_match if case.expected_outcome != "answer" else None
+    )
+    overabstention = case.expected_outcome == "answer" and observed_outcome != "answer"
+
+    try:
+        confidence = float(candidate.get("confidence", 0.0))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    confidence = max(0.0, min(1.0, confidence))
+
+    case_correct = (
+        outcome_match
+        and required_present
+        and not unsupported_ids
+        and not forbidden_present
+        and citation_correct
+        and contradiction_handled
+    )
+    unsupported_rate = len(unsupported_ids) / max(len(claim_id_set), 1)
+
+    return {
+        "case_id": case.case_id,
+        "category": case.category,
+        "expected_outcome": case.expected_outcome,
+        "observed_outcome": observed_outcome,
+        "outcome_match": outcome_match,
+        "required_claim_ids": sorted(case.required_claim_ids),
+        "observed_claim_ids": claim_ids,
+        "unsupported_claim_ids": unsupported_ids,
+        "unsupported_claim_rate": unsupported_rate,
+        "forbidden_claim_ids_present": forbidden_present,
+        "completeness": completeness,
+        "citation_checks": citation_checks,
+        "required_citation_ids": sorted(case.required_citation_ids),
+        "required_citations_present": required_citations_present,
+        "citation_correct": citation_correct,
+        "contradiction_handled": contradiction_handled,
+        "appropriate_abstention": appropriate_abstention,
+        "overabstention": overabstention,
+        "confidence": confidence,
+        "case_correct": case_correct,
+    }
+
+
+class DeterministicEvidenceAnswerService:
+    """Provider-independent answer baseline that can only emit retrieved durable claims.
+
+    It is intentionally conservative. It copies claim text/citation identity from validated
+    retrieval documents, respects lifecycle state, and abstains instead of inventing prose.
+    """
+
+    def __init__(self, *, version: str = "1") -> None:
+        self.version = version
+
+    def metadata(self) -> dict[str, Any]:
+        return ServiceMetadata(
+            kind="model",
+            provider="fossil",
+            provider_version="1",
+            implementation="deterministic-evidence-answerer",
+            implementation_version=self.version,
+            model_id=None,
+            local=True,
+            estimated_cost_per_call_usd=0.0,
+            runtime={"authority": "durable-context-only"},
+        ).as_dict()
+
+    @staticmethod
+    def _overlap(query: str, document: Mapping[str, Any]) -> float:
+        query_terms = set(tokenize(query))
+        if not query_terms:
+            return 0.0
+        document_terms = set(tokenize(str(document.get("text", ""))))
+        return len(query_terms & document_terms) / len(query_terms)
+
+    def run(self, task: dict[str, Any]) -> dict[str, Any]:
+        query = str(task["query"])
+        items = [dict(item) for item in task.get("context_items", [])]
+        claim_items = [
+            item for item in items if str(item.get("document_type", "")) == "claim"
+        ]
+        if not claim_items:
+            return {
+                "output": {
+                    "outcome": "insufficient_evidence",
+                    "answer_text": "Insufficient evidence.",
+                    "claims": [],
+                    "confidence": 1.0,
+                },
+                "authority": "candidate_only",
+                "service": self.metadata(),
+            }
+
+        ranked_claims = sorted(
+            enumerate(claim_items),
+            key=lambda pair: (
+                -self._overlap(query, pair[1]),
+                pair[0],
+                str(pair[1].get("id", "")),
+            ),
+        )
+        top_overlap = self._overlap(query, ranked_claims[0][1])
+        topical = [
+            item
+            for _, item in ranked_claims
+            if abs(self._overlap(query, item) - top_overlap) < 1e-12
+        ]
+        topical_by_id = {str(item["id"]): item for item in topical}
+
+        relations = [
+            item
+            for item in items
+            if str(item.get("document_type", "")) == "relation"
+            and str(item.get("relation_type", "")) == "CONTRADICTS"
+            and str(item.get("current_state", "")) == "active"
+        ]
+        for relation in relations:
+            source = topical_by_id.get(str(relation.get("source_ref", "")))
+            target = topical_by_id.get(str(relation.get("target_ref", "")))
+            if not source or not target:
+                continue
+            source_state = str(source.get("current_state", ""))
+            target_state = str(target.get("current_state", ""))
+            if source_state in LIVE_CONFLICT_STATES and target_state in LIVE_CONFLICT_STATES:
+                evidence = [_claim_payload(source), _claim_payload(target)]
+                evidence.sort(key=lambda item: str(item["claim_id"]))
+                return {
+                    "output": {
+                        "outcome": "conflicting_evidence",
+                        "answer_text": "Conflicting evidence remains unresolved.",
+                        "claims": evidence,
+                        "confidence": 1.0,
+                    },
+                    "authority": "candidate_only",
+                    "service": self.metadata(),
+                }
+
+        intent = LifecycleIntentReranker.intent_for_query(query)
+        if intent == "historical":
+            historical = [
+                item
+                for item in topical
+                if str(item.get("current_state", "")) in HISTORICAL_STATES
+            ]
+            if historical:
+                chosen = historical[0]
+                return {
+                    "output": {
+                        "outcome": "answer",
+                        "answer_text": str(chosen.get("text", "")),
+                        "claims": [_claim_payload(chosen)],
+                        "confidence": 1.0,
+                    },
+                    "authority": "candidate_only",
+                    "service": self.metadata(),
+                }
+
+        current = [
+            item for item in topical if str(item.get("current_state", "")) in CURRENT_STATES
+        ]
+        if current:
+            chosen = current[0]
+            return {
+                "output": {
+                    "outcome": "answer",
+                    "answer_text": str(chosen.get("text", "")),
+                    "claims": [_claim_payload(chosen)],
+                    "confidence": 1.0,
+                },
+                "authority": "candidate_only",
+                "service": self.metadata(),
+            }
+
+        unresolved = [
+            item
+            for item in topical
+            if str(item.get("current_state", "")) in UNRESOLVED_STATES
+        ]
+        if unresolved:
+            chosen = unresolved[0]
+            return {
+                "output": {
+                    "outcome": "current_state_unresolved",
+                    "answer_text": "Current state unresolved.",
+                    "claims": [_claim_payload(chosen)],
+                    "confidence": 1.0,
+                },
+                "authority": "candidate_only",
+                "service": self.metadata(),
+            }
+
+        return {
+            "output": {
+                "outcome": "insufficient_evidence",
+                "answer_text": "Insufficient evidence.",
+                "claims": [],
+                "confidence": 1.0,
+            },
+            "authority": "candidate_only",
+            "service": self.metadata(),
+        }
+
+
+def build_answer_context(
+    documents: Iterable[Mapping[str, Any]],
+    case: AnswerReliabilityCase,
+) -> list[dict[str, Any]]:
+    document_list = [dict(document) for document in documents]
+    base = BM25Retriever(document_list)
+    retriever = RerankedRetriever(
+        base,
+        LifecycleIntentReranker(),
+        candidate_multiplier=4,
+        version="answer-reliability-baseline-v1",
+    )
+    return retriever.search(
+        case.query,
+        pack_ids=list(case.pack_ids),
+        limit=case.limit,
+    )
+
+
+def run_answer_reliability_benchmark(
+    service: Any,
+    *,
+    documents: Iterable[Mapping[str, Any]],
+    cases: Iterable[AnswerReliabilityCase],
+    benchmark_id: str = "post-gate2-answer-reliability-v1",
+) -> dict[str, Any]:
+    document_list = [dict(document) for document in documents]
+    case_list = list(cases)
+    if not document_list or not case_list:
+        raise ValueError("answer reliability benchmark requires documents and cases")
+
+    service_metadata = dict(service.metadata())
+    observations: list[dict[str, Any]] = []
+    latencies_ms: list[float] = []
+
+    for case in case_list:
+        context_items = build_answer_context(document_list, case)
+        started = time.perf_counter()
+        response = dict(
+            service.run(
+                {
+                    "query": case.query,
+                    "pack_ids": list(case.pack_ids),
+                    "context_items": context_items,
+                    "response_contract": {
+                        "outcomes": sorted(ANSWER_OUTCOMES),
+                        "claims": "structured claim_id/text/citation assertions",
+                        "confidence": "0..1 confidence in the emitted outcome",
+                    },
+                }
+            )
+        )
+        latency_ms = (time.perf_counter() - started) * 1000.0
+        latencies_ms.append(latency_ms)
+        candidate = dict(response.get("output", {}))
+        evaluation = evaluate_answer_candidate(
+            candidate,
+            case=case,
+            documents=document_list,
+        )
+        observations.append(
+            {
+                **evaluation,
+                "query": case.query,
+                "context_ids": [str(item["id"]) for item in context_items],
+                "answer_text": str(candidate.get("answer_text", "")),
+                "latency_ms": latency_ms,
+                "authority": response.get("authority"),
+                "service": dict(response.get("service", service_metadata)),
+            }
+        )
+
+    count = len(observations)
+    abstention_cases = [
+        item for item in observations if item["expected_outcome"] != "answer"
+    ]
+    conflict_cases = [
+        item
+        for item in observations
+        if item["expected_outcome"] == "conflicting_evidence"
+    ]
+    exact_citations = [bool(item["citation_correct"]) for item in observations]
+    brier = sum(
+        (
+            float(item["confidence"])
+            - (1.0 if bool(item["case_correct"]) else 0.0)
+        )
+        ** 2
+        for item in observations
+    ) / count
+    high_confidence_errors = [
+        item
+        for item in observations
+        if float(item["confidence"]) >= 0.8 and not bool(item["case_correct"])
+    ]
+    cost_per_call = float(service_metadata.get("estimated_cost_per_call_usd", 0.0))
+
+    metrics = {
+        "final_answer_correctness_rate": sum(
+            bool(item["case_correct"]) for item in observations
+        )
+        / count,
+        "outcome_accuracy": sum(bool(item["outcome_match"]) for item in observations)
+        / count,
+        "citation_correctness_rate": sum(exact_citations) / count,
+        "mean_unsupported_claim_rate": sum(
+            float(item["unsupported_claim_rate"]) for item in observations
+        )
+        / count,
+        "completeness_rate": sum(
+            float(item["completeness"]) == 1.0 for item in observations
+        )
+        / count,
+        "contradiction_handling_rate": (
+            sum(bool(item["contradiction_handled"]) for item in conflict_cases)
+            / len(conflict_cases)
+            if conflict_cases
+            else None
+        ),
+        "appropriate_abstention_rate": (
+            sum(bool(item["appropriate_abstention"]) for item in abstention_cases)
+            / len(abstention_cases)
+            if abstention_cases
+            else None
+        ),
+        "overabstention_rate": sum(bool(item["overabstention"]) for item in observations)
+        / count,
+        "brier_score": brier,
+        "high_confidence_error_rate": len(high_confidence_errors) / count,
+        "mean_latency_ms": sum(latencies_ms) / count,
+        "estimated_cost_usd": cost_per_call * count,
+    }
+
+    return {
+        "schema_version": "fossil.answer-reliability-benchmark.v1",
+        "benchmark_id": benchmark_id,
+        "authority_rule": "durable evidence/lifecycle/citation identity outranks model confidence",
+        "service": service_metadata,
+        "case_count": count,
+        "metrics": metrics,
+        "observations": observations,
+        "passed": all(bool(item["case_correct"]) for item in observations),
+    }

--- a/src/dkg/answer_pipeline.py
+++ b/src/dkg/answer_pipeline.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import copy
+from typing import Any, Iterable, Mapping
+
+
+def expand_context_with_lineage(
+    context_items: Iterable[Mapping[str, Any]],
+    *,
+    documents: Iterable[Mapping[str, Any]],
+    pack_ids: Iterable[str],
+    max_expansions: int = 24,
+) -> list[dict[str, Any]]:
+    """Expand retrieved relation endpoints from the durable corpus before answering.
+
+    Retrieval rank remains candidate ordering. When retrieval returns a durable relation,
+    its stable source/target references are resolved from the mounted packs so top-k absence
+    cannot erase lineage needed for a current/history answer.
+    """
+
+    if max_expansions < 0:
+        raise ValueError("max_expansions must be non-negative")
+    allowed = {str(pack_id) for pack_id in pack_ids}
+    document_by_id = {
+        str(document["id"]): copy.deepcopy(dict(document))
+        for document in documents
+        if str(document.get("pack_id", "")) in allowed
+    }
+    selected = [copy.deepcopy(dict(item)) for item in context_items]
+    selected_ids = {str(item.get("id", "")) for item in selected}
+    expansion_ids: list[str] = []
+
+    for item in selected:
+        if str(item.get("document_type", "")) != "relation":
+            continue
+        for key in ("source_ref", "target_ref"):
+            identifier = str(item.get(key, ""))
+            if identifier and identifier not in selected_ids and identifier in document_by_id:
+                expansion_ids.append(identifier)
+                selected_ids.add(identifier)
+                if len(expansion_ids) >= max_expansions:
+                    break
+        if len(expansion_ids) >= max_expansions:
+            break
+
+    for identifier in expansion_ids:
+        item = document_by_id[identifier]
+        item["context_expansion"] = {
+            "reason": "durable_relation_endpoint",
+            "resolver": "fossil-lineage-context-v1",
+        }
+        selected.append(item)
+    return selected
+
+
+class LineageResolvedModelService:
+    """Wrap any ModelService with deterministic durable-lineage context resolution."""
+
+    def __init__(
+        self,
+        service: Any,
+        *,
+        documents: Iterable[Mapping[str, Any]],
+        max_expansions: int = 24,
+    ) -> None:
+        self.service = service
+        self.documents = [copy.deepcopy(dict(document)) for document in documents]
+        self.max_expansions = int(max_expansions)
+        if self.max_expansions < 0:
+            raise ValueError("max_expansions must be non-negative")
+
+    def metadata(self) -> dict[str, Any]:
+        metadata = copy.deepcopy(dict(self.service.metadata()))
+        runtime = dict(metadata.get("runtime", {}))
+        runtime["lineage_context_resolver"] = "fossil-lineage-context-v1"
+        runtime["lineage_max_expansions"] = str(self.max_expansions)
+        metadata["runtime"] = runtime
+        return metadata
+
+    def run(self, task: dict[str, Any]) -> dict[str, Any]:
+        request = copy.deepcopy(task)
+        request["context_items"] = expand_context_with_lineage(
+            request.get("context_items", []),
+            documents=self.documents,
+            pack_ids=request.get("pack_ids", []),
+            max_expansions=self.max_expansions,
+        )
+        response = copy.deepcopy(dict(self.service.run(request)))
+        response["service"] = self.metadata()
+        return response

--- a/tests/test_answer_eval.py
+++ b/tests/test_answer_eval.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from dkg.answer_eval import (
+    AnswerReliabilityCase,
+    DeterministicEvidenceAnswerService,
+    evaluate_answer_candidate,
+    run_answer_reliability_benchmark,
+)
+
+PACK = "pack_test_answer_reliability"
+
+
+def _citation(identifier: str, *, start: int = 0) -> dict:
+    return {
+        "schema_version": "fossil.citation.v1",
+        "citation_id": identifier,
+        "snapshot_id": f"snap_{identifier}",
+        "artifact_id": f"art_{identifier}",
+        "byte_start": start,
+        "byte_end": start + 20,
+        "passage_hash": {"algorithm": "sha256", "digest": identifier[-1] * 64},
+    }
+
+
+def _claim(identifier: str, text: str, state: str, citation_id: str) -> dict:
+    return {
+        "id": identifier,
+        "pack_id": PACK,
+        "text": text,
+        "document_type": "claim",
+        "current_state": state,
+        "state_history": [state],
+        "citation": _citation(citation_id),
+    }
+
+
+def test_evaluator_accepts_exact_supported_answer_and_citation():
+    document = _claim(
+        "clm_durable",
+        "Durable truth uses immutable evidence and append-only events.",
+        "supported",
+        "cite_durable",
+    )
+    case = AnswerReliabilityCase(
+        case_id="current-durable",
+        query="What is the current durable truth?",
+        pack_ids=(PACK,),
+        expected_outcome="answer",
+        required_claim_ids=frozenset({"clm_durable"}),
+        allowed_claim_ids=frozenset({"clm_durable"}),
+        required_citation_ids=frozenset({"cite_durable"}),
+    )
+    result = evaluate_answer_candidate(
+        {
+            "outcome": "answer",
+            "answer_text": document["text"],
+            "claims": [
+                {
+                    "claim_id": document["id"],
+                    "text": document["text"],
+                    "citation": document["citation"],
+                }
+            ],
+            "confidence": 0.95,
+        },
+        case=case,
+        documents=[document],
+    )
+
+    assert result["case_correct"] is True
+    assert result["citation_correct"] is True
+    assert result["unsupported_claim_rate"] == 0.0
+    assert result["completeness"] == 1.0
+
+
+def test_evaluator_flags_wrong_citation_and_unsupported_claim():
+    supported = _claim("clm_supported", "Supported claim.", "supported", "cite_supported")
+    other = _claim("clm_other", "Other claim.", "supported", "cite_other")
+    case = AnswerReliabilityCase(
+        case_id="bad-answer",
+        query="What is supported?",
+        pack_ids=(PACK,),
+        expected_outcome="answer",
+        required_claim_ids=frozenset({"clm_supported"}),
+        allowed_claim_ids=frozenset({"clm_supported"}),
+        required_citation_ids=frozenset({"cite_supported"}),
+    )
+    result = evaluate_answer_candidate(
+        {
+            "outcome": "answer",
+            "claims": [
+                {
+                    "claim_id": "clm_supported",
+                    "text": supported["text"],
+                    "citation": other["citation"],
+                },
+                {
+                    "claim_id": "clm_other",
+                    "text": other["text"],
+                    "citation": other["citation"],
+                },
+            ],
+            "confidence": 1.0,
+        },
+        case=case,
+        documents=[supported, other],
+    )
+
+    assert result["case_correct"] is False
+    assert result["citation_correct"] is False
+    assert result["unsupported_claim_ids"] == ["clm_other"]
+    assert result["unsupported_claim_rate"] == 0.5
+
+
+def test_deterministic_answerer_emits_unresolved_and_conflicting_evidence():
+    service = DeterministicEvidenceAnswerService()
+    stale = _claim(
+        "clm_stale",
+        "The first SQLite prototype is the canonical architecture implementation.",
+        "stale_pending_review",
+        "cite_stale",
+    )
+    unresolved = service.run(
+        {
+            "query": "Is the first SQLite prototype the current canonical architecture implementation?",
+            "context_items": [stale],
+        }
+    )["output"]
+    assert unresolved["outcome"] == "current_state_unresolved"
+    assert unresolved["claims"][0]["claim_id"] == "clm_stale"
+
+    left = _claim("clm_blue", "Widget mode is blue.", "supported", "cite_blue")
+    right = _claim("clm_not_blue", "Widget mode is not blue.", "supported", "cite_not_blue")
+    contradiction = {
+        "id": "rel_widget_conflict",
+        "pack_id": PACK,
+        "text": "Widget mode is blue. Relation: CONTRADICTS. Widget mode is not blue.",
+        "document_type": "relation",
+        "relation_type": "CONTRADICTS",
+        "source_ref": "clm_blue",
+        "target_ref": "clm_not_blue",
+        "current_state": "active",
+    }
+    conflict = service.run(
+        {
+            "query": "What is the current widget mode blue?",
+            "context_items": [left, right, contradiction],
+        }
+    )["output"]
+    assert conflict["outcome"] == "conflicting_evidence"
+    assert {item["claim_id"] for item in conflict["claims"]} == {
+        "clm_blue",
+        "clm_not_blue",
+    }
+
+
+def test_benchmark_scores_answer_abstention_conflict_and_calibration():
+    durable = _claim(
+        "clm_durable",
+        "Durable truth uses immutable evidence and append-only events.",
+        "supported",
+        "cite_durable",
+    )
+    stale = _claim(
+        "clm_stale",
+        "The first SQLite prototype is the canonical architecture implementation.",
+        "stale_pending_review",
+        "cite_stale",
+    )
+    left = _claim("clm_blue", "Widget mode is blue.", "supported", "cite_blue")
+    right = _claim("clm_not_blue", "Widget mode is not blue.", "supported", "cite_not_blue")
+    contradiction = {
+        "id": "rel_widget_conflict",
+        "pack_id": PACK,
+        "text": "Widget mode is blue. Relation: CONTRADICTS. Widget mode is not blue.",
+        "document_type": "relation",
+        "relation_type": "CONTRADICTS",
+        "source_ref": "clm_blue",
+        "target_ref": "clm_not_blue",
+        "current_state": "active",
+    }
+    cases = [
+        AnswerReliabilityCase(
+            case_id="answer",
+            query="What is the current durable truth using immutable evidence and append-only events?",
+            pack_ids=(PACK,),
+            expected_outcome="answer",
+            required_claim_ids=frozenset({"clm_durable"}),
+            allowed_claim_ids=frozenset({"clm_durable"}),
+            required_citation_ids=frozenset({"cite_durable"}),
+        ),
+        AnswerReliabilityCase(
+            case_id="unresolved",
+            query="Is the first SQLite prototype the current canonical architecture implementation?",
+            pack_ids=(PACK,),
+            expected_outcome="current_state_unresolved",
+            required_claim_ids=frozenset({"clm_stale"}),
+            allowed_claim_ids=frozenset({"clm_stale"}),
+            required_citation_ids=frozenset({"cite_stale"}),
+        ),
+        AnswerReliabilityCase(
+            case_id="conflict",
+            query="What is the current widget mode blue?",
+            pack_ids=(PACK,),
+            expected_outcome="conflicting_evidence",
+            required_claim_ids=frozenset({"clm_blue", "clm_not_blue"}),
+            allowed_claim_ids=frozenset({"clm_blue", "clm_not_blue"}),
+            required_citation_ids=frozenset({"cite_blue", "cite_not_blue"}),
+        ),
+        AnswerReliabilityCase(
+            case_id="insufficient",
+            query="quasar zebrafish magnetotail authorization",
+            pack_ids=(PACK,),
+            expected_outcome="insufficient_evidence",
+        ),
+    ]
+
+    report = run_answer_reliability_benchmark(
+        DeterministicEvidenceAnswerService(),
+        documents=[durable, stale, left, right, contradiction],
+        cases=cases,
+    )
+
+    assert report["passed"] is True
+    assert report["metrics"]["final_answer_correctness_rate"] == 1.0
+    assert report["metrics"]["citation_correctness_rate"] == 1.0
+    assert report["metrics"]["mean_unsupported_claim_rate"] == 0.0
+    assert report["metrics"]["completeness_rate"] == 1.0
+    assert report["metrics"]["contradiction_handling_rate"] == 1.0
+    assert report["metrics"]["appropriate_abstention_rate"] == 1.0
+    assert report["metrics"]["overabstention_rate"] == 0.0
+    assert report["metrics"]["brier_score"] == 0.0
+    assert report["metrics"]["high_confidence_error_rate"] == 0.0

--- a/tests/test_answer_pipeline.py
+++ b/tests/test_answer_pipeline.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from dkg.answer_eval import (
+    AnswerReliabilityCase,
+    DeterministicEvidenceAnswerService,
+    run_answer_reliability_benchmark,
+)
+from dkg.answer_pipeline import LineageResolvedModelService, expand_context_with_lineage
+
+PACK = "pack_lineage_answer"
+
+
+def _citation(identifier: str) -> dict:
+    return {
+        "schema_version": "fossil.citation.v1",
+        "citation_id": identifier,
+        "snapshot_id": f"snap_{identifier}",
+        "artifact_id": f"art_{identifier}",
+        "byte_start": 0,
+        "byte_end": 20,
+        "passage_hash": {"algorithm": "sha256", "digest": "a" * 64},
+    }
+
+
+def _claim(identifier: str, text: str, state: str, citation_id: str) -> dict:
+    return {
+        "id": identifier,
+        "pack_id": PACK,
+        "text": text,
+        "document_type": "claim",
+        "current_state": state,
+        "state_history": [state],
+        "citation": _citation(citation_id),
+    }
+
+
+def test_lineage_expansion_resolves_relation_endpoints_missing_from_top_k():
+    premise = _claim(
+        "clm_premise",
+        "SQLite is the canonical corpus database.",
+        "superseded",
+        "cite_premise",
+    )
+    dependent = _claim(
+        "clm_dependent",
+        "The first SQLite prototype is the canonical architecture implementation.",
+        "stale_pending_review",
+        "cite_dependent",
+    )
+    unrelated = _claim(
+        "clm_unrelated",
+        "Production RAG hardening keeps the durable core.",
+        "supported",
+        "cite_unrelated",
+    )
+    relation = {
+        "id": "rel_depends",
+        "pack_id": PACK,
+        "text": (
+            "The first SQLite prototype is the canonical architecture implementation.\n"
+            "Relation: DEPENDS_ON\nSQLite is the canonical corpus database."
+        ),
+        "document_type": "relation",
+        "relation_type": "DEPENDS_ON",
+        "source_ref": "clm_dependent",
+        "target_ref": "clm_premise",
+        "current_state": "active",
+    }
+
+    expanded = expand_context_with_lineage(
+        [relation, unrelated],
+        documents=[premise, dependent, unrelated, relation],
+        pack_ids=[PACK],
+    )
+
+    assert [item["id"] for item in expanded] == [
+        "rel_depends",
+        "clm_unrelated",
+        "clm_dependent",
+        "clm_premise",
+    ]
+    assert expanded[2]["context_expansion"]["reason"] == "durable_relation_endpoint"
+
+
+def test_lineage_resolved_service_recovers_stale_current_state_case():
+    premise = _claim(
+        "clm_premise",
+        "SQLite is the canonical corpus database.",
+        "superseded",
+        "cite_premise",
+    )
+    dependent = _claim(
+        "clm_dependent",
+        "The first SQLite prototype is the canonical architecture implementation.",
+        "stale_pending_review",
+        "cite_dependent",
+    )
+    unrelated = _claim(
+        "clm_unrelated",
+        "Production RAG hardening keeps the durable core.",
+        "supported",
+        "cite_unrelated",
+    )
+    relation = {
+        "id": "rel_depends",
+        "pack_id": PACK,
+        "text": (
+            "The first SQLite prototype is the canonical architecture implementation.\n"
+            "Relation: DEPENDS_ON\nSQLite is the canonical corpus database."
+        ),
+        "document_type": "relation",
+        "relation_type": "DEPENDS_ON",
+        "source_ref": "clm_dependent",
+        "target_ref": "clm_premise",
+        "current_state": "active",
+    }
+    documents = [premise, dependent, unrelated, relation]
+    service = LineageResolvedModelService(
+        DeterministicEvidenceAnswerService(),
+        documents=documents,
+    )
+    case = AnswerReliabilityCase(
+        case_id="stale-current",
+        query="Is the first SQLite prototype the current canonical architecture implementation?",
+        pack_ids=(PACK,),
+        expected_outcome="current_state_unresolved",
+        required_claim_ids=frozenset({"clm_dependent"}),
+        allowed_claim_ids=frozenset({"clm_dependent"}),
+        required_citation_ids=frozenset({"cite_dependent"}),
+        limit=2,
+    )
+
+    report = run_answer_reliability_benchmark(
+        service,
+        documents=documents,
+        cases=[case],
+    )
+
+    assert report["passed"] is True
+    observation = report["observations"][0]
+    assert observation["observed_outcome"] == "current_state_unresolved"
+    assert observation["observed_claim_ids"] == ["clm_dependent"]
+    assert report["service"]["runtime"]["lineage_context_resolver"] == (
+        "fossil-lineage-context-v1"
+    )


### PR DESCRIPTION
Implements the first provider-independent slice of Issue #48 Workstream B above retrieval.

## What changed

- adds `dkg.answer_eval` with a structured answer contract and evaluator for final-answer correctness, exact citation/source-snapshot/span identity, unsupported claims, completeness, contradiction handling, abstention, confidence/Brier error, latency, and provider cost;
- adds a conservative deterministic evidence answerer that can only copy validated durable claims/citations from retrieved context and must abstain on insufficient, conflicting, or unresolved evidence;
- adds a versioned real-corpus plan over the landed common + AI-systems pack pins;
- adds an exact-pin runner for execution-only proof;
- adds deterministic tests for good answers, wrong citations, unsupported claims, unresolved current state, active contradiction, insufficient evidence, abstention, and calibration metrics.

## LiteLLM / Cortex boundary

This PR intentionally does **not** make LiteLLM or Cortex v4 a correctness dependency. The existing `ModelService` / `CallableCandidateModelService` boundary can later feed the same structured output contract from LiteLLM/Cortex models. That will let hosted/frontier/OSS candidates compete against the deterministic baseline under identical metrics.

The branch starts from main commit `133bd37eb149a6047180ec66b7f3757f7531aad2`, which already contains the shared LiteLLM gateway documentation/config. Live model proof is separate because gateway fallbacks and actual-model identity must be recorded honestly.

## Real corpus pins

- `Pukujan/fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`
- `Pukujan/fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`

After normal CI is green, run an execution-only proof against those exact pack revisions. Workstream B should not be marked complete unless that real-corpus benchmark passes.

Refs #48 and #47.