### PR TITLE
Execution proof: run answer reliability benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,13 @@ jobs:
         run: python -m pip install -e '.[test]'
       - name: Test
         run: pytest -q
+      - name: Post-Gate-2 answer reliability real-corpus proof
+        run: |
+          git clone --quiet https://github.com/Pukujan/fossil-common.git .answer-packs/common
+          git -C .answer-packs/common checkout --quiet d583005dce06dbb499c3c0de5c22b899655eb8d2
+          git clone --quiet https://github.com/Pukujan/fossil-ai-systems.git .answer-packs/ai-systems
+          git -C .answer-packs/ai-systems checkout --quiet 84accd2ee895663990e82ca5b79b592cb503db24
+          python scripts/run_post_gate2_answer_reliability.py \
+            --common-root .answer-packs/common \
+            --ai-root .answer-packs/ai-systems \
+            --output .answer-proof/report.json


### PR DESCRIPTION
Execution-only proof for Issue #48 Workstream B. Intentionally **not for merge**.

This PR adds only a temporary CI step on top of `agent/post-gate2-answer-reliability`.

It clones and pins:
- `Pukujan/fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`
- `Pukujan/fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`

Then it runs `scripts/run_post_gate2_answer_reliability.py`, which validates the real packs and executes the committed provider-independent final-answer/citation/unsupported-claim/abstention benchmark.

The proof must pass before PR #57 is merged. This branch is closed unmerged afterward so external pack cloning does not become permanent CI.

Refs #48 and #57.