### PR TITLE
Execution proof v2: answer reliability with lineage resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,13 @@ jobs:
         run: python -m pip install -e '.[test]'
       - name: Test
         run: pytest -q
+      - name: Post-Gate-2 answer reliability real-corpus proof
+        run: |
+          git clone --quiet https://github.com/Pukujan/fossil-common.git .answer-packs/common
+          git -C .answer-packs/common checkout --quiet d583005dce06dbb499c3c0de5c22b899655eb8d2
+          git clone --quiet https://github.com/Pukujan/fossil-ai-systems.git .answer-packs/ai-systems
+          git -C .answer-packs/ai-systems checkout --quiet 84accd2ee895663990e82ca5b79b592cb503db24
+          python scripts/run_post_gate2_answer_reliability.py \
+            --common-root .answer-packs/common \
+            --ai-root .answer-packs/ai-systems \
+            --output .answer-proof/report.json


### PR DESCRIPTION
Second execution-only proof for Issue #48 Workstream B. Intentionally **not for merge**.

The first proof (#58) correctly failed because the stale SQLite dependent claim fell outside top-k even though its durable `DEPENDS_ON` relation was retrieved. That demonstrated why D021 forbids treating top-k absence as evidence of nonexistence.

The base branch now adds deterministic relation-endpoint resolution before answer generation. This proof reruns the same unchanged real-corpus benchmark against the same exact pins:
- `Pukujan/fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`
- `Pukujan/fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`

It must pass without weakening the expected answer cases. Close unmerged afterward.

Refs #48, #57, #58.