### PR TITLE
Reconcile handoff after answer reliability

### DIFF
--- a/docs/HANDOFF_CURRENT.md
+++ b/docs/HANDOFF_CURRENT.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-10  
 **Project:** **FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage**  
 **Repository:** `Pukujan/fossil-core`  
-**Status:** **Gate 1 complete. Gate 2 complete and formally closed. Post-Gate-2 campaign #48 active. Research ingestion and Workstream A temporal benchmark complete.**
+**Status:** **Gate 1 complete. Gate 2 complete and formally closed. Post-Gate-2 campaign #48 active. Research ingestion, Workstream A, and Workstream B are complete. Workstream C is next.**
 
 ## Fresh-session transfer
 
@@ -12,135 +12,164 @@ Read, in order:
 1. `AGENTS.md`
 2. `ARCHITECTURE.md`
 3. this file
-4. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-temporal-benchmark.md`
+4. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-answer-reliability.md`
 5. `docs/PROJECT_STATE.md`
-6. `docs/research/2026-08-10-production-rag-hardening-research-trace.md`
-7. Issue #48 — active production RAG hardening campaign
-8. Issue #47 — embedding/reranker/model-scale bakeoff workstream
-9. `docs/DECISION_LOG.md`
-10. older handoffs only when historical context is needed
+6. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
+7. `docs/operations/LITELLM-GATEWAY.md`
+8. Issue #48 — active production RAG hardening campaign
+9. Issue #47 — embedding/reranker/model-scale bakeoff workstream
+10. `docs/DECISION_LOG.md`
 
 ## Exact active continuation point
 
-**Do not redo the research ingestion or Workstream A.**
+**Do not redo the research ingestion, Workstream A, or Workstream B.**
 
 The next unfinished Issue #48 workstream is:
 
-**B. End-to-end answer/citation/abstention evaluation.**
+**C. Retrieval poisoning / untrusted-context hardening.**
 
-Start with a provider-independent baseline above retrieval. Extend evaluation beyond hit-rate/recall/MRR to final-answer behavior and measure:
+Build an adversarial suite proving that retrieved/source text remains untrusted data rather than executable policy. Cover at minimum:
 
-1. final-answer correctness;
-2. citation/source-snapshot/span correctness;
-3. unsupported-claim rate;
-4. answer completeness and contradiction handling;
-5. explicit `insufficient evidence`, `conflicting evidence`, and `current state unresolved` outcomes;
-6. appropriate abstention/calibration rather than confident guessing.
+1. poisoned retrieved documents containing instructions;
+2. authority spoofing;
+3. malicious supersession attempts;
+4. duplicated adversarial passages intended to dominate ranking;
+5. conflicting-source attacks;
+6. pack-isolation pressure;
+7. attempts to bypass proposal-before-commit / deterministic gates;
+8. explicit residual-risk documentation.
 
-Use deterministic/direct-source paths and the existing service contracts for the first baseline. Hosted/frontier models can later compete behind those interfaces; they are not a prerequisite for the correctness contract.
+Reuse Workstream B metrics wherever useful. Do not only test whether poisoned text is retrieved; test whether poisoning changes final-answer correctness, citation correctness, unsupported claims, lifecycle/lineage resolution, abstention behavior, authority boundaries, pack isolation, or proposal-before-commit behavior.
 
-D021 lifecycle/lineage resolution remains authoritative. Retrieval/model scores cannot manufacture truth state.
+Do not claim a universal poisoning defense.
 
-## Workstream A proof — complete
+## Workstream B proof — complete
 
-Implementation landed in core PR #54 / squash:
+Implementation landed in core PR #57 / squash:
 
-`e14148f504702ae9e708e2d58add4ee5c91bc8de`
+`483772ac0e1d441719aec42658ae00b62a032c11`
 
 Landed artifacts:
 
-- `src/dkg/pack_corpus.py` — as-of durable-event projection support;
-- `src/dkg/temporal_benchmark.py` — phased evolving-corpus benchmark;
-- `benchmarks/post-gate2/evolving-corpus-temporal-v1.json` — versioned real-corpus plan;
-- `scripts/run_post_gate2_temporal_benchmark.py` — exact-pin runner;
-- `tests/test_temporal_benchmark.py` — deterministic lifecycle/retrieval tests;
-- `docs/implementation/2026-08-10-post-gate2-temporal-benchmark-proof.md` — durable proof.
+- `src/dkg/answer_eval.py`;
+- `src/dkg/answer_pipeline.py`;
+- `benchmarks/post-gate2/answer-reliability-v1.json`;
+- `scripts/run_post_gate2_answer_reliability.py`;
+- `tests/test_answer_eval.py`;
+- `tests/test_answer_pipeline.py`;
+- `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`.
 
-Final PR #54 CI:
+Final normal CI:
 
-- run `31431210018`;
-- job `93594807498`;
-- **88 passed in 0.99s**.
+- run `31433539654`;
+- job `93602384284`;
+- **94 passed in 1.80s**.
 
-Execution-only proof PR #55 was closed without merge after running the plan against exact pack pins:
+### Failed-first execution proof
 
-- common `d583005dce06dbb499c3c0de5c22b899655eb8d2`;
-- AI-systems `84accd2ee895663990e82ca5b79b592cb503db24`;
-- workflow run `31431113829`;
-- job `93594491275`;
-- **88 core tests passed in 0.84s**;
-- temporal benchmark: **PASS** across three phases.
+Execution-only PR #58 intentionally exposed a real failure and was closed without merge.
 
-Key real-corpus result:
+- run `31433165782`;
+- job `93601155740`;
+- core tests passed;
+- answer benchmark scored **5/6**.
 
-- before supersession, the SQLite premise and its dependent prototype were `supported`;
-- after the durable-core replacement, the SQLite premise became `superseded`, the dependent became `stale_pending_review`, and the durable-core claim was `supported`;
-- current and historical queries were both rank 1 / recall@5 1.0;
-- after later corpus growth from 13 to 27 projected documents, those same current/history queries remained rank 1 / recall@5 1.0 with no current-state leakage;
-- baseline projection rebuilds were roughly 23.68–25.28 ms on the proof runner.
+The query asking whether the first SQLite prototype was still the current canonical architecture implementation retrieved its durable `DEPENDS_ON` relation, but the stale dependent claim fell outside top-k. The answerer then selected an unrelated supported claim with confidence `1.0`.
 
-Those timings are baseline observations only and do not change D021.
+This reinforced D021: **top-k absence is not evidence of nonexistence**.
 
-## Research ingestion — complete
+The fix was `fossil-lineage-context-v1`: when a durable relation is retrieved, FOSSIL resolves stable `source_ref` / `target_ref` endpoints from the mounted validated packs before model execution. This sits around the `ModelService` boundary so future LiteLLM/Cortex/frontier/OSS models receive the same deterministic lineage correction.
 
-The production-RAG synthesis is already ingested into `Pukujan/fossil-ai-systems`.
+### Final execution proof
 
-AI-systems PR #3 squash:
+Execution-only PR #59 reran the unchanged benchmark against:
+
+- `fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
+- `fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`.
+
+Proof:
+
+- run `31433427436`;
+- job `93602011104`;
+- **94 core tests passed**;
+- corpus projection: **27 documents**;
+- benchmark: **PASS 6/6**;
+- final-answer correctness `1.0`;
+- outcome accuracy `1.0`;
+- citation correctness `1.0`;
+- completeness `1.0`;
+- appropriate abstention `1.0`;
+- unsupported-claim rate `0.0`;
+- over-abstention `0.0`;
+- Brier score `0.0`;
+- high-confidence error rate `0.0`.
+
+The previously failing SQLite case now correctly returns `current_state_unresolved` using claim `clm_a047d79b8604fadbd44efdf4` with exact citation `cite_b4e13e4e1a809f76527311ba`.
+
+PR #59 was closed unmerged because it was execution-only.
+
+## Workstream A / ingestion anchors
+
+Workstream A landed in PR #54 / squash:
+
+`e14148f504702ae9e708e2d58add4ee5c91bc8de`
+
+Its exact-pack temporal proof passed in execution-only PR #55, run `31431113829`, job `93594491275`.
+
+The production-RAG synthesis remains ingested in `fossil-ai-systems` at:
 
 `84accd2ee895663990e82ca5b79b592cb503db24`
 
-Cross-pack ingestion proof:
+Cross-pack ingestion proof passed in core execution-only PR #51, run `31415053398`, job `93541977670`.
 
-- core PR #51 — closed execution-only;
-- run `31415053398`;
-- job `93541977670`;
-- 86 core tests passed;
-- `PackFixtureAudit`: 6 artifacts, 6 snapshots, 51 events, 47 citations, 23 claims, 4 relations — PASS.
+## D021 remains frozen
 
-The ingested synthesis remains a **local derived research artifact**. Original external papers/vendor documentation must remain distinguishable and should be captured separately when full research-source ingestion is implemented.
+Do not replace or weaken D021 without new committed benchmark evidence.
 
-## Completed foundation / policy
+Current rules:
 
-Gate 1 and Gate 2 remain closed. Do not reopen them to continue #48.
-
-D021 remains approved:
-
-- normal primary: revision-pinned BGE dense retrieval;
-- semantic-runtime availability fallback: BM25, explicitly degraded;
+- revision-pinned BGE dense is the normal primary retriever;
+- BM25 is explicit degraded availability fallback;
 - current/latest/accepted queries resolve durable lifecycle/provenance;
-- lineage/history/disagreement questions use durable lineage/read resolution;
+- history/lineage/disagreement queries resolve durable lineage/read state;
 - top-k absence is not evidence of nonexistence;
-- citation-bearing answers resolve immutable source identity;
-- retrieval/reranker/model output does not receive truth authority from score, confidence, or agreement.
+- citations resolve immutable source snapshot/span/hash identity;
+- retrieval score is not truth;
+- reranker score is not truth;
+- model confidence is not truth;
+- multi-model consensus is not external evidence.
 
-## Active campaign — #48
+Stable pack IDs:
 
-Completed campaign exit criteria:
+- common: `pack_269099f7b2ba43b7a99b9427d64092de`;
+- AI systems: `pack_f024177f89a5442db84171c3dd7f58e5`.
 
-- research trace committed and ingested into AI-systems with provenance;
-- evolving-corpus benchmark committed.
+Do not casually rename `src/dkg`.
 
-Workstream A's four checklist items are complete. Issue #48 remains open.
+## LiteLLM / Cortex boundary
 
-Remaining high-level order:
+Read `docs/operations/LITELLM-GATEWAY.md` before live model work.
 
-1. **B** — end-to-end answer/citation/unsupported-claim/contradiction/abstention evaluation;
-2. **C** — poisoning/untrusted-context adversarial suite;
-3. **F** — replayable query execution receipt;
-4. **D / #47** — embedding/hybrid/reranker/model comparisons;
-5. **E** — conservative adaptive routing only if it beats simple baselines;
-6. **G** — ACL/redaction propagation readiness;
-7. final retrieval-policy/decision-log/residual-risk/handoff reconciliation.
+Recorded LiteLLM defaults at this handoff:
 
-## Frozen invariants
+- chat: `qwen3-coder-next`;
+- embeddings: `gemini-embedding-2`;
+- reranking: `rerank-v4-pro`.
 
-Preserve stable pack IDs:
+For every live benchmark record requested model, actual model, provider, fallback/attempt diagnostics, latency, cost, and runtime identity. A fallback response is not proof that the requested model succeeded. Probe embedding and reranking lanes independently. Do not send secrets, personal information, or confidential documents while gateway retention guarantees remain unverified.
 
-- `fossil-common`: `pack_269099f7b2ba43b7a99b9427d64092de`
-- `fossil-ai-systems`: `pack_f024177f89a5442db84171c3dd7f58e5`
+Cortex v4 may be used as a replaceable cognitive-service competitor, but FOSSIL durable storage, stable identity, lifecycle logic, proposal-before-commit, and correctness guarantees must not couple to Cortex internals. Multiple agents agreeing does not manufacture truth.
 
-Canonical truth remains durable evidence + stable identity + append-only validated events + versioned contracts + provenance/history. Graphiti/Neo4j, lexical/vector retrieval, rerankers, context builders, planners, models, Skills, MCP, and future databases remain replaceable services/projections. Model consensus is not external evidence. Retrieved/source text is untrusted data. Reconstructed evidence cannot silently become verbatim. Do not casually rename `src/dkg`.
+## Remaining campaign order
+
+1. **C** — poisoning / untrusted context;
+2. **F** — reproducible query execution receipt;
+3. **D / Issue #47** — embeddings, hybrid retrieval, rerankers, model bakeoff;
+4. **E** — conservative adaptive routing, only if benchmark justified;
+5. **G** — ACL/redaction propagation readiness;
+6. final D021/retrieval-policy decision reconciliation;
+7. decision log + residual risks + final handoff.
 
 ## Suggested next-session prompt
 
-> Continue FOSSIL after Issue #48 Workstream A. Read `AGENTS.md`, `ARCHITECTURE.md`, `docs/HANDOFF_CURRENT.md`, and `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-temporal-benchmark.md` first, then verify GitHub state. Workstream A is complete in core PR #54 / squash `e14148f504702ae9e708e2d58add4ee5c91bc8de`; its real-corpus temporal proof passed in execution-only PR #55, run `31431113829`, job `93594491275`. Do not redo A. Continue Issue #48 Workstream B: build provider-independent end-to-end answer/citation/unsupported-claim/contradiction/abstention evaluation first, preserving D021 lifecycle/lineage authority. Hosted/frontier models should later compete behind existing service interfaces rather than become correctness dependencies.
+> Continue FOSSIL Issue #48 from this handoff. Verify GitHub first. Workstreams A and B are complete; do not redo them. Workstream B landed in PR #57 / squash `483772ac0e1d441719aec42658ae00b62a032c11`. Its first real-corpus proof intentionally failed because top-k omitted a stale lineage endpoint; the unchanged benchmark passed after deterministic relation-endpoint resolution in execution-only PR #59, run `31433427436`, job `93602011104`, with 6/6 correctness and exact citations. Continue Workstream C: retrieval poisoning / untrusted-context hardening. Preserve D021, stable pack IDs, proposal-before-commit, and deterministic lifecycle/lineage authority. LiteLLM and Cortex v4 are optional replaceable cognitive-service competitors, never truth authority.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -2,8 +2,8 @@
 
 **Project:** **FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage**  
 **Durable substrate:** **DICS — Durable Intellectual Corpus System**  
-**Completed:** **Milestone 0 / Gate 1; Gate 2; Issue #48 research ingestion; Issue #48 Workstream A**  
-**Active work:** **Issue #48 Workstream B — end-to-end answer/citation/abstention evaluation**  
+**Completed:** **Milestone 0 / Gate 1; Gate 2; Issue #48 research ingestion; Issue #48 Workstreams A and B**  
+**Active work:** **Issue #48 Workstream C — retrieval poisoning / untrusted-context hardening**  
 **Related workstream:** **Issue #47 — embedding/reranker/model-scale bakeoff**  
 **Control plane:** GitHub issues + durable repository docs  
 **Last updated:** 2026-08-10
@@ -21,13 +21,13 @@ Repository/database/graph placement is physical placement, not knowledge identit
 1. `AGENTS.md`
 2. `ARCHITECTURE.md`
 3. `docs/HANDOFF_CURRENT.md`
-4. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-temporal-benchmark.md`
+4. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-answer-reliability.md`
 5. this file
-6. `docs/research/2026-08-10-production-rag-hardening-research-trace.md`
-7. Issue #48
-8. Issue #47
-9. `docs/DECISION_LOG.md`
-10. completed proof/policy docs under `docs/implementation/`
+6. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
+7. `docs/operations/LITELLM-GATEWAY.md`
+8. Issue #48
+9. Issue #47
+10. `docs/DECISION_LOG.md`
 
 The chat UI is source material, not the control plane.
 
@@ -37,7 +37,7 @@ Canonical FOSSIL knowledge is **immutable evidence + stable corpus IDs + append-
 
 Graphiti/Neo4j, lexical/vector indexes, embedding models, rerankers, context construction, planners, model services, Skills, MCP, and future databases remain replaceable projections/services.
 
-A graph deletion or embedding replacement must never delete irreplaceable intellectual history.
+Retrieved/source text is untrusted data. Retrieval rank, reranker score, model confidence, and multi-model agreement are not truth authority.
 
 ## Completed foundation
 
@@ -56,39 +56,29 @@ Evidence anchors:
 - Gate 2A core commit `a028f9e328c2cbcde0185930e90b5eeb4c4efcb8`;
 - Gate 2B core commit `2affde923acf196319d90bfa63f206e4a5e2f25f`;
 - Gate 2C PR #44 / squash `38aac6325cdb5b738c8a6ac5e55959affb3acfb5`;
-- Gate 2C final CI run `31366259213`, job `93385174741` — **86 passed in 1.25s**;
-- semantic proof run `31364039745`, artifact `9053475462`, digest `sha256:23c95b46f47cec5a16e0a8c0926a4f13532f283d8f4fbcc0de12ceb63db63c41`;
+- Gate 2C semantic proof run `31364039745`, artifact `9053475462`, digest `sha256:23c95b46f47cec5a16e0a8c0926a4f13532f283d8f4fbcc0de12ceb63db63c41`;
 - Gate 2D PR #45 / squash `2d22dee9e6b176956d30005f4d7877baf68b0a3c`;
-- Gate 2D CI run `31366800697`, job `93386832166` — **86 passed in 1.02s**;
 - closed-state reconciliation PR #46 / squash `a614936249ff0ab201756fa54a1e89699d7b924f`.
 
-The 21-case history-rich corpus compared BM25, a hash embedding control, revision-pinned BGE dense, and BM25+BGE hybrid/lifecycle reranking. BGE dense was the only compared strategy with zero full retrieval misses and had mean recall@5 `0.98413`. It still showed current-state ranking leakage and incomplete multi-target lineage recall.
-
-Decision D021 therefore selects revision-pinned `BAAI/bge-small-en-v1.5@5c38ec7c405ec4b44b94cc5a9bb96e735b38267a` as the normal primary retriever and BM25 as an explicit degraded availability fallback.
+Decision D021 remains active: revision-pinned `BAAI/bge-small-en-v1.5@5c38ec7c405ec4b44b94cc5a9bb96e735b38267a` is the normal primary retriever and BM25 is explicit degraded availability fallback.
 
 Mandatory D021 safeguards remain:
 
 - current/latest/accepted questions resolve lifecycle/provenance;
 - lineage/history/disagreement questions use durable lineage/read resolution;
 - top-k absence is not evidence of nonexistence;
-- citation-bearing answers resolve immutable source snapshot/span/hash identity;
+- citation-bearing answers resolve immutable source snapshots/spans/hashes;
 - retrieval/model output does not receive truth authority from score, confidence, or agreement.
-
-Policy proof: `docs/implementation/2026-08-10-gate2-default-retrieval-policy.md`.
 
 ## Active campaign #48 — production RAG hardening
 
-Research basis:
-
-`docs/research/2026-08-10-production-rag-hardening-research-trace.md`
-
-The campaign conclusion remains **harden, do not redesign the durable core**.
+The campaign remains **hardening, not a durable-core redesign and not a GraphRAG rewrite**.
 
 ### Workstream state
 
 1. **A — evolving-corpus temporal/update benchmark: COMPLETE**
-2. **B — end-to-end answer/citation/unsupported-claim/abstention evaluation: ACTIVE NEXT**
-3. **C — poisoning/untrusted-context adversarial suite: pending**
+2. **B — end-to-end answer/citation/unsupported-claim/abstention evaluation: COMPLETE**
+3. **C — poisoning/untrusted-context adversarial suite: ACTIVE NEXT**
 4. **F — replayable query execution receipt: pending**
 5. **D / #47 — embedding/hybrid/reranker/model bakeoff: pending provider-backed comparison**
 6. **E — conservative adaptive routing: pending evidence**
@@ -101,65 +91,71 @@ Core PR #54 / squash:
 
 `e14148f504702ae9e708e2d58add4ee5c91bc8de`
 
-Final CI:
+Execution-only proof PR #55 ran the exact pack pins and passed, workflow `31431113829`, job `93594491275`.
 
-- run `31431210018`;
-- job `93594807498`;
-- **88 passed in 0.99s**.
+The temporal benchmark proved lifecycle transitions, current/history reconstruction, and repeated-query stability after corpus growth while preserving D021 authority.
 
-The implementation adds:
+### Workstream B — landed evidence
 
-- historical/as-of durable-event replay for pack search projections;
-- reusable phased temporal benchmark machinery;
-- a versioned real-corpus benchmark plan;
-- exact Git pin verification in the runner;
-- deterministic lifecycle/current/history tests;
-- durable proof at `docs/implementation/2026-08-10-post-gate2-temporal-benchmark-proof.md`.
+Core PR #57 / squash:
 
-Execution-only proof PR #55 ran the exact plan against:
+`483772ac0e1d441719aec42658ae00b62a032c11`
+
+Final normal CI:
+
+- run `31433539654`;
+- job `93602384284`;
+- **94 passed in 1.80s**.
+
+The implementation added:
+
+- `src/dkg/answer_eval.py` — answer-level evaluator and deterministic durable-evidence baseline;
+- `src/dkg/answer_pipeline.py` — deterministic durable relation-endpoint context resolution before model execution;
+- `benchmarks/post-gate2/answer-reliability-v1.json` — six-case exact-pin benchmark plan;
+- exact-pin runner, tests, and durable proof.
+
+The first execution-only proof PR #58 correctly failed 5/6 because top-k omitted a stale dependent claim while retrieving its durable `DEPENDS_ON` relation. This showed that retrieval-only context could select an unrelated supported claim with confidence `1.0`.
+
+FOSSIL then added `fossil-lineage-context-v1`, resolving stable relation endpoints from mounted validated packs before model execution. The benchmark expectation was not weakened.
+
+Execution-only PR #59 reran the unchanged benchmark against:
 
 - `fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
 - `fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`.
 
-Proof run `31431113829`, job `93594491275`:
+Final proof run `31433427436`, job `93602011104`:
 
-- **88 tests passed in 0.84s**;
-- temporal benchmark **PASS** across three phases;
-- former SQLite premise changed `supported -> superseded`;
-- its dependent prototype changed `supported -> stale_pending_review`;
-- accepted durable-core claim remained `supported`;
-- current and historical queries were rank 1 / recall@5 1.0;
-- after projected corpus growth from 13 to 27 documents, both repeated queries remained rank 1 / recall@5 1.0 with no current-state leakage;
-- projection rebuilds were roughly 23.68–25.28 ms on that runner.
+- **94 core tests passed**;
+- **27 projected documents**;
+- benchmark **PASS 6/6**;
+- final-answer correctness `1.0`;
+- outcome accuracy `1.0`;
+- exact citation correctness `1.0`;
+- completeness `1.0`;
+- appropriate abstention `1.0`;
+- unsupported-claim rate `0.0`;
+- over-abstention `0.0`;
+- Brier score `0.0`;
+- high-confidence error rate `0.0`.
 
-The timing observations are baseline measurements, not evidence to replace D021.
+The formerly failing SQLite case now resolves `current_state_unresolved` via durable claim `clm_a047d79b8604fadbd44efdf4` with exact citation `cite_b4e13e4e1a809f76527311ba`.
 
-Issue #48 now has all four Workstream A checklist items checked and the `Evolving-corpus benchmark committed` exit criterion checked.
+### Workstream C — exact active target
 
-### Workstream B — exact next target
+Build a retrieval-poisoning / untrusted-context adversarial suite. Cover at minimum:
 
-Extend evaluation above retrieval to answer-level reliability. The first committed baseline should be provider-independent and should measure:
+- poisoned retrieved documents containing instructions;
+- authority spoofing;
+- malicious supersession attempts;
+- duplicated adversarial passages intended to dominate ranking;
+- conflicting-source attacks;
+- pack-isolation pressure;
+- attempts to bypass proposal-before-commit / deterministic gates;
+- residual-risk documentation.
 
-- final-answer correctness;
-- citation/source-snapshot/span correctness;
-- unsupported-claim rate;
-- answer completeness;
-- contradiction handling;
-- explicit insufficient/conflicting/unresolved outcomes;
-- appropriate abstention/calibration.
+Reuse Workstream B answer metrics where possible. The suite must test downstream behavior, not merely retrieval presence: final-answer correctness, citations, unsupported claims, lifecycle/lineage resolution, abstention, authority boundaries, pack isolation, and proposal-before-commit behavior.
 
-Use deterministic/direct-source/read paths and existing `ModelService` / `VerificationService` contracts first. Hosted/frontier models may later be evaluated behind those interfaces; they should not become correctness dependencies.
-
-### Hardening principles under test
-
-- retrieved/source text is untrusted data, not executable policy;
-- uncertainty/abstention is explicit answer behavior when evidence is insufficient/conflicting/unresolved;
-- simple direct-source/read and fixed retrieval baselines remain mandatory competitors;
-- a reranker can improve candidate ordering but cannot decide lifecycle truth;
-- adaptive planners must expose route/execution metadata and earn their cost/complexity;
-- important benchmark queries should be replayable after provider/model/projection changes.
-
-These are campaign hypotheses/requirements, not silent changes to `ARCHITECTURE.md`.
+Do not claim universal poisoning resistance. Retrieved/source text is untrusted data and never executable policy merely because it was retrieved.
 
 ## Research-to-corpus state
 
@@ -168,15 +164,11 @@ The 2026-08-10 production-RAG research synthesis is ingested into `fossil-ai-sys
 Exact landed pack state:
 
 - `fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
-- `fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24` via PR #3;
+- `fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`;
 - research artifact `art_b030642ff65f883ff467529c73cbb6e5`;
-- SHA-256 `b030642ff65f883ff467529c73cbb6e502deca28f4c3dece0c2879bf690d3b15`;
-- source snapshot `snap_9c0e088ab2d7d8e1b21db563`;
-- source core commit `6799b2db743d91b004b1e16b5129285a582f8847`.
+- source snapshot `snap_9c0e088ab2d7d8e1b21db563`.
 
-Cross-pack validation proof ran in execution-only core PR #51, workflow `31415053398`, job `93541977670`: **86 core tests passed** and `PackFixtureAudit` reported **6 artifacts, 6 snapshots, 51 events, 47 citations, 23 claims, 4 relations — PASS**.
-
-Original external papers and production documentation must still be captured as distinct source snapshots when full research-source ingestion is implemented. The synthesis or chat transcript must not be presented as verbatim external evidence.
+Original external papers and production documentation remain distinct source evidence; the local synthesis must not be presented as verbatim external evidence.
 
 ## Cognitive-service posture
 
@@ -191,7 +183,9 @@ Existing replaceable service contracts include:
 - `ModelService`;
 - `VerificationService`.
 
-This allows later #48/#47 work to test new embeddings, rerankers, routing/context strategies, and model services without coupling canonical knowledge to them.
+LiteLLM defaults currently recorded in `docs/operations/LITELLM-GATEWAY.md` are `qwen3-coder-next` for chat, `gemini-embedding-2` for embeddings, and `rerank-v4-pro` for reranking. Live benchmark evidence must record requested/actual model, provider, fallback attempts, latency, cost, and runtime identity. Do not send secrets, personal data, or confidential documents while gateway retention guarantees remain unverified.
+
+Cortex v4 and multi-agent orchestration are optional replaceable cognitive-service competitors. Durable storage, stable identity, lifecycle/lineage logic, proposal-before-commit, and correctness guarantees must not couple to Cortex internals. Multiple workers agreeing does not create evidence.
 
 ## Frozen invariants
 
@@ -209,7 +203,9 @@ This allows later #48/#47 work to test new embeddings, rerankers, routing/contex
 - Skills contain methodology, not canonical truth;
 - protocol adapters cannot become the durable knowledge model;
 - cognitive services expose provider/version metadata and compete behind interfaces;
-- model agreement is not evidence; model output remains bounded by evidence/risk policy.
+- model agreement is not evidence; model output remains bounded by evidence/risk policy;
+- agents propose; deterministic validation/policy gates commit durable changes;
+- do not casually rename `src/dkg`.
 
 ## Workflow state
 
@@ -217,4 +213,4 @@ This allows later #48/#47 work to test new embeddings, rerankers, routing/contex
 
 `.github/workflows/graphiti-live.yml` contains reusable live materialization plus redaction/non-resurrection smoke coverage.
 
-Execution-only PRs #51 and #55 were closed without merge after their proofs. Issue #48 remains active; do not extend closed Gate 2 issues to implement it.
+Execution-only PRs #51, #55, #58, and #59 were closed without merge after their proofs. Issue #48 remains active; do not extend closed Gate 2 issues to implement it.

--- a/docs/handoffs/2026-08-10-chatgpt-session-handoff-post-answer-reliability.md
+++ b/docs/handoffs/2026-08-10-chatgpt-session-handoff-post-answer-reliability.md
@@ -1,0 +1,180 @@
+# ChatGPT Session Handoff — Post-Answer-Reliability
+
+**Date:** 2026-08-10  
+**Project:** FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage  
+**Campaign:** Issue #48 — production RAG hardening  
+**State:** Gate 1 closed; Gate 2 closed; research ingestion complete; Workstream A complete; **Workstream B complete**; Workstream C next.
+
+## Read first
+
+1. `AGENTS.md`
+2. `ARCHITECTURE.md`
+3. `docs/HANDOFF_CURRENT.md`
+4. this file
+5. `docs/PROJECT_STATE.md`
+6. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
+7. `docs/operations/LITELLM-GATEWAY.md`
+8. Issue #48
+9. Issue #47
+10. `docs/DECISION_LOG.md`
+
+## Exact continuation
+
+Do **not** redo research ingestion, Workstream A, or Workstream B.
+
+The exact next Issue #48 workstream is:
+
+**C. Retrieval poisoning / untrusted-context hardening.**
+
+Build an adversarial suite that proves retrieved/source text remains data rather than executable policy. Cover at least:
+
+- poisoned-document instructions;
+- authority spoofing;
+- malicious supersession attempts;
+- duplicated adversarial passages intended to dominate ranking;
+- conflicting-source cases;
+- pack-isolation pressure;
+- proposal-before-commit / deterministic-gate preservation;
+- explicit residual-risk documentation rather than a claim of universal poisoning defense.
+
+Reuse Workstream B's answer reliability metrics where useful. A poisoning test should not only ask whether a malicious passage was retrieved; it should check whether the final answer, citations, lifecycle resolution, abstention, and authority boundary remained correct.
+
+## Workstream B — landed
+
+Core PR #57 squash:
+
+`483772ac0e1d441719aec42658ae00b62a032c11`
+
+Landed components:
+
+- `src/dkg/answer_eval.py` — structured answer-level evaluator + deterministic durable-evidence baseline;
+- `src/dkg/answer_pipeline.py` — deterministic durable relation-endpoint context resolution before model execution;
+- `benchmarks/post-gate2/answer-reliability-v1.json` — six-case exact-pin real-corpus plan;
+- `scripts/run_post_gate2_answer_reliability.py` — exact-pin runner;
+- `tests/test_answer_eval.py` and `tests/test_answer_pipeline.py` — evaluator, abstention, contradiction, unsupported-claim, citation, and lineage regression tests;
+- `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md` — durable proof including the failed first execution.
+
+Final PR #57 CI:
+
+- run `31433539654`;
+- job `93602384284`;
+- **94 passed in 1.80s**.
+
+## Workstream B — important failed-first proof
+
+Execution-only PR #58 was deliberately closed without merge after exposing a real failure.
+
+- run `31433165782`;
+- job `93601155740`;
+- core suite: **92 passed in 8.68s**;
+- six-case answer benchmark: **FAIL**, 5/6 correct.
+
+The failed query asked whether the first SQLite prototype was the current canonical architecture implementation. Retrieval returned its durable `DEPENDS_ON` relation but the stale dependent claim itself fell outside top-k. A retrieval-only answer context therefore chose an unrelated supported claim with confidence 1.0.
+
+This directly reinforced D021: **top-k absence is not evidence of nonexistence**. The fix was not to weaken the expected answer. FOSSIL added `fossil-lineage-context-v1`, resolving stable source/target refs from retrieved durable relations before model execution.
+
+Regression CI after the fix:
+
+- run `31433377445`;
+- job `93601846449`;
+- **94 passed in 1.24s**.
+
+## Workstream B — final real-corpus proof
+
+Execution-only PR #59 reran the unchanged six-case plan against exact pack pins and was closed without merge after PASS.
+
+Exact inputs:
+
+- `fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
+- `fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`.
+
+Proof:
+
+- run `31433427436`;
+- job `93602011104`;
+- **94 core tests passed in 1.04s**;
+- corpus projection: **27 documents**;
+- benchmark: **PASS, 6/6 cases**;
+- final-answer correctness: `1.0`;
+- outcome accuracy: `1.0`;
+- exact citation correctness: `1.0`;
+- completeness: `1.0`;
+- appropriate abstention: `1.0`;
+- mean unsupported-claim rate: `0.0`;
+- over-abstention: `0.0`;
+- Brier score: `0.0`;
+- high-confidence error rate: `0.0`;
+- baseline estimated model cost: `$0.0`;
+- mean deterministic answer-service latency: about `0.863 ms` on that runner.
+
+The formerly failing SQLite dependent case resolved to `current_state_unresolved`, using durable claim `clm_a047d79b8604fadbd44efdf4` and exact citation `cite_b4e13e4e1a809f76527311ba`.
+
+## LiteLLM / model integration boundary
+
+A shared LiteLLM gateway configuration is already present in core. Read `docs/operations/LITELLM-GATEWAY.md` before live model work.
+
+Current recorded defaults at this handoff:
+
+- chat: `qwen3-coder-next`;
+- embeddings: `gemini-embedding-2`;
+- reranking: `rerank-v4-pro`;
+- gateway key is a GitHub Actions secret, not repository data.
+
+Important operational rules:
+
+- gateway/chat fallbacks are possible, so benchmark evidence must record **requested model and actual model** plus attempt/fallback diagnostics;
+- a fallback response is not evidence that the requested model succeeded;
+- embedding and reranking lanes should be probed independently;
+- the gateway privacy warning means secrets, personal data, or confidential documents should not be sent until the data-retention boundary is verified.
+
+LiteLLM, Cortex, frontier models, and future OSS models belong behind FOSSIL's replaceable cognitive-service interfaces. They can compete on the Workstream B contract; they do not become durable truth or a prerequisite for correctness.
+
+## Cortex / multi-agent posture
+
+Cortex v4 is evolving. Do not couple FOSSIL's durable substrate or benchmark correctness to its current internal orchestration shape.
+
+If Cortex workers are used later, treat each worker/model invocation as a replaceable cognitive service and preserve:
+
+- requested/actual provider and model identity;
+- route/fallback identity;
+- FOSSIL stable retrieved IDs and citations;
+- deterministic lifecycle/lineage resolution before truth-changing conclusions;
+- proposal-before-commit gates;
+- replayable receipts in future Workstream F.
+
+A multi-agent consensus is not evidence merely because multiple models agree.
+
+## Workstream A / ingestion anchors
+
+Workstream A landed in PR #54 / squash:
+
+`e14148f504702ae9e708e2d58add4ee5c91bc8de`
+
+Its exact-pack temporal proof passed in execution-only PR #55, run `31431113829`, job `93594491275`.
+
+Research ingestion remains landed in AI-systems at:
+
+`84accd2ee895663990e82ca5b79b592cb503db24`
+
+Cross-pack ingestion audit passed in core execution-only PR #51, run `31415053398`, job `93541977670`.
+
+## D021 / frozen authority
+
+D021 remains approved and unchanged.
+
+- revision-pinned BGE dense remains the normal primary retriever;
+- BM25 remains explicit degraded availability fallback;
+- current/latest/accepted questions resolve lifecycle/provenance;
+- lineage/history/disagreement questions resolve durable lineage/read state;
+- top-k absence is not evidence of nonexistence;
+- exact citation-bearing answers resolve immutable source snapshot/span/hash identity;
+- retrieval scores, reranker scores, model confidence, multi-model agreement, and planner output are not truth authority.
+
+Stable pack IDs remain:
+
+- common: `pack_269099f7b2ba43b7a99b9427d64092de`;
+- AI-systems: `pack_f024177f89a5442db84171c3dd7f58e5`.
+
+## Suggested continuation prompt
+
+> Continue FOSSIL Issue #48 after Workstream B. Read `AGENTS.md`, `ARCHITECTURE.md`, `docs/HANDOFF_CURRENT.md`, and `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-answer-reliability.md`, then verify GitHub state. Workstream B landed in core PR #57 / squash `483772ac0e1d441719aec42658ae00b62a032c11`. The first execution-only proof #58 correctly failed because top-k omitted a stale dependent claim; the unchanged benchmark passed after deterministic durable relation-endpoint resolution in proof #59, run `31433427436`, job `93602011104`, with 6/6 final-answer correctness and exact citation correctness. Do not redo A or B. Continue Workstream C: retrieval poisoning / untrusted-context hardening. Preserve D021 and stable pack identities. LiteLLM/Cortex models may be evaluated as replaceable competitors behind the existing service boundary, never as truth authority.


### PR DESCRIPTION
Finishes the paused post-Workstream-B handoff reconciliation.

## What changed

- adds the dated post-answer-reliability handoff;
- updates `docs/HANDOFF_CURRENT.md` so Workstreams A/B are complete and C is next;
- updates `docs/PROJECT_STATE.md` with the landed PR #57 / failed-first #58 / passing #59 evidence and the Workstream C target.

## Scope

Docs/state only. No code, policy, pack identity, or D021 changes.

Refs #48.