### PR TITLE
Reconcile handoff after retrieval poisoning

### DIFF
--- a/docs/HANDOFF_CURRENT.md
+++ b/docs/HANDOFF_CURRENT.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-10  
 **Project:** **FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage**  
 **Repository:** `Pukujan/fossil-core`  
-**Status:** **Gate 1 complete. Gate 2 complete and formally closed. Post-Gate-2 campaign #48 active. Research ingestion, Workstream A, and Workstream B are complete. Workstream C is next.**
+**Status:** **Gate 1 complete. Gate 2 complete and formally closed. Post-Gate-2 campaign #48 active. Research ingestion and Workstreams A, B, and C are complete. Workstream F is next.**
 
 ## Fresh-session transfer
 
@@ -12,88 +12,84 @@ Read, in order:
 1. `AGENTS.md`
 2. `ARCHITECTURE.md`
 3. this file
-4. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-answer-reliability.md`
+4. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-retrieval-poisoning.md`
 5. `docs/PROJECT_STATE.md`
-6. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
-7. `docs/operations/LITELLM-GATEWAY.md`
-8. Issue #48 — active production RAG hardening campaign
-9. Issue #47 — embedding/reranker/model-scale bakeoff workstream
-10. `docs/DECISION_LOG.md`
+6. `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`
+7. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
+8. `docs/operations/LITELLM-GATEWAY.md`
+9. Issue #48 — active production RAG hardening campaign
+10. Issue #47 — embedding/reranker/model-scale bakeoff workstream
+11. `docs/DECISION_LOG.md`
+
+Verify GitHub state before changing anything.
 
 ## Exact active continuation point
 
-**Do not redo the research ingestion, Workstream A, or Workstream B.**
+**Do not redo research ingestion or Workstreams A, B, or C.**
 
 The next unfinished Issue #48 workstream is:
 
-**C. Retrieval poisoning / untrusted-context hardening.**
+**F. Reproducible query execution receipt.**
 
-Build an adversarial suite proving that retrieved/source text remains untrusted data rather than executable policy. Cover at minimum:
+Define a compact versioned receipt containing at minimum:
 
-1. poisoned retrieved documents containing instructions;
-2. authority spoofing;
-3. malicious supersession attempts;
-4. duplicated adversarial passages intended to dominate ranking;
-5. conflicting-source attacks;
-6. pack-isolation pressure;
-7. attempts to bypass proposal-before-commit / deterministic gates;
-8. explicit residual-risk documentation.
+1. query ID and deterministic query hash;
+2. mounted stable pack IDs and exact pack revisions;
+3. route/retrieval-policy identity;
+4. requested and actual service/model/provider/version/runtime identity;
+5. retrieved candidate stable IDs and scores;
+6. reranker identity and reranked order when present;
+7. deterministic lifecycle/lineage/context-security resolution and resolved IDs;
+8. final model-bound context stable IDs and exact citation IDs;
+9. final outcome / abstention;
+10. latency, cost, and trace/run reference.
 
-Reuse Workstream B metrics wherever useful. Do not only test whether poisoned text is retrieved; test whether poisoning changes final-answer correctness, citation correctness, unsupported claims, lifecycle/lineage resolution, abstention behavior, authority boundaries, pack isolation, or proposal-before-commit behavior.
+Keep verbose telemetry outside canonical durable knowledge. The receipt is execution observability/evidence, not a new truth source and not a durable knowledge event merely because it exists.
 
-Do not claim a universal poisoning defense.
+The replay proof should show that important benchmark queries can be rerun after retriever/model/projection changes and the receipt makes the changed execution identity visible.
 
-## Workstream B proof — complete
+## Workstream C proof — complete
 
-Implementation landed in core PR #57 / squash:
+Implementation landed in core PR #61 / squash:
 
-`483772ac0e1d441719aec42658ae00b62a032c11`
+`f5634412222e8d86173eb6e8e364f3414a6f3cd6`
 
 Landed artifacts:
 
-- `src/dkg/answer_eval.py`;
-- `src/dkg/answer_pipeline.py`;
-- `benchmarks/post-gate2/answer-reliability-v1.json`;
-- `scripts/run_post_gate2_answer_reliability.py`;
-- `tests/test_answer_eval.py`;
-- `tests/test_answer_pipeline.py`;
-- `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`.
+- `src/dkg/context_security.py`;
+- `src/dkg/poisoning_eval.py`;
+- `benchmarks/post-gate2/retrieval-poisoning-v1.json`;
+- `scripts/run_post_gate2_retrieval_poisoning.py`;
+- `tests/test_context_security.py`;
+- `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`.
+
+The provider-independent structural boundary is `fossil-untrusted-context-v1`:
+
+- known stable IDs are re-resolved from mounted durable documents;
+- retrieved payload metadata cannot self-author lifecycle/relation/citation/pack truth;
+- unknown in-scope payloads are demoted to non-authoritative `untrusted_context`;
+- out-of-scope pack payloads are removed;
+- exact duplicate unknown passages are collapsed;
+- answer/model output is candidate-only with no executable tool/action surface;
+- emitted claim text/citation identity is re-resolved from mounted durable claims;
+- invalid claim IDs are contained as `insufficient_evidence`;
+- proposal-before-commit and deterministic domain gates remain authoritative.
 
 Final normal CI:
 
-- run `31433539654`;
-- job `93602384284`;
-- **94 passed in 1.80s**.
+- run `31436499505`;
+- job `93611686820`;
+- **100 passed in 1.07s**.
 
-### Failed-first execution proof
-
-Execution-only PR #58 intentionally exposed a real failure and was closed without merge.
-
-- run `31433165782`;
-- job `93601155740`;
-- core tests passed;
-- answer benchmark scored **5/6**.
-
-The query asking whether the first SQLite prototype was still the current canonical architecture implementation retrieved its durable `DEPENDS_ON` relation, but the stale dependent claim fell outside top-k. The answerer then selected an unrelated supported claim with confidence `1.0`.
-
-This reinforced D021: **top-k absence is not evidence of nonexistence**.
-
-The fix was `fossil-lineage-context-v1`: when a durable relation is retrieved, FOSSIL resolves stable `source_ref` / `target_ref` endpoints from the mounted validated packs before model execution. This sits around the `ModelService` boundary so future LiteLLM/Cortex/frontier/OSS models receive the same deterministic lineage correction.
-
-### Final execution proof
-
-Execution-only PR #59 reran the unchanged benchmark against:
-
-- `fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
-- `fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`.
+Execution-only PR #62 ran the unchanged eight-case adversarial plan against exact pack pins and was closed unmerged.
 
 Proof:
 
-- run `31433427436`;
-- job `93602011104`;
-- **94 core tests passed**;
-- corpus projection: **27 documents**;
-- benchmark: **PASS 6/6**;
+- run `31436425791`;
+- job `93611459472`;
+- **100 core tests passed in 0.96s**;
+- **27 projected documents**;
+- benchmark **PASS 8/8**;
 - final-answer correctness `1.0`;
 - outcome accuracy `1.0`;
 - citation correctness `1.0`;
@@ -102,25 +98,26 @@ Proof:
 - unsupported-claim rate `0.0`;
 - over-abstention `0.0`;
 - Brier score `0.0`;
-- high-confidence error rate `0.0`.
+- high-confidence error rate `0.0`;
+- pack-isolation preservation `1.0`;
+- candidate-only authority `1.0`;
+- executable-output containment `1.0`;
+- durable-claim output boundary `1.0`;
+- aggregate security-boundary pass rate `1.0`.
 
-The previously failing SQLite case now correctly returns `current_state_unresolved` using claim `clm_a047d79b8604fadbd44efdf4` with exact citation `cite_b4e13e4e1a809f76527311ba`.
+The poisoned SQLite lifecycle case still returned `current_state_unresolved` using `clm_a047d79b8604fadbd44efdf4` with exact citation `cite_b4e13e4e1a809f76527311ba`.
 
-PR #59 was closed unmerged because it was execution-only.
+Do not claim a universal poisoning defense. See the C proof for residual risks.
 
-## Workstream A / ingestion anchors
+## Workstream B anchor
 
-Workstream A landed in PR #54 / squash:
+Workstream B landed in PR #57 / squash:
 
-`e14148f504702ae9e708e2d58add4ee5c91bc8de`
+`483772ac0e1d441719aec42658ae00b62a032c11`
 
-Its exact-pack temporal proof passed in execution-only PR #55, run `31431113829`, job `93594491275`.
+Its failed-first real-corpus proof established that top-k can omit a stale claim even when a durable relation points to it. `fossil-lineage-context-v1` resolves stable relation endpoints before model execution. Final unchanged B benchmark proof: PR #59, run `31433427436`, job `93602011104`, PASS 6/6 with exact citations.
 
-The production-RAG synthesis remains ingested in `fossil-ai-systems` at:
-
-`84accd2ee895663990e82ca5b79b592cb503db24`
-
-Cross-pack ingestion proof passed in core execution-only PR #51, run `31415053398`, job `93541977670`.
+D021 therefore continues to include: **top-k absence is not evidence of nonexistence**.
 
 ## D021 remains frozen
 
@@ -134,6 +131,7 @@ Current rules:
 - history/lineage/disagreement queries resolve durable lineage/read state;
 - top-k absence is not evidence of nonexistence;
 - citations resolve immutable source snapshot/span/hash identity;
+- retrieved/source text is untrusted data, never executable policy;
 - retrieval score is not truth;
 - reranker score is not truth;
 - model confidence is not truth;
@@ -143,6 +141,11 @@ Stable pack IDs:
 
 - common: `pack_269099f7b2ba43b7a99b9427d64092de`;
 - AI systems: `pack_f024177f89a5442db84171c3dd7f58e5`.
+
+Exact pack revisions used by the B/C proofs:
+
+- `fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
+- `fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`.
 
 Do not casually rename `src/dkg`.
 
@@ -156,20 +159,19 @@ Recorded LiteLLM defaults at this handoff:
 - embeddings: `gemini-embedding-2`;
 - reranking: `rerank-v4-pro`.
 
-For every live benchmark record requested model, actual model, provider, fallback/attempt diagnostics, latency, cost, and runtime identity. A fallback response is not proof that the requested model succeeded. Probe embedding and reranking lanes independently. Do not send secrets, personal information, or confidential documents while gateway retention guarantees remain unverified.
+For every live benchmark and future Workstream-F receipt, record requested model, actual model, provider, fallback/attempt diagnostics, latency, cost, and runtime identity. A fallback response is not proof that the requested model succeeded. Probe embedding and reranking lanes independently. Do not send secrets, personal information, or confidential documents while gateway retention guarantees remain unverified.
 
-Cortex v4 may be used as a replaceable cognitive-service competitor, but FOSSIL durable storage, stable identity, lifecycle logic, proposal-before-commit, and correctness guarantees must not couple to Cortex internals. Multiple agents agreeing does not manufacture truth.
+Cortex v4 may be used as a replaceable cognitive-service/orchestration competitor, but FOSSIL durable storage, stable identity, lifecycle/lineage, context-security, proposal-before-commit, and correctness guarantees must not couple to Cortex internals. Multiple agents agreeing does not manufacture truth. Future worker/model invocations should fit the Workstream-F receipt without changing that authority model.
 
 ## Remaining campaign order
 
-1. **C** — poisoning / untrusted context;
-2. **F** — reproducible query execution receipt;
-3. **D / Issue #47** — embeddings, hybrid retrieval, rerankers, model bakeoff;
-4. **E** — conservative adaptive routing, only if benchmark justified;
-5. **G** — ACL/redaction propagation readiness;
-6. final D021/retrieval-policy decision reconciliation;
-7. decision log + residual risks + final handoff.
+1. **F** — reproducible query execution receipt;
+2. **D / Issue #47** — embeddings, hybrid retrieval, rerankers, model bakeoff;
+3. **E** — conservative adaptive routing, only if benchmark justified;
+4. **G** — ACL/redaction propagation readiness;
+5. final D021/retrieval-policy decision reconciliation;
+6. decision log + residual risks + final handoff.
 
 ## Suggested next-session prompt
 
-> Continue FOSSIL Issue #48 from this handoff. Verify GitHub first. Workstreams A and B are complete; do not redo them. Workstream B landed in PR #57 / squash `483772ac0e1d441719aec42658ae00b62a032c11`. Its first real-corpus proof intentionally failed because top-k omitted a stale lineage endpoint; the unchanged benchmark passed after deterministic relation-endpoint resolution in execution-only PR #59, run `31433427436`, job `93602011104`, with 6/6 correctness and exact citations. Continue Workstream C: retrieval poisoning / untrusted-context hardening. Preserve D021, stable pack IDs, proposal-before-commit, and deterministic lifecycle/lineage authority. LiteLLM and Cortex v4 are optional replaceable cognitive-service competitors, never truth authority.
+> Continue FOSSIL Issue #48 from this handoff. Verify GitHub first. Workstreams A, B, and C are complete; do not redo them. C landed in PR #61 / squash `f5634412222e8d86173eb6e8e364f3414a6f3cd6`; exact-pin execution proof PR #62 was closed unmerged after run `31436425791`, job `93611459472`, with 100 core tests, 27 documents, adversarial PASS 8/8, exact answer/citation/security-boundary metrics at 1.0, and unsupported-claim rate 0.0. Begin Workstream F: a compact reproducible query execution receipt and replay proof. Preserve D021, stable pack IDs, `fossil-lineage-context-v1`, `fossil-untrusted-context-v1`, proposal-before-commit, and deterministic lifecycle/lineage authority. The receipt is observability/evidence, not truth authority.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -2,8 +2,8 @@
 
 **Project:** **FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage**  
 **Durable substrate:** **DICS — Durable Intellectual Corpus System**  
-**Completed:** **Milestone 0 / Gate 1; Gate 2; Issue #48 research ingestion; Issue #48 Workstreams A and B**  
-**Active work:** **Issue #48 Workstream C — retrieval poisoning / untrusted-context hardening**  
+**Completed:** **Milestone 0 / Gate 1; Gate 2; Issue #48 research ingestion; Issue #48 Workstreams A, B, and C**  
+**Active work:** **Issue #48 Workstream F — reproducible query execution receipt**  
 **Related workstream:** **Issue #47 — embedding/reranker/model-scale bakeoff**  
 **Control plane:** GitHub issues + durable repository docs  
 **Last updated:** 2026-08-10
@@ -21,13 +21,14 @@ Repository/database/graph placement is physical placement, not knowledge identit
 1. `AGENTS.md`
 2. `ARCHITECTURE.md`
 3. `docs/HANDOFF_CURRENT.md`
-4. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-answer-reliability.md`
+4. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-retrieval-poisoning.md`
 5. this file
-6. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
-7. `docs/operations/LITELLM-GATEWAY.md`
-8. Issue #48
-9. Issue #47
-10. `docs/DECISION_LOG.md`
+6. `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`
+7. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
+8. `docs/operations/LITELLM-GATEWAY.md`
+9. Issue #48
+10. Issue #47
+11. `docs/DECISION_LOG.md`
 
 The chat UI is source material, not the control plane.
 
@@ -68,6 +69,7 @@ Mandatory D021 safeguards remain:
 - lineage/history/disagreement questions use durable lineage/read resolution;
 - top-k absence is not evidence of nonexistence;
 - citation-bearing answers resolve immutable source snapshots/spans/hashes;
+- retrieved/source text is untrusted data, never executable policy;
 - retrieval/model output does not receive truth authority from score, confidence, or agreement.
 
 ## Active campaign #48 — production RAG hardening
@@ -78,8 +80,8 @@ The campaign remains **hardening, not a durable-core redesign and not a GraphRAG
 
 1. **A — evolving-corpus temporal/update benchmark: COMPLETE**
 2. **B — end-to-end answer/citation/unsupported-claim/abstention evaluation: COMPLETE**
-3. **C — poisoning/untrusted-context adversarial suite: ACTIVE NEXT**
-4. **F — replayable query execution receipt: pending**
+3. **C — poisoning/untrusted-context adversarial suite: COMPLETE**
+4. **F — replayable query execution receipt: ACTIVE NEXT**
 5. **D / #47 — embedding/hybrid/reranker/model bakeoff: pending provider-backed comparison**
 6. **E — conservative adaptive routing: pending evidence**
 7. **G — ACL/redaction propagation readiness: pending**
@@ -107,27 +109,54 @@ Final normal CI:
 - job `93602384284`;
 - **94 passed in 1.80s**.
 
-The implementation added:
+The implementation added Workstream-B answer evaluation plus `fossil-lineage-context-v1`, which resolves durable relation endpoints from mounted validated packs before model execution.
 
-- `src/dkg/answer_eval.py` — answer-level evaluator and deterministic durable-evidence baseline;
-- `src/dkg/answer_pipeline.py` — deterministic durable relation-endpoint context resolution before model execution;
-- `benchmarks/post-gate2/answer-reliability-v1.json` — six-case exact-pin benchmark plan;
-- exact-pin runner, tests, and durable proof.
-
-The first execution-only proof PR #58 correctly failed 5/6 because top-k omitted a stale dependent claim while retrieving its durable `DEPENDS_ON` relation. This showed that retrieval-only context could select an unrelated supported claim with confidence `1.0`.
-
-FOSSIL then added `fossil-lineage-context-v1`, resolving stable relation endpoints from mounted validated packs before model execution. The benchmark expectation was not weakened.
-
-Execution-only PR #59 reran the unchanged benchmark against:
-
-- `fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
-- `fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`.
-
-Final proof run `31433427436`, job `93602011104`:
+The failed-first execution-only PR #58 correctly exposed that top-k can omit a stale dependent claim even when its durable `DEPENDS_ON` relation is present. The unchanged benchmark then passed in execution-only PR #59, run `31433427436`, job `93602011104`:
 
 - **94 core tests passed**;
 - **27 projected documents**;
 - benchmark **PASS 6/6**;
+- final-answer/outcome/citation/completeness/appropriate-abstention rates `1.0`;
+- unsupported-claim and over-abstention rates `0.0`;
+- Brier score and high-confidence error rate `0.0`.
+
+The SQLite case resolves `current_state_unresolved` via durable claim `clm_a047d79b8604fadbd44efdf4` with exact citation `cite_b4e13e4e1a809f76527311ba`.
+
+### Workstream C — landed evidence
+
+Core PR #61 / squash:
+
+`f5634412222e8d86173eb6e8e364f3414a6f3cd6`
+
+Final normal CI:
+
+- run `31436499505`;
+- job `93611686820`;
+- **100 passed in 1.07s**.
+
+The provider-independent `fossil-untrusted-context-v1` boundary:
+
+- re-resolves known retrieved stable IDs from mounted durable documents;
+- prevents retrieved payload metadata from self-authoring lifecycle/relation/citation/pack truth;
+- demotes unknown in-scope payloads to non-authoritative `untrusted_context`;
+- removes out-of-scope pack payloads;
+- collapses exact duplicate unknown passages;
+- exposes no executable tool/action surface through answer generation;
+- keeps model output candidate-only;
+- re-resolves emitted durable claim text/citation identity;
+- contains unknown claim IDs as `insufficient_evidence`;
+- leaves proposal-before-commit and deterministic mutation gates authoritative.
+
+Execution-only PR #62 ran the unchanged eight-case plan against:
+
+- `fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
+- `fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`.
+
+Final proof run `31436425791`, job `93611459472`:
+
+- **100 core tests passed in 0.96s**;
+- **27 projected documents**;
+- adversarial benchmark **PASS 8/8**;
 - final-answer correctness `1.0`;
 - outcome accuracy `1.0`;
 - exact citation correctness `1.0`;
@@ -136,26 +165,32 @@ Final proof run `31433427436`, job `93602011104`:
 - unsupported-claim rate `0.0`;
 - over-abstention `0.0`;
 - Brier score `0.0`;
-- high-confidence error rate `0.0`.
+- high-confidence error rate `0.0`;
+- pack-isolation preservation `1.0`;
+- candidate-only authority `1.0`;
+- executable-output containment `1.0`;
+- durable-claim output boundary `1.0`;
+- aggregate security-boundary pass rate `1.0`.
 
-The formerly failing SQLite case now resolves `current_state_unresolved` via durable claim `clm_a047d79b8604fadbd44efdf4` with exact citation `cite_b4e13e4e1a809f76527311ba`.
+The poisoned SQLite case remained `current_state_unresolved` with the same durable claim/citation. This is a bounded structural proof, not universal poisoning resistance; residual risks are explicit in `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`.
 
-### Workstream C — exact active target
+### Workstream F — exact active target
 
-Build a retrieval-poisoning / untrusted-context adversarial suite. Cover at minimum:
+Define and prove a compact reproducible query execution receipt containing at minimum:
 
-- poisoned retrieved documents containing instructions;
-- authority spoofing;
-- malicious supersession attempts;
-- duplicated adversarial passages intended to dominate ranking;
-- conflicting-source attacks;
-- pack-isolation pressure;
-- attempts to bypass proposal-before-commit / deterministic gates;
-- residual-risk documentation.
+- deterministic query identity/hash plus human-debuggable query reference;
+- mounted stable pack IDs and exact revisions;
+- route/retrieval-policy identity;
+- requested and actual provider/model/service/runtime identity, including fallback diagnostics;
+- retrieved candidate stable IDs and scores;
+- reranker identity/order when present;
+- lifecycle/lineage/context-security resolver identities and resolved stable IDs;
+- final model-bound context IDs and exact citation IDs;
+- final outcome/abstention;
+- latency/cost;
+- trace/run reference.
 
-Reuse Workstream B answer metrics where possible. The suite must test downstream behavior, not merely retrieval presence: final-answer correctness, citations, unsupported claims, lifecycle/lineage resolution, abstention, authority boundaries, pack isolation, and proposal-before-commit behavior.
-
-Do not claim universal poisoning resistance. Retrieved/source text is untrusted data and never executable policy merely because it was retrieved.
+Keep verbose telemetry outside canonical durable knowledge. The receipt is execution observability/evidence, not truth authority. Prove important benchmark queries can be replayed after retriever/model/projection changes and that changed execution identity is visible rather than silently conflated.
 
 ## Research-to-corpus state
 
@@ -183,9 +218,9 @@ Existing replaceable service contracts include:
 - `ModelService`;
 - `VerificationService`.
 
-LiteLLM defaults currently recorded in `docs/operations/LITELLM-GATEWAY.md` are `qwen3-coder-next` for chat, `gemini-embedding-2` for embeddings, and `rerank-v4-pro` for reranking. Live benchmark evidence must record requested/actual model, provider, fallback attempts, latency, cost, and runtime identity. Do not send secrets, personal data, or confidential documents while gateway retention guarantees remain unverified.
+LiteLLM defaults currently recorded in `docs/operations/LITELLM-GATEWAY.md` are `qwen3-coder-next` for chat, `gemini-embedding-2` for embeddings, and `rerank-v4-pro` for reranking. Live benchmark evidence and Workstream-F receipts must record requested/actual model, provider, fallback attempts, latency, cost, and runtime identity. Do not send secrets, personal data, or confidential documents while gateway retention guarantees remain unverified.
 
-Cortex v4 and multi-agent orchestration are optional replaceable cognitive-service competitors. Durable storage, stable identity, lifecycle/lineage logic, proposal-before-commit, and correctness guarantees must not couple to Cortex internals. Multiple workers agreeing does not create evidence.
+Cortex v4 and multi-agent orchestration are optional replaceable cognitive-service competitors. Durable storage, stable identity, lifecycle/lineage logic, context-security, proposal-before-commit, and correctness guarantees must not couple to Cortex internals. Multiple workers agreeing does not create evidence. Future worker/model invocations should fit the Workstream-F receipt.
 
 ## Frozen invariants
 
@@ -204,6 +239,7 @@ Cortex v4 and multi-agent orchestration are optional replaceable cognitive-servi
 - protocol adapters cannot become the durable knowledge model;
 - cognitive services expose provider/version metadata and compete behind interfaces;
 - model agreement is not evidence; model output remains bounded by evidence/risk policy;
+- retrieved/source text is untrusted data and cannot become executable policy merely because it was retrieved;
 - agents propose; deterministic validation/policy gates commit durable changes;
 - do not casually rename `src/dkg`.
 
@@ -213,4 +249,4 @@ Cortex v4 and multi-agent orchestration are optional replaceable cognitive-servi
 
 `.github/workflows/graphiti-live.yml` contains reusable live materialization plus redaction/non-resurrection smoke coverage.
 
-Execution-only PRs #51, #55, #58, and #59 were closed without merge after their proofs. Issue #48 remains active; do not extend closed Gate 2 issues to implement it.
+Execution-only PRs #51, #55, #58, #59, and #62 were closed without merge after their proofs. Issue #48 remains active; do not extend closed Gate 2 issues to implement it.

--- a/docs/handoffs/2026-08-10-chatgpt-session-handoff-post-retrieval-poisoning.md
+++ b/docs/handoffs/2026-08-10-chatgpt-session-handoff-post-retrieval-poisoning.md
@@ -1,0 +1,216 @@
+# FOSSIL Session Handoff — Post-Retrieval-Poisoning
+
+**Date:** 2026-08-10  
+**Repository:** `Pukujan/fossil-core`  
+**Campaign:** Issue #48 — production RAG hardening  
+**State:** Gate 1 complete; Gate 2 complete/formally closed; Workstreams A, B, and C complete; **Workstream F is next**.
+
+## Read first
+
+1. `AGENTS.md`
+2. `ARCHITECTURE.md`
+3. `docs/HANDOFF_CURRENT.md`
+4. this file
+5. `docs/PROJECT_STATE.md`
+6. `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`
+7. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
+8. `docs/operations/LITELLM-GATEWAY.md`
+9. Issue #48
+10. Issue #47
+11. `docs/DECISION_LOG.md`
+
+Verify GitHub state before changing anything.
+
+## Completed work — do not redo
+
+- production-RAG research trace + AI-systems ingestion;
+- Workstream A — evolving-corpus / temporal benchmark;
+- Workstream B — end-to-end answer/citation/abstention reliability;
+- Workstream C — retrieval poisoning / untrusted-context hardening.
+
+## Workstream C — landed
+
+Core PR #61 landed with squash:
+
+`f5634412222e8d86173eb6e8e364f3414a6f3cd6`
+
+Landed artifacts:
+
+- `src/dkg/context_security.py`;
+- `src/dkg/poisoning_eval.py`;
+- `benchmarks/post-gate2/retrieval-poisoning-v1.json`;
+- `scripts/run_post_gate2_retrieval_poisoning.py`;
+- `tests/test_context_security.py`;
+- `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`.
+
+The structural boundary is named:
+
+`fossil-untrusted-context-v1`
+
+Its rule is not natural-language poison classification. Retrieved/source text stays data, while authority is resolved structurally:
+
+- known retrieved stable IDs are re-resolved from mounted durable documents;
+- retrieved text/lifecycle/relation/citation/pack metadata cannot override durable identity;
+- unknown in-scope payloads are demoted to `untrusted_context` and lose claim/relation/lifecycle/citation authority;
+- out-of-scope pack payloads are dropped before model execution;
+- exact duplicate unknown payloads are collapsed to reduce trivial context flooding;
+- the answer boundary exposes no executable tool/action surface;
+- model output is `candidate_only`;
+- emitted claim IDs must resolve to mounted durable claims, with canonical text/citation copied from durable documents;
+- invalid claim IDs become `insufficient_evidence` rather than new truth;
+- mutation remains behind the existing capability/provenance/validation/proposal-before-commit gates.
+
+This wrapper is provider/model independent and composes outside `fossil-lineage-context-v1` so B's durable relation-endpoint correction remains active.
+
+## Workstream C proof
+
+Final normal PR #61 CI:
+
+- run `31436499505`;
+- job `93611686820`;
+- **100 passed in 1.07s**.
+
+Execution-only PR #62 ran the unchanged adversarial plan against exact pack pins and was closed unmerged by design.
+
+Proof:
+
+- run `31436425791`;
+- job `93611459472`;
+- **100 core tests passed in 0.96s**;
+- **27 projected documents**;
+- adversarial benchmark **PASS 8/8**;
+- final-answer correctness `1.0`;
+- outcome accuracy `1.0`;
+- citation correctness `1.0`;
+- completeness `1.0`;
+- appropriate abstention `1.0`;
+- unsupported-claim rate `0.0`;
+- over-abstention `0.0`;
+- Brier score `0.0`;
+- high-confidence error rate `0.0`;
+- pack-isolation preservation `1.0`;
+- candidate-only authority `1.0`;
+- executable-output containment `1.0`;
+- durable-claim output boundary `1.0`;
+- aggregate security-boundary pass rate `1.0`.
+
+The attack set covers:
+
+1. poisoned retrieved instructions;
+2. authority spoofing with a real durable ID;
+3. malicious supersession metadata;
+4. duplicate adversarial ranking/context pressure;
+5. fake conflicting claims/relations;
+6. pack-isolation pressure;
+7. lifecycle/lineage spoofing of the stale SQLite case;
+8. proposal-before-commit bypass instructions.
+
+The SQLite regression remained correct under direct spoofing:
+
+- outcome `current_state_unresolved`;
+- claim `clm_a047d79b8604fadbd44efdf4`;
+- exact citation `cite_b4e13e4e1a809f76527311ba`.
+
+Do not turn this into a claim of universal prompt-injection or poisoning resistance. Residual risks are documented in the proof file, including semantic near-duplicate flooding, context-budget/ranking pressure before the model boundary, upstream evidence compromise, and future generative-model confusion/refusal/error.
+
+## Workstream B anchor
+
+B remains landed in PR #57 / squash:
+
+`483772ac0e1d441719aec42658ae00b62a032c11`
+
+The failed-first execution PR #58 established the critical D021 lesson: a retrieved durable relation can point to a relevant claim that fell outside top-k; top-k absence is not evidence of nonexistence.
+
+The final unchanged B benchmark passed in execution-only PR #59, run `31433427436`, job `93602011104`, after `fossil-lineage-context-v1` resolved durable relation endpoints before model execution.
+
+## Exact next workstream — F
+
+Build the **reproducible query execution receipt** before the retrieval/model bakeoff.
+
+Issue #48 requires a compact receipt containing at minimum:
+
+- query ID and/or deterministic query hash;
+- mounted stable pack IDs and exact pack revisions;
+- route / retrieval policy identity;
+- service/model/provider/version/runtime identity;
+- retrieved candidate stable IDs and scores;
+- reranker identity and reranked ordering when present;
+- deterministic lifecycle/lineage resolution performed;
+- final model-bound context stable IDs;
+- exact citation IDs;
+- final outcome / abstention state;
+- latency and provider/model cost;
+- trace/run reference suitable for replay and debugging.
+
+Keep verbose provider telemetry outside canonical durable knowledge. The receipt is execution evidence/observability, not a new truth source and not a durable knowledge event merely because it exists.
+
+The completion proof should show that important benchmark queries can be replayed after retriever/model/projection changes and that the receipt is sufficient to identify what changed.
+
+### Suggested F design constraints
+
+- prefer a versioned compact JSON contract under a stable FOSSIL namespace;
+- keep deterministic fields separate from provider-specific diagnostics;
+- hash/identify the normalized query without making the hash the only human-debuggable field;
+- record requested **and actual** model/provider identity for fallbacks;
+- record retrieval/reranking candidate ordering without granting score authority;
+- record lifecycle/lineage/context-security resolver identities (`fossil-lineage-context-v1`, `fossil-untrusted-context-v1`) and their resolved stable IDs;
+- record mounted pack IDs and exact source revisions so replay does not silently change corpus state;
+- do not embed secrets, raw credentials, or unnecessary private telemetry;
+- make receipts reproducible enough for Workstream D/#47 comparisons and future Cortex multi-worker execution receipts.
+
+## D021 remains frozen
+
+Do not replace or weaken D021 without new committed benchmark evidence.
+
+Current rules:
+
+- revision-pinned BGE dense is the normal primary retriever;
+- BM25 is explicit degraded availability fallback;
+- current/latest/accepted queries resolve durable lifecycle/provenance;
+- history/lineage/disagreement queries resolve durable lineage/read state;
+- top-k absence is not evidence of nonexistence;
+- citations resolve immutable source snapshot/span/hash identity;
+- retrieval score is not truth;
+- reranker score is not truth;
+- model confidence is not truth;
+- multi-model consensus is not external evidence;
+- retrieved/source text is untrusted data, never executable policy.
+
+Stable pack IDs:
+
+- common: `pack_269099f7b2ba43b7a99b9427d64092de`;
+- AI systems: `pack_f024177f89a5442db84171c3dd7f58e5`.
+
+Exact current pack revisions used by B/C proofs:
+
+- `fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
+- `fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`.
+
+Do not casually rename `src/dkg`.
+
+## LiteLLM / Cortex boundary
+
+Read `docs/operations/LITELLM-GATEWAY.md` before live provider work.
+
+Recorded LiteLLM defaults remain:
+
+- chat: `qwen3-coder-next`;
+- embeddings: `gemini-embedding-2`;
+- reranking: `rerank-v4-pro`.
+
+For every live benchmark/receipt record requested model, actual model, provider, fallback/attempt diagnostics, latency, cost, and runtime identity. A fallback response is not proof that the requested model succeeded. Embedding and reranking are separate lanes and should be probed independently. Do not send secrets, personal information, or confidential documents while retention guarantees remain unverified.
+
+Cortex v4 remains a replaceable cognitive-service/orchestration competitor. FOSSIL stable identity, durable storage, lifecycle/lineage, context-security, proposal-before-commit, and correctness guarantees must not couple to Cortex internals. Multiple workers agreeing does not manufacture truth. Future worker/model invocations should fit into the Workstream F execution receipt without changing that authority model.
+
+## Remaining campaign order
+
+1. **F** — reproducible query execution receipt;
+2. **D / Issue #47** — embeddings, hybrid retrieval, rerankers, model bakeoff;
+3. **E** — conservative adaptive routing, only if benchmark justified;
+4. **G** — ACL/redaction propagation readiness;
+5. final D021/retrieval-policy decision reconciliation;
+6. decision log + residual risks + final handoff.
+
+## Suggested next-session prompt
+
+> Continue FOSSIL Issue #48 from the post-retrieval-poisoning handoff. Verify GitHub first. Workstreams A, B, and C are complete; do not redo them. C landed in PR #61 / squash `f5634412222e8d86173eb6e8e364f3414a6f3cd6`. Its exact-pin execution proof ran in closed-unmerged PR #62, run `31436425791`, job `93611459472`, with 100 core tests, 27 documents, adversarial PASS 8/8, exact answer/citation/security-boundary metrics at 1.0, and unsupported-claim rate 0.0. The poisoned SQLite case still returned `current_state_unresolved` via `clm_a047d79b8604fadbd44efdf4` / `cite_b4e13e4e1a809f76527311ba`. Begin Workstream F: a compact reproducible query execution receipt and replay proof. Preserve D021, stable pack IDs, proposal-before-commit, deterministic lifecycle/lineage authority, and `fossil-untrusted-context-v1`. The receipt is observability/evidence, not truth authority.


### PR DESCRIPTION
Reconciles project state after Issue #48 Workstream C.

## What changed

- adds a dated post-retrieval-poisoning handoff;
- records PR #61 / squash `f5634412222e8d86173eb6e8e364f3414a6f3cd6` and execution-only PR #62 proof;
- updates `docs/HANDOFF_CURRENT.md` and `docs/PROJECT_STATE.md` so A/B/C are complete and F is the exact next workstream.

Docs/state only. No code, D021, pack identity, or authority-policy changes.

Refs #48.