### PR TITLE
Post-Gate-2: add reproducible query execution receipts

### DIFF
--- a/docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md
+++ b/docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md
@@ -1,0 +1,219 @@
+# Post-Gate-2 Workstream F — Reproducible Query Execution Receipt Proof
+
+**Date:** 2026-08-10  
+**Campaign:** Issue #48 — production RAG hardening  
+**Workstream:** F — reproducible query execution receipt
+
+## Scope
+
+Workstream F adds a compact, versioned execution receipt for important FOSSIL queries and proves that the receipt can distinguish a true execution/configuration change from telemetry-only replay noise while preserving the existing durable answer/citation authority model.
+
+The receipt is explicitly:
+
+`execution_observability_only`
+
+It is **not** a durable knowledge event, does not become canonical truth merely because it is recorded, and cannot grant retrieval/model output mutation authority.
+
+D021 is unchanged.
+
+## Receipt contract
+
+The versioned contract is:
+
+`fossil.query-execution-receipt.v1`
+
+Implementation:
+
+- `src/dkg/execution_receipt.py`;
+- `schemas/query-execution-receipt/v1.schema.json`;
+- `tests/test_execution_receipt.py`;
+- `scripts/run_post_gate2_query_receipt.py`.
+
+Observability-only diagnostics were also added to the existing deterministic boundaries:
+
+- `src/dkg/answer_pipeline.py` now reports `fossil-lineage-context-v1` input/expanded/final stable IDs;
+- `src/dkg/context_security.py` now reports the stable IDs forwarded by `fossil-untrusted-context-v1`.
+
+Neither change alters the resolver's authority behavior.
+
+## Recorded fields
+
+The compact receipt records:
+
+- human-debuggable query text and query ID;
+- normalized query text plus deterministic SHA-256 identity;
+- mounted stable pack IDs and exact revisions;
+- explicit retrieval pack scope, separately from mounted packs;
+- projection name/version/build identity;
+- route ID and retrieval-policy identity;
+- requested and actual provider/model/service implementation identity;
+- bounded fallback/attempt diagnostics;
+- ordered retrieved candidate stable IDs, pack IDs, ranks, and scores;
+- optional base-retrieval and reranker scores when present;
+- reranker service identity when present;
+- deterministic context-security and lineage resolver identities;
+- stable IDs resolved/added/removed and final model-bound context IDs;
+- exact citation IDs and emitted durable claim IDs;
+- final answer/abstention outcome, confidence, and candidate-only authority;
+- aggregate latency/cost plus trace/run references;
+- an execution-identity hash and result-identity hash.
+
+Raw source text is not copied into the compact retrieval-candidate section.
+
+## Execution identity versus telemetry
+
+`execution_identity_sha256` is intentionally independent of timing/run-reference noise. It covers the logical query, exact corpus mounts and scope, projection identity, route/policy, requested/actual service identities and bounded attempts, and resolver identities.
+
+`result_sha256` covers the ordered retrieval candidates, resolver effects, model-bound context IDs/citations, and final result.
+
+`recorded_at`, trace/run references, latency, and cost remain telemetry. They may differ across exact replays without falsely changing the execution identity.
+
+The replay comparator reports changes separately across:
+
+- query;
+- corpus revision;
+- pack scope;
+- projection;
+- policy;
+- services/fallback identity;
+- retrieval candidates;
+- resolver behavior;
+- final context;
+- result;
+- telemetry.
+
+This is intended to make later Workstream D/#47 comparisons inspectable rather than silently conflating model/retriever changes with corpus drift.
+
+## Requested versus actual provider/model identity
+
+The service invocation record distinguishes requested identity from actual identity and marks fallback usage. Bounded attempt diagnostics can record provider/model/implementation, outcome, error type, and fallback reason.
+
+This preserves the existing LiteLLM rule: a fallback response is not proof that the requested model succeeded.
+
+Credential-shaped fields are removed recursively from retained runtime/attempt diagnostics using key-name filtering for API keys, authorization, cookies, credentials, passwords, secrets, and tokens. This is a compact receipt safeguard, not a general DLP system.
+
+## Normal CI proof
+
+Draft core PR #64 normal contract CI before the exact-pin execution proof:
+
+- workflow run: `31437380214`;
+- job: `93614423141`;
+- result: **104 passed in 2.49s**.
+
+## Exact corpus pins
+
+The replay proof uses the same validated pack revisions as Workstreams B and C:
+
+- `Pukujan/fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
+- `Pukujan/fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`.
+
+Stable mounted pack IDs:
+
+- `pack_269099f7b2ba43b7a99b9427d64092de`;
+- `pack_f024177f89a5442db84171c3dd7f58e5`.
+
+The proof's deterministic pack-fixture projection identity was:
+
+- name: `pack-fixture-retrieval-documents`;
+- version: `1`;
+- build ID: `packfix_59b82d8d50ab38ea68402db7`.
+
+## Real-corpus replay execution proof — PASS
+
+Execution-only PR #65 added only the temporary workflow step needed to clone the exact pack pins and run the unchanged receipt/replay proof. It is not implementation evidence and is intended to remain unmerged.
+
+Proof:
+
+- workflow run: `31437447245`;
+- job: `93614630416`;
+- core suite inside proof: **104 passed in 2.41s**;
+- projected corpus: **27 documents**;
+- Workstream-B benchmark queries replayed: **6**;
+- receipts emitted: **18** — baseline, exact replay, and controlled service/policy variant for every query;
+- overall proof result: **PASS**;
+- answer correctness rate: `1.0`;
+- exact replay identity rate: `1.0`;
+- resolver recording rate: `1.0`;
+- semantic result stability rate: `1.0`;
+- service-change visibility rate: `1.0`.
+
+### Exact replay behavior
+
+For every query, the exact replay preserved:
+
+- the normalized logical query;
+- exact corpus revisions;
+- retrieval pack scope;
+- projection identity;
+- route/policy identity;
+- service identity;
+- execution identity hash;
+- result identity hash;
+- durable answer/citation result.
+
+At the same time, trace references and measured latency changed as expected. The replay comparator therefore reported:
+
+- `changed_dimensions: []`;
+- `execution_identity_match: true`;
+- `result_identity_match: true`;
+- `telemetry_changed: true`;
+- `same_logical_query: true`;
+- `same_corpus_revision: true`;
+- `same_pack_scope: true`.
+
+This is the key replay property: ordinary timing/run-reference variance does not masquerade as a semantic execution change.
+
+### Controlled service/policy change
+
+For every query, the third execution changed only controlled execution identity inputs:
+
+- route changed from `d021-answer-baseline-v1` to `workstream-f-service-version-probe`;
+- retriever implementation version changed from `answer-reliability-baseline-v1` to `query-receipt-replay-probe-v2`;
+- corpus revisions, pack scope, projection, underlying retrieval algorithm, deterministic resolvers, and model answer semantics remained fixed.
+
+The receipt comparison correctly reported:
+
+- `execution_identity_match: false`;
+- `result_identity_match: true`;
+- `same_logical_query: true`;
+- `same_corpus_revision: true`;
+- `same_pack_scope: true`;
+- changed dimensions including `policy` and `services`;
+- semantic durable result stability for all six cases.
+
+This proves the receipt can expose a retriever/policy implementation-identity change without incorrectly reporting corpus drift or result drift.
+
+### Deterministic authority/resolver trace
+
+Every execution recorded both structural resolver identities:
+
+- `fossil-untrusted-context-v1`;
+- `fossil-lineage-context-v1`.
+
+The receipt includes their stable-ID effects and the final model-bound context IDs. This preserves the Workstream-B/C authority model rather than asking provider/model telemetry to reconstruct it after the fact.
+
+The six answer cases remained correct across all 18 executions. In particular, the Workstream-B stale-lineage regression remained governed by durable lifecycle/lineage resolution rather than top-k alone.
+
+## What the proof does not establish
+
+This proof is intentionally bounded:
+
+- the deterministic baseline does not establish that hosted/frontier/OSS providers are deterministic;
+- exact historical provider/model replay can become impossible if a provider removes or silently changes an implementation, even though the receipt still identifies what was requested and what actually ran;
+- key-name credential filtering is not a general-purpose DLP or privacy scanner;
+- compact receipts intentionally omit verbose provider telemetry, so detailed debugging may still require the referenced external trace while that trace is retained;
+- trace/run references can outlive or outlast the referenced telemetry store unless retention is managed separately;
+- provider costs may be estimates rather than invoice-grade accounting when only estimated per-call metadata is available;
+- floating-point scores, provider implementations, hardware/runtime changes, or nondeterministic generation can change result identity on a future replay;
+- JSON hashes provide identity/integrity cues inside this contract but do not by themselves provide trusted signing, timestamping, or globally durable receipt storage;
+- future Cortex/multi-worker execution may need child invocation IDs and causal parent/worker links rather than flattening every worker into one service record;
+- a receipt records what an execution did; it does not make retrieval rank, reranker score, model confidence, or agent consensus into evidence;
+- a receipt cannot authorize knowledge mutation and must not bypass proposal-before-commit or deterministic validation/policy gates.
+
+## D021 / authority conclusion
+
+D021 remains unchanged.
+
+The receipt makes retriever/reranker/model/projection execution choices inspectable and replay-comparable, but authority remains with immutable evidence, stable pack/corpus identity, durable lifecycle/lineage, exact citations, context-security boundaries, and deterministic commit policy.
+
+Workstream F is complete for the committed deterministic baseline once PR #64 lands with this proof. The receipt is now suitable as the observability substrate for Workstream D / Issue #47 model/retriever/reranker comparisons without granting those services truth authority.

--- a/docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md
+++ b/docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md
@@ -94,11 +94,17 @@ Credential-shaped fields are removed recursively from retained runtime/attempt d
 
 ## Normal CI proof
 
-Draft core PR #64 normal contract CI before the exact-pin execution proof:
+Initial draft PR #64 normal contract CI before the exact-pin execution proof:
 
 - workflow run: `31437380214`;
 - job: `93614423141`;
 - result: **104 passed in 2.49s**.
+
+Final feature-head normal CI after recording the replay proof:
+
+- workflow run: `31437679718`;
+- job: `93615371591`;
+- result: **104 passed in 1.23s**.
 
 ## Exact corpus pins
 
@@ -120,7 +126,7 @@ The proof's deterministic pack-fixture projection identity was:
 
 ## Real-corpus replay execution proof — PASS
 
-Execution-only PR #65 added only the temporary workflow step needed to clone the exact pack pins and run the unchanged receipt/replay proof. It is not implementation evidence and is intended to remain unmerged.
+Execution-only PR #65 added only the temporary workflow step needed to clone the exact pack pins and run the unchanged receipt/replay proof. It is not implementation evidence and was closed unmerged.
 
 Proof:
 

--- a/schemas/query-execution-receipt/v1.schema.json
+++ b/schemas/query-execution-receipt/v1.schema.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pukujan.github.io/fossil-core/schemas/query-execution-receipt/v1.schema.json",
+  "title": "FOSSIL Query Execution Receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "receipt_id",
+    "recorded_at",
+    "authority",
+    "query",
+    "packs",
+    "projection",
+    "policy",
+    "services",
+    "retrieval",
+    "resolvers",
+    "context",
+    "result",
+    "telemetry",
+    "execution_identity_sha256",
+    "result_sha256"
+  ],
+  "properties": {
+    "schema_version": {"const": "fossil.query-execution-receipt.v1"},
+    "receipt_id": {"type": "string", "pattern": "^qrx_[0-9a-f]{24}$"},
+    "recorded_at": {"type": "string", "format": "date-time"},
+    "authority": {"const": "execution_observability_only"},
+    "query": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["query_id", "text", "normalized", "sha256"],
+      "properties": {
+        "query_id": {"type": "string", "minLength": 1},
+        "text": {"type": "string", "minLength": 1},
+        "normalized": {"type": "string", "minLength": 1},
+        "sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "packs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["pack_id", "revision"],
+        "properties": {
+          "pack_id": {"type": "string", "minLength": 1},
+          "revision": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "projection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "build_id"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1},
+        "build_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["route_id", "retrieval_policy_id", "mode"],
+      "properties": {
+        "route_id": {"type": "string", "minLength": 1},
+        "retrieval_policy_id": {"type": "string", "minLength": 1},
+        "mode": {"type": "string", "minLength": 1}
+      }
+    },
+    "services": {
+      "type": "array",
+      "minItems": 2,
+      "items": {"$ref": "#/$defs/serviceInvocation"}
+    },
+    "retrieval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["candidates", "candidate_count"],
+      "properties": {
+        "candidate_count": {"type": "integer", "minimum": 0},
+        "candidates": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/candidate"}
+        }
+      }
+    },
+    "resolvers": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/resolver"}
+    },
+    "context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["item_ids", "citation_ids"],
+      "properties": {
+        "item_ids": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "citation_ids": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["outcome", "abstained", "claim_ids", "citation_ids", "confidence", "authority"],
+      "properties": {
+        "outcome": {"type": "string", "minLength": 1},
+        "abstained": {"type": "boolean"},
+        "claim_ids": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "citation_ids": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "confidence": {"type": ["number", "null"], "minimum": 0, "maximum": 1},
+        "authority": {"type": "string", "minLength": 1}
+      }
+    },
+    "telemetry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["latency_ms", "cost_usd", "trace_ref", "run_ref"],
+      "properties": {
+        "latency_ms": {"type": "number", "minimum": 0},
+        "cost_usd": {"type": "number", "minimum": 0},
+        "trace_ref": {"type": "string", "minLength": 1},
+        "run_ref": {"type": ["string", "null"]}
+      }
+    },
+    "execution_identity_sha256": {"$ref": "#/$defs/sha256"},
+    "result_sha256": {"$ref": "#/$defs/sha256"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "serviceIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "provider", "provider_version", "implementation", "implementation_version", "model_id", "local", "runtime"],
+      "properties": {
+        "kind": {"type": "string", "minLength": 1},
+        "provider": {"type": "string", "minLength": 1},
+        "provider_version": {"type": "string", "minLength": 1},
+        "implementation": {"type": "string", "minLength": 1},
+        "implementation_version": {"type": "string", "minLength": 1},
+        "model_id": {"type": ["string", "null"]},
+        "local": {"type": "boolean"},
+        "runtime": {"type": "object", "additionalProperties": true}
+      }
+    },
+    "requestedService": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "model_id", "implementation"],
+      "properties": {
+        "provider": {"type": "string", "minLength": 1},
+        "model_id": {"type": ["string", "null"]},
+        "implementation": {"type": "string", "minLength": 1}
+      }
+    },
+    "attempt": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {"type": "string"},
+        "model_id": {"type": ["string", "null"]},
+        "implementation": {"type": "string"},
+        "outcome": {"type": "string"},
+        "error_type": {"type": "string"},
+        "fallback_reason": {"type": "string"}
+      }
+    },
+    "serviceInvocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "requested", "actual", "fallback_used", "attempts", "latency_ms", "cost_usd"],
+      "properties": {
+        "role": {"type": "string", "minLength": 1},
+        "requested": {"$ref": "#/$defs/requestedService"},
+        "actual": {"$ref": "#/$defs/serviceIdentity"},
+        "fallback_used": {"type": "boolean"},
+        "attempts": {"type": "array", "items": {"$ref": "#/$defs/attempt"}},
+        "latency_ms": {"type": ["number", "null"], "minimum": 0},
+        "cost_usd": {"type": ["number", "null"], "minimum": 0}
+      }
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "pack_id", "rank", "score"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "pack_id": {"type": "string", "minLength": 1},
+        "rank": {"type": "integer", "minimum": 1},
+        "score": {"type": ["number", "null"]},
+        "base_rank": {"type": "integer", "minimum": 1},
+        "base_score": {"type": ["number", "null"]},
+        "rerank_score": {"type": ["number", "null"]}
+      }
+    },
+    "resolver": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["resolver", "resolved_ids", "added_ids", "removed_ids", "final_context_ids", "diagnostics"],
+      "properties": {
+        "resolver": {"type": "string", "minLength": 1},
+        "resolved_ids": {"type": "array", "items": {"type": "string"}},
+        "added_ids": {"type": "array", "items": {"type": "string"}},
+        "removed_ids": {"type": "array", "items": {"type": "string"}},
+        "final_context_ids": {"type": "array", "items": {"type": "string"}},
+        "diagnostics": {"type": "object", "additionalProperties": true}
+      }
+    }
+  }
+}

--- a/schemas/query-execution-receipt/v1.schema.json
+++ b/schemas/query-execution-receipt/v1.schema.json
@@ -11,6 +11,7 @@
     "authority",
     "query",
     "packs",
+    "pack_scope_ids",
     "projection",
     "policy",
     "services",
@@ -50,6 +51,12 @@
           "revision": {"type": "string", "minLength": 1}
         }
       }
+    },
+    "pack_scope_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
     },
     "projection": {
       "type": "object",

--- a/scripts/run_post_gate2_query_receipt.py
+++ b/scripts/run_post_gate2_query_receipt.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+from dkg.answer_eval import (
+    AnswerReliabilityCase,
+    DeterministicEvidenceAnswerService,
+    evaluate_answer_candidate,
+)
+from dkg.answer_pipeline import LineageResolvedModelService
+from dkg.context_security import UntrustedContextModelService
+from dkg.execution_receipt import (
+    compare_query_execution_receipts,
+    execute_query_with_receipt,
+)
+from dkg.pack_corpus import retrieval_documents_from_pack_fixtures
+from dkg.real_retrieval import LifecycleIntentReranker, RerankedRetriever
+from dkg.services import BM25Retriever
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PLAN = ROOT / "benchmarks" / "post-gate2" / "answer-reliability-v1.json"
+COMMON_PACK = "pack_269099f7b2ba43b7a99b9427d64092de"
+AI_PACK = "pack_f024177f89a5442db84171c3dd7f58e5"
+
+
+def _git_head(root: Path) -> str:
+    return subprocess.check_output(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+
+
+def _load_plan(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("answer reliability plan must be a JSON object")
+    return value
+
+
+def _projection_build_id(pack_mounts: dict[str, str]) -> str:
+    payload = json.dumps(pack_mounts, sort_keys=True, separators=(",", ":"))
+    return "packfix_" + hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+
+
+def _model(documents):
+    return UntrustedContextModelService(
+        LineageResolvedModelService(
+            DeterministicEvidenceAnswerService(),
+            documents=documents,
+        ),
+        documents=documents,
+    )
+
+
+def _retriever(documents, *, version: str):
+    return RerankedRetriever(
+        BM25Retriever(documents),
+        LifecycleIntentReranker(),
+        candidate_multiplier=4,
+        version=version,
+    )
+
+
+def _run_one(
+    *,
+    case: AnswerReliabilityCase,
+    documents,
+    pack_mounts: dict[str, str],
+    projection: dict,
+    route_id: str,
+    retriever_version: str,
+    trace_ref: str,
+    run_ref: str,
+):
+    return execute_query_with_receipt(
+        query=case.query,
+        pack_mounts=pack_mounts,
+        query_pack_ids=list(case.pack_ids),
+        projection=projection,
+        policy={
+            "route_id": route_id,
+            "retrieval_policy_id": "D021",
+            "mode": "receipt-replay-proof",
+        },
+        retriever=_retriever(documents, version=retriever_version),
+        model_service=_model(documents),
+        limit=case.limit,
+        trace_ref=trace_ref,
+        run_ref=run_ref,
+        query_id=case.case_id,
+        requested_model={
+            "provider": "fossil",
+            "model_id": None,
+            "implementation": "deterministic-evidence-answerer",
+        },
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the post-Gate-2 reproducible query execution receipt replay proof."
+    )
+    parser.add_argument("--common-root", type=Path, required=True)
+    parser.add_argument("--ai-root", type=Path, required=True)
+    parser.add_argument("--plan", type=Path, default=DEFAULT_PLAN)
+    parser.add_argument("--run-ref", default="post-gate2-query-receipt-proof")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    plan = _load_plan(args.plan)
+    expected_repo_pins = {
+        "fossil-common": str(plan["pack_pins"]["fossil-common"]),
+        "fossil-ai-systems": str(plan["pack_pins"]["fossil-ai-systems"]),
+    }
+    observed_repo_pins = {
+        "fossil-common": _git_head(args.common_root),
+        "fossil-ai-systems": _git_head(args.ai_root),
+    }
+    if observed_repo_pins != expected_repo_pins:
+        raise SystemExit(
+            "pack pin mismatch: "
+            + json.dumps(
+                {"expected": expected_repo_pins, "observed": observed_repo_pins},
+                sort_keys=True,
+            )
+        )
+
+    pack_mounts = {
+        COMMON_PACK: observed_repo_pins["fossil-common"],
+        AI_PACK: observed_repo_pins["fossil-ai-systems"],
+    }
+    projection = {
+        "name": "pack-fixture-retrieval-documents",
+        "version": "1",
+        "build_id": _projection_build_id(pack_mounts),
+    }
+    documents = retrieval_documents_from_pack_fixtures(
+        [args.common_root, args.ai_root],
+        schemas_root=ROOT / "schemas",
+    )
+    cases = [AnswerReliabilityCase.from_mapping(item) for item in plan["cases"]]
+
+    observations: list[dict] = []
+    exact_matches = 0
+    variant_visible = 0
+    stable_semantic_results = 0
+    all_answers_correct = True
+    all_security_resolvers_recorded = True
+
+    for case in cases:
+        baseline_response, baseline = _run_one(
+            case=case,
+            documents=documents,
+            pack_mounts=pack_mounts,
+            projection=projection,
+            route_id="d021-answer-baseline-v1",
+            retriever_version="answer-reliability-baseline-v1",
+            trace_ref=f"trace://query-receipt/{case.case_id}/baseline",
+            run_ref=args.run_ref,
+        )
+        replay_response, replay = _run_one(
+            case=case,
+            documents=documents,
+            pack_mounts=pack_mounts,
+            projection=projection,
+            route_id="d021-answer-baseline-v1",
+            retriever_version="answer-reliability-baseline-v1",
+            trace_ref=f"trace://query-receipt/{case.case_id}/exact-replay",
+            run_ref=args.run_ref,
+        )
+        variant_response, variant = _run_one(
+            case=case,
+            documents=documents,
+            pack_mounts=pack_mounts,
+            projection=projection,
+            route_id="workstream-f-service-version-probe",
+            retriever_version="query-receipt-replay-probe-v2",
+            trace_ref=f"trace://query-receipt/{case.case_id}/service-variant",
+            run_ref=args.run_ref,
+        )
+
+        baseline_eval = evaluate_answer_candidate(
+            baseline_response["output"], case=case, documents=documents
+        )
+        replay_eval = evaluate_answer_candidate(
+            replay_response["output"], case=case, documents=documents
+        )
+        variant_eval = evaluate_answer_candidate(
+            variant_response["output"], case=case, documents=documents
+        )
+        case_answers_correct = all(
+            bool(item["case_correct"])
+            for item in (baseline_eval, replay_eval, variant_eval)
+        )
+        all_answers_correct = all_answers_correct and case_answers_correct
+
+        exact_comparison = compare_query_execution_receipts(baseline, replay)
+        variant_comparison = compare_query_execution_receipts(baseline, variant)
+        exact_ok = (
+            exact_comparison["same_logical_query"]
+            and exact_comparison["same_corpus_revision"]
+            and exact_comparison["same_pack_scope"]
+            and exact_comparison["execution_identity_match"]
+            and exact_comparison["result_identity_match"]
+            and exact_comparison["changed_dimensions"] == []
+        )
+        if exact_ok:
+            exact_matches += 1
+
+        variant_change_visible = (
+            variant_comparison["same_logical_query"]
+            and variant_comparison["same_corpus_revision"]
+            and variant_comparison["same_pack_scope"]
+            and not variant_comparison["execution_identity_match"]
+            and {"policy", "services"}
+            <= set(variant_comparison["changed_dimensions"])
+        )
+        if variant_change_visible:
+            variant_visible += 1
+
+        semantic_result_stable = baseline["result"] == variant["result"]
+        if semantic_result_stable:
+            stable_semantic_results += 1
+
+        required_resolvers = {
+            "fossil-untrusted-context-v1",
+            "fossil-lineage-context-v1",
+        }
+        resolver_sets = [
+            {item["resolver"] for item in receipt["resolvers"]}
+            for receipt in (baseline, replay, variant)
+        ]
+        resolvers_recorded = all(required_resolvers <= values for values in resolver_sets)
+        all_security_resolvers_recorded = all_security_resolvers_recorded and resolvers_recorded
+
+        observations.append(
+            {
+                "case_id": case.case_id,
+                "category": case.category,
+                "expected_outcome": case.expected_outcome,
+                "baseline_evaluation": baseline_eval,
+                "replay_evaluation": replay_eval,
+                "variant_evaluation": variant_eval,
+                "exact_replay_comparison": exact_comparison,
+                "variant_comparison": variant_comparison,
+                "semantic_result_stable_across_service_version_change": semantic_result_stable,
+                "required_resolvers_recorded": resolvers_recorded,
+                "receipts": {
+                    "baseline": baseline,
+                    "exact_replay": replay,
+                    "service_version_variant": variant,
+                },
+            }
+        )
+
+    count = len(cases)
+    report = {
+        "schema_version": "fossil.query-execution-replay-proof.v1",
+        "benchmark_id": "post-gate2-query-execution-receipt-v1",
+        "authority": "execution receipts are observability/replay evidence, not truth authority",
+        "repo_pack_pins": observed_repo_pins,
+        "pack_mounts": pack_mounts,
+        "projection": projection,
+        "corpus_document_count": len(documents),
+        "case_count": count,
+        "receipt_count": count * 3,
+        "metrics": {
+            "answer_correctness_rate": 1.0 if all_answers_correct else sum(
+                all(
+                    bool(item[name]["case_correct"])
+                    for name in (
+                        "baseline_evaluation",
+                        "replay_evaluation",
+                        "variant_evaluation",
+                    )
+                )
+                for item in observations
+            )
+            / count,
+            "exact_replay_identity_rate": exact_matches / count,
+            "service_change_visibility_rate": variant_visible / count,
+            "semantic_result_stability_rate": stable_semantic_results / count,
+            "resolver_recording_rate": sum(
+                bool(item["required_resolvers_recorded"]) for item in observations
+            )
+            / count,
+        },
+        "observations": observations,
+        "passed": (
+            all_answers_correct
+            and exact_matches == count
+            and variant_visible == count
+            and stable_semantic_results == count
+            and all_security_resolvers_recorded
+        ),
+        "residual_note": (
+            "This proof demonstrates receipt/replay identity and change visibility for the "
+            "committed deterministic baseline. It does not establish provider determinism, "
+            "and latency/cost remain telemetry rather than replay identity."
+        ),
+    }
+
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    return 0 if report["passed"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dkg/answer_pipeline.py
+++ b/src/dkg/answer_pipeline.py
@@ -4,6 +4,9 @@ import copy
 from typing import Any, Iterable, Mapping
 
 
+LINEAGE_CONTEXT_RESOLVER = "fossil-lineage-context-v1"
+
+
 def expand_context_with_lineage(
     context_items: Iterable[Mapping[str, Any]],
     *,
@@ -18,6 +21,24 @@ def expand_context_with_lineage(
     cannot erase lineage needed for a current/history answer.
     """
 
+    expanded, _ = expand_context_with_lineage_diagnostics(
+        context_items,
+        documents=documents,
+        pack_ids=pack_ids,
+        max_expansions=max_expansions,
+    )
+    return expanded
+
+
+def expand_context_with_lineage_diagnostics(
+    context_items: Iterable[Mapping[str, Any]],
+    *,
+    documents: Iterable[Mapping[str, Any]],
+    pack_ids: Iterable[str],
+    max_expansions: int = 24,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Expand relation endpoints and return compact replay/receipt diagnostics."""
+
     if max_expansions < 0:
         raise ValueError("max_expansions must be non-negative")
     allowed = {str(pack_id) for pack_id in pack_ids}
@@ -27,7 +48,8 @@ def expand_context_with_lineage(
         if str(document.get("pack_id", "")) in allowed
     }
     selected = [copy.deepcopy(dict(item)) for item in context_items]
-    selected_ids = {str(item.get("id", "")) for item in selected}
+    input_ids = [str(item.get("id", "")) for item in selected if item.get("id")]
+    selected_ids = set(input_ids)
     expansion_ids: list[str] = []
 
     for item in selected:
@@ -47,10 +69,21 @@ def expand_context_with_lineage(
         item = document_by_id[identifier]
         item["context_expansion"] = {
             "reason": "durable_relation_endpoint",
-            "resolver": "fossil-lineage-context-v1",
+            "resolver": LINEAGE_CONTEXT_RESOLVER,
         }
         selected.append(item)
-    return selected
+
+    diagnostics = {
+        "resolver": LINEAGE_CONTEXT_RESOLVER,
+        "allowed_pack_ids": sorted(allowed),
+        "input_context_ids": input_ids,
+        "expanded_ids": expansion_ids,
+        "final_context_ids": [
+            str(item.get("id", "")) for item in selected if item.get("id")
+        ],
+        "max_expansions": max_expansions,
+    }
+    return selected, diagnostics
 
 
 class LineageResolvedModelService:
@@ -72,19 +105,21 @@ class LineageResolvedModelService:
     def metadata(self) -> dict[str, Any]:
         metadata = copy.deepcopy(dict(self.service.metadata()))
         runtime = dict(metadata.get("runtime", {}))
-        runtime["lineage_context_resolver"] = "fossil-lineage-context-v1"
+        runtime["lineage_context_resolver"] = LINEAGE_CONTEXT_RESOLVER
         runtime["lineage_max_expansions"] = str(self.max_expansions)
         metadata["runtime"] = runtime
         return metadata
 
     def run(self, task: dict[str, Any]) -> dict[str, Any]:
         request = copy.deepcopy(task)
-        request["context_items"] = expand_context_with_lineage(
+        expanded, diagnostics = expand_context_with_lineage_diagnostics(
             request.get("context_items", []),
             documents=self.documents,
             pack_ids=request.get("pack_ids", []),
             max_expansions=self.max_expansions,
         )
+        request["context_items"] = expanded
         response = copy.deepcopy(dict(self.service.run(request)))
         response["service"] = self.metadata()
+        response["lineage_resolution"] = diagnostics
         return response

--- a/src/dkg/context_security.py
+++ b/src/dkg/context_security.py
@@ -161,6 +161,9 @@ def canonicalize_untrusted_context(
         "allowed_pack_ids": sorted(allowed_packs),
         "input_item_count": len(raw_items),
         "forwarded_item_count": len(secured),
+        "forwarded_item_ids": [
+            str(item.get("id", "")) for item in secured if item.get("id")
+        ],
         "forwarded_pack_ids": sorted(
             {str(item.get("pack_id", "")) for item in secured if item.get("pack_id")}
         ),

--- a/src/dkg/execution_receipt.py
+++ b/src/dkg/execution_receipt.py
@@ -175,6 +175,16 @@ def normalize_pack_mounts(
     ]
 
 
+def _normalize_pack_scope(
+    mounts: Sequence[Mapping[str, str]], pack_scope_ids: Sequence[str] | None
+) -> list[str]:
+    mounted_ids = {str(item["pack_id"]) for item in mounts}
+    scope = sorted({str(item) for item in (pack_scope_ids or sorted(mounted_ids))})
+    if not scope or not set(scope) <= mounted_ids:
+        raise ValueError("query receipt pack scope must be a non-empty subset of mounted packs")
+    return scope
+
+
 def _retrieval_candidate(candidate: Mapping[str, Any], fallback_rank: int) -> dict[str, Any]:
     retrieval = dict(candidate.get("retrieval", {}))
     result: dict[str, Any] = {
@@ -297,6 +307,7 @@ def _execution_identity_payload(receipt: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "query_sha256": receipt["query"]["sha256"],
         "packs": receipt["packs"],
+        "pack_scope_ids": receipt["pack_scope_ids"],
         "projection": receipt["projection"],
         "policy": receipt["policy"],
         "services": [
@@ -326,6 +337,7 @@ def build_query_execution_receipt(
     *,
     query: str,
     pack_mounts: Mapping[str, str] | Iterable[Mapping[str, Any]],
+    pack_scope_ids: Sequence[str] | None = None,
     projection: Mapping[str, Any],
     policy: Mapping[str, Any],
     services: Sequence[Mapping[str, Any]],
@@ -343,6 +355,7 @@ def build_query_execution_receipt(
         raise ValueError("query receipt requires a non-empty query")
     query_hash = _sha256_text(normalized)
     mounts = normalize_pack_mounts(pack_mounts)
+    scope = _normalize_pack_scope(mounts, pack_scope_ids)
     projection_value = sanitize_diagnostics(dict(projection))
     if not all(str(projection_value.get(key, "")) for key in ("name", "version", "build_id")):
         raise ValueError("query receipt requires projection name, version, and build_id")
@@ -385,6 +398,7 @@ def build_query_execution_receipt(
             "sha256": query_hash,
         },
         "packs": mounts,
+        "pack_scope_ids": scope,
         "projection": {
             "name": str(projection_value["name"]),
             "version": str(projection_value["version"]),
@@ -432,6 +446,7 @@ def compare_query_execution_receipts(
     dimensions = {
         "query": before.get("query", {}).get("sha256") != after.get("query", {}).get("sha256"),
         "corpus": before.get("packs") != after.get("packs"),
+        "pack_scope": before.get("pack_scope_ids") != after.get("pack_scope_ids"),
         "projection": before.get("projection") != after.get("projection"),
         "policy": before.get("policy") != after.get("policy"),
         "services": [
@@ -469,6 +484,7 @@ def compare_query_execution_receipts(
         "after_receipt_id": str(after.get("receipt_id", "")),
         "same_logical_query": not dimensions["query"],
         "same_pack_ids": same_pack_ids,
+        "same_pack_scope": not dimensions["pack_scope"],
         "same_corpus_revision": not dimensions["corpus"],
         "corpus_revision_changed": same_pack_ids and dimensions["corpus"],
         "execution_identity_match": (
@@ -505,8 +521,8 @@ def execute_query_with_receipt(
     mounts = normalize_pack_mounts(pack_mounts)
     mounted_ids = {item["pack_id"] for item in mounts}
     requested_pack_ids = [str(item) for item in query_pack_ids]
-    if not set(requested_pack_ids) <= mounted_ids:
-        raise ValueError("query_pack_ids must be mounted at exact revisions")
+    if not requested_pack_ids or not set(requested_pack_ids) <= mounted_ids:
+        raise ValueError("query_pack_ids must be a non-empty subset of mounted exact revisions")
 
     started = time.perf_counter()
     retrieval_started = time.perf_counter()
@@ -573,6 +589,7 @@ def execute_query_with_receipt(
     receipt = build_query_execution_receipt(
         query=query,
         pack_mounts=mounts,
+        pack_scope_ids=requested_pack_ids,
         projection=projection,
         policy=policy,
         services=services,

--- a/src/dkg/execution_receipt.py
+++ b/src/dkg/execution_receipt.py
@@ -1,0 +1,587 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+import time
+import unicodedata
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping, Sequence
+
+
+QUERY_EXECUTION_RECEIPT_SCHEMA = "fossil.query-execution-receipt.v1"
+QUERY_EXECUTION_RECEIPT_AUTHORITY = "execution_observability_only"
+
+_SECRET_KEY_PARTS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "cookie",
+    "credential",
+    "password",
+    "secret",
+    "token",
+)
+_ABSTENTION_OUTCOMES = frozenset(
+    {"insufficient_evidence", "conflicting_evidence", "current_state_unresolved"}
+)
+
+
+def normalize_query(query: str) -> str:
+    """Normalize representation noise without changing query wording or case."""
+
+    return re.sub(r"\s+", " ", unicodedata.normalize("NFC", str(query)).strip())
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sha256_json(value: Any) -> str:
+    return _sha256_text(_canonical_json(value))
+
+
+def _is_secret_key(key: str) -> bool:
+    normalized = key.lower().replace("-", "_")
+    return any(part in normalized for part in _SECRET_KEY_PARTS)
+
+
+def sanitize_diagnostics(value: Any) -> Any:
+    """Return JSON-safe bounded diagnostics while dropping credential-shaped fields."""
+
+    if isinstance(value, Mapping):
+        return {
+            str(key): sanitize_diagnostics(item)
+            for key, item in value.items()
+            if not _is_secret_key(str(key))
+        }
+    if isinstance(value, (list, tuple)):
+        return [sanitize_diagnostics(item) for item in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def _service_identity(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    value = sanitize_diagnostics(dict(metadata))
+    runtime = value.get("runtime", {})
+    if not isinstance(runtime, Mapping):
+        runtime = {"value": str(runtime)}
+    return {
+        "kind": str(value.get("kind", "unknown")),
+        "provider": str(value.get("provider", "unknown")),
+        "provider_version": str(value.get("provider_version", "unknown")),
+        "implementation": str(value.get("implementation", "unknown")),
+        "implementation_version": str(value.get("implementation_version", "unknown")),
+        "model_id": (
+            str(value["model_id"]) if value.get("model_id") is not None else None
+        ),
+        "local": bool(value.get("local", False)),
+        "runtime": sanitize_diagnostics(dict(runtime)),
+    }
+
+
+def build_service_invocation(
+    role: str,
+    actual_metadata: Mapping[str, Any],
+    *,
+    requested: Mapping[str, Any] | None = None,
+    attempts: Iterable[Mapping[str, Any]] = (),
+    latency_ms: float | None = None,
+    cost_usd: float | None = None,
+) -> dict[str, Any]:
+    """Build a compact requested-vs-actual service record without raw telemetry."""
+
+    actual = _service_identity(actual_metadata)
+    requested_value = sanitize_diagnostics(dict(requested or {}))
+    requested_identity = {
+        "provider": str(requested_value.get("provider", actual["provider"])),
+        "model_id": (
+            str(requested_value["model_id"])
+            if requested_value.get("model_id") is not None
+            else actual["model_id"]
+        ),
+        "implementation": str(
+            requested_value.get("implementation", actual["implementation"])
+        ),
+    }
+    safe_attempts: list[dict[str, Any]] = []
+    for attempt in attempts:
+        item = sanitize_diagnostics(dict(attempt))
+        safe_attempts.append(
+            {
+                key: item[key]
+                for key in (
+                    "provider",
+                    "model_id",
+                    "implementation",
+                    "outcome",
+                    "error_type",
+                    "fallback_reason",
+                )
+                if key in item
+            }
+        )
+
+    if cost_usd is None:
+        cost_usd = float(actual_metadata.get("estimated_cost_per_call_usd", 0.0))
+    return {
+        "role": str(role),
+        "requested": requested_identity,
+        "actual": actual,
+        "fallback_used": bool(
+            requested_identity.get("provider") != actual.get("provider")
+            or requested_identity.get("model_id") != actual.get("model_id")
+            or any(str(item.get("outcome", "")) not in {"", "success"} for item in safe_attempts)
+        ),
+        "attempts": safe_attempts,
+        "latency_ms": float(latency_ms) if latency_ms is not None else None,
+        "cost_usd": float(cost_usd) if cost_usd is not None else None,
+    }
+
+
+def normalize_pack_mounts(
+    pack_mounts: Mapping[str, str] | Iterable[Mapping[str, Any]],
+) -> list[dict[str, str]]:
+    if isinstance(pack_mounts, Mapping):
+        mounts = [
+            {"pack_id": str(pack_id), "revision": str(revision)}
+            for pack_id, revision in pack_mounts.items()
+        ]
+    else:
+        mounts = [
+            {
+                "pack_id": str(item.get("pack_id", "")),
+                "revision": str(item.get("revision", "")),
+            }
+            for item in pack_mounts
+        ]
+    if not mounts or any(not item["pack_id"] or not item["revision"] for item in mounts):
+        raise ValueError("query receipt requires non-empty pack_id and exact revision")
+    by_pack: dict[str, str] = {}
+    for item in mounts:
+        existing = by_pack.get(item["pack_id"])
+        if existing is not None and existing != item["revision"]:
+            raise ValueError("query receipt cannot mount one pack_id at multiple revisions")
+        by_pack[item["pack_id"]] = item["revision"]
+    return [
+        {"pack_id": pack_id, "revision": by_pack[pack_id]}
+        for pack_id in sorted(by_pack)
+    ]
+
+
+def _retrieval_candidate(candidate: Mapping[str, Any], fallback_rank: int) -> dict[str, Any]:
+    retrieval = dict(candidate.get("retrieval", {}))
+    result: dict[str, Any] = {
+        "id": str(candidate.get("id", "")),
+        "pack_id": str(candidate.get("pack_id", "")),
+        "rank": int(retrieval.get("rank", fallback_rank)),
+        "score": (
+            float(retrieval["score"]) if retrieval.get("score") is not None else None
+        ),
+    }
+    base = candidate.get("base_retrieval")
+    if isinstance(base, Mapping):
+        result["base_rank"] = int(base.get("rank", fallback_rank))
+        result["base_score"] = (
+            float(base["score"]) if base.get("score") is not None else None
+        )
+    rerank = candidate.get("rerank")
+    if isinstance(rerank, Mapping):
+        result["rerank_score"] = (
+            float(rerank["score"]) if rerank.get("score") is not None else None
+        )
+    return result
+
+
+def _reranker_metadata(candidates: Sequence[Mapping[str, Any]]) -> Mapping[str, Any] | None:
+    for candidate in candidates:
+        rerank = candidate.get("rerank")
+        if isinstance(rerank, Mapping) and isinstance(rerank.get("service"), Mapping):
+            return rerank["service"]
+    return None
+
+
+def _citation_ids(output: Mapping[str, Any]) -> list[str]:
+    values: list[str] = []
+    for claim in output.get("claims", []):
+        if not isinstance(claim, Mapping):
+            continue
+        citation = claim.get("citation")
+        if not isinstance(citation, Mapping):
+            continue
+        citation_id = str(citation.get("citation_id", ""))
+        if citation_id and citation_id not in values:
+            values.append(citation_id)
+    return values
+
+
+def _claim_ids(output: Mapping[str, Any]) -> list[str]:
+    return [
+        str(claim.get("claim_id"))
+        for claim in output.get("claims", [])
+        if isinstance(claim, Mapping) and claim.get("claim_id")
+    ]
+
+
+def _resolver_records(response: Mapping[str, Any]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    security = response.get("context_security")
+    if isinstance(security, Mapping):
+        records.append(
+            {
+                "resolver": str(security.get("resolver", "unknown")),
+                "resolved_ids": [str(item) for item in security.get("canonicalized_ids", [])],
+                "added_ids": [str(item) for item in security.get("demoted_untrusted_ids", [])],
+                "removed_ids": [
+                    str(item)
+                    for item in [
+                        *security.get("dropped_out_of_scope_ids", []),
+                        *security.get("deduplicated_ids", []),
+                    ]
+                ],
+                "final_context_ids": [
+                    str(item) for item in security.get("forwarded_item_ids", [])
+                ],
+                "diagnostics": sanitize_diagnostics(
+                    {
+                        key: security[key]
+                        for key in (
+                            "source_text_trust",
+                            "retrieved_payload_mismatch_ids",
+                            "blocked_response_fields",
+                            "blocked_output_fields",
+                            "invalid_output_claim_ids",
+                        )
+                        if key in security
+                    }
+                ),
+            }
+        )
+    lineage = response.get("lineage_resolution")
+    if isinstance(lineage, Mapping):
+        records.append(
+            {
+                "resolver": str(lineage.get("resolver", "unknown")),
+                "resolved_ids": [str(item) for item in lineage.get("expanded_ids", [])],
+                "added_ids": [str(item) for item in lineage.get("expanded_ids", [])],
+                "removed_ids": [],
+                "final_context_ids": [
+                    str(item) for item in lineage.get("final_context_ids", [])
+                ],
+                "diagnostics": {
+                    "max_expansions": int(lineage.get("max_expansions", 0)),
+                },
+            }
+        )
+    return records
+
+
+def _final_context_ids(
+    candidates: Sequence[Mapping[str, Any]],
+    resolver_records: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    for record in reversed(resolver_records):
+        values = [str(item) for item in record.get("final_context_ids", [])]
+        if values:
+            return values
+    return [str(item.get("id", "")) for item in candidates if item.get("id")]
+
+
+def _execution_identity_payload(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "query_sha256": receipt["query"]["sha256"],
+        "packs": receipt["packs"],
+        "projection": receipt["projection"],
+        "policy": receipt["policy"],
+        "services": [
+            {
+                "role": item["role"],
+                "requested": item["requested"],
+                "actual": item["actual"],
+                "fallback_used": item["fallback_used"],
+                "attempts": item["attempts"],
+            }
+            for item in receipt["services"]
+        ],
+        "resolvers": [item["resolver"] for item in receipt["resolvers"]],
+    }
+
+
+def _result_identity_payload(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "retrieval": receipt["retrieval"],
+        "resolvers": receipt["resolvers"],
+        "context": receipt["context"],
+        "result": receipt["result"],
+    }
+
+
+def build_query_execution_receipt(
+    *,
+    query: str,
+    pack_mounts: Mapping[str, str] | Iterable[Mapping[str, Any]],
+    projection: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    services: Sequence[Mapping[str, Any]],
+    candidates: Sequence[Mapping[str, Any]],
+    response: Mapping[str, Any],
+    trace_ref: str,
+    run_ref: str | None = None,
+    query_id: str | None = None,
+    recorded_at: str | None = None,
+    latency_ms: float = 0.0,
+    cost_usd: float = 0.0,
+) -> dict[str, Any]:
+    normalized = normalize_query(query)
+    if not normalized:
+        raise ValueError("query receipt requires a non-empty query")
+    query_hash = _sha256_text(normalized)
+    mounts = normalize_pack_mounts(pack_mounts)
+    projection_value = sanitize_diagnostics(dict(projection))
+    if not all(str(projection_value.get(key, "")) for key in ("name", "version", "build_id")):
+        raise ValueError("query receipt requires projection name, version, and build_id")
+    policy_value = sanitize_diagnostics(dict(policy))
+    if not str(policy_value.get("route_id", "")) or not str(
+        policy_value.get("retrieval_policy_id", "")
+    ):
+        raise ValueError("query receipt requires route_id and retrieval_policy_id")
+    if not trace_ref:
+        raise ValueError("query receipt requires trace_ref")
+
+    output_value = response.get("output", {})
+    output = dict(output_value) if isinstance(output_value, Mapping) else {}
+    resolver_records = _resolver_records(response)
+    citation_ids = _citation_ids(output)
+    candidate_records = [
+        _retrieval_candidate(candidate, rank)
+        for rank, candidate in enumerate(candidates, start=1)
+    ]
+    result = {
+        "outcome": str(output.get("outcome", "unknown")),
+        "abstained": str(output.get("outcome", "")) in _ABSTENTION_OUTCOMES,
+        "claim_ids": _claim_ids(output),
+        "citation_ids": citation_ids,
+        "confidence": (
+            float(output["confidence"]) if output.get("confidence") is not None else None
+        ),
+        "authority": str(response.get("authority", "unknown")),
+    }
+    context_ids = _final_context_ids(candidates, resolver_records)
+    receipt: dict[str, Any] = {
+        "schema_version": QUERY_EXECUTION_RECEIPT_SCHEMA,
+        "receipt_id": "pending",
+        "recorded_at": recorded_at or datetime.now(timezone.utc).isoformat(),
+        "authority": QUERY_EXECUTION_RECEIPT_AUTHORITY,
+        "query": {
+            "query_id": query_id or f"qry_{query_hash[:24]}",
+            "text": str(query),
+            "normalized": normalized,
+            "sha256": query_hash,
+        },
+        "packs": mounts,
+        "projection": {
+            "name": str(projection_value["name"]),
+            "version": str(projection_value["version"]),
+            "build_id": str(projection_value["build_id"]),
+        },
+        "policy": {
+            "route_id": str(policy_value["route_id"]),
+            "retrieval_policy_id": str(policy_value["retrieval_policy_id"]),
+            "mode": str(policy_value.get("mode", "unspecified")),
+        },
+        "services": [copy.deepcopy(dict(item)) for item in services],
+        "retrieval": {
+            "candidates": candidate_records,
+            "candidate_count": len(candidate_records),
+        },
+        "resolvers": resolver_records,
+        "context": {
+            "item_ids": context_ids,
+            "citation_ids": citation_ids,
+        },
+        "result": result,
+        "telemetry": {
+            "latency_ms": float(latency_ms),
+            "cost_usd": float(cost_usd),
+            "trace_ref": str(trace_ref),
+            "run_ref": str(run_ref) if run_ref is not None else None,
+        },
+    }
+    receipt["execution_identity_sha256"] = _sha256_json(
+        _execution_identity_payload(receipt)
+    )
+    receipt["result_sha256"] = _sha256_json(_result_identity_payload(receipt))
+    receipt_without_id = copy.deepcopy(receipt)
+    receipt_without_id["receipt_id"] = ""
+    receipt_hash = _sha256_json(receipt_without_id)
+    receipt["receipt_id"] = f"qrx_{receipt_hash[:24]}"
+    return receipt
+
+
+def compare_query_execution_receipts(
+    before: Mapping[str, Any], after: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Compare replay receipts while separating corpus drift from execution changes."""
+
+    dimensions = {
+        "query": before.get("query", {}).get("sha256") != after.get("query", {}).get("sha256"),
+        "corpus": before.get("packs") != after.get("packs"),
+        "projection": before.get("projection") != after.get("projection"),
+        "policy": before.get("policy") != after.get("policy"),
+        "services": [
+            {
+                "role": item.get("role"),
+                "requested": item.get("requested"),
+                "actual": item.get("actual"),
+                "fallback_used": item.get("fallback_used"),
+                "attempts": item.get("attempts"),
+            }
+            for item in before.get("services", [])
+        ]
+        != [
+            {
+                "role": item.get("role"),
+                "requested": item.get("requested"),
+                "actual": item.get("actual"),
+                "fallback_used": item.get("fallback_used"),
+                "attempts": item.get("attempts"),
+            }
+            for item in after.get("services", [])
+        ],
+        "retrieval_candidates": before.get("retrieval") != after.get("retrieval"),
+        "resolvers": before.get("resolvers") != after.get("resolvers"),
+        "context": before.get("context") != after.get("context"),
+        "result": before.get("result") != after.get("result"),
+    }
+    changed = [name for name, did_change in dimensions.items() if did_change]
+    before_pack_ids = [item.get("pack_id") for item in before.get("packs", [])]
+    after_pack_ids = [item.get("pack_id") for item in after.get("packs", [])]
+    same_pack_ids = before_pack_ids == after_pack_ids
+    return {
+        "schema_version": "fossil.query-execution-replay-comparison.v1",
+        "before_receipt_id": str(before.get("receipt_id", "")),
+        "after_receipt_id": str(after.get("receipt_id", "")),
+        "same_logical_query": not dimensions["query"],
+        "same_pack_ids": same_pack_ids,
+        "same_corpus_revision": not dimensions["corpus"],
+        "corpus_revision_changed": same_pack_ids and dimensions["corpus"],
+        "execution_identity_match": (
+            before.get("execution_identity_sha256")
+            == after.get("execution_identity_sha256")
+        ),
+        "result_identity_match": before.get("result_sha256") == after.get("result_sha256"),
+        "changed_dimensions": changed,
+        "telemetry_changed": before.get("telemetry") != after.get("telemetry"),
+        "replay_comparable": not dimensions["query"],
+    }
+
+
+def execute_query_with_receipt(
+    *,
+    query: str,
+    pack_mounts: Mapping[str, str] | Iterable[Mapping[str, Any]],
+    query_pack_ids: Sequence[str],
+    projection: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    retriever: Any,
+    model_service: Any,
+    limit: int,
+    trace_ref: str,
+    run_ref: str | None = None,
+    query_id: str | None = None,
+    requested_model: Mapping[str, Any] | None = None,
+    model_attempts: Iterable[Mapping[str, Any]] = (),
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Execute one query and emit a compact replayable receipt around existing services."""
+
+    if limit < 1:
+        raise ValueError("query receipt execution limit must be positive")
+    mounts = normalize_pack_mounts(pack_mounts)
+    mounted_ids = {item["pack_id"] for item in mounts}
+    requested_pack_ids = [str(item) for item in query_pack_ids]
+    if not set(requested_pack_ids) <= mounted_ids:
+        raise ValueError("query_pack_ids must be mounted at exact revisions")
+
+    started = time.perf_counter()
+    retrieval_started = time.perf_counter()
+    candidates = retriever.search(query, pack_ids=requested_pack_ids, limit=limit)
+    retrieval_latency_ms = (time.perf_counter() - retrieval_started) * 1000.0
+
+    model_started = time.perf_counter()
+    response = copy.deepcopy(
+        dict(
+            model_service.run(
+                {
+                    "query": query,
+                    "pack_ids": requested_pack_ids,
+                    "context_items": candidates,
+                    "response_contract": {
+                        "outcomes": [
+                            "answer",
+                            "conflicting_evidence",
+                            "current_state_unresolved",
+                            "insufficient_evidence",
+                        ],
+                        "authority": "candidate_only",
+                    },
+                }
+            )
+        )
+    )
+    model_latency_ms = (time.perf_counter() - model_started) * 1000.0
+    total_latency_ms = (time.perf_counter() - started) * 1000.0
+
+    retriever_metadata = dict(retriever.metadata())
+    model_metadata = dict(response.get("service", model_service.metadata()))
+    retriever_cost = float(retriever_metadata.get("estimated_cost_per_call_usd", 0.0))
+    model_cost = float(response.get("cost_usd", model_metadata.get("estimated_cost_per_call_usd", 0.0)))
+    services = [
+        build_service_invocation(
+            "retriever",
+            retriever_metadata,
+            latency_ms=retrieval_latency_ms,
+            cost_usd=retriever_cost,
+        )
+    ]
+    reranker_metadata = _reranker_metadata(candidates)
+    if reranker_metadata is not None:
+        services.append(
+            build_service_invocation(
+                "reranker",
+                reranker_metadata,
+                latency_ms=None,
+                cost_usd=None,
+            )
+        )
+    services.append(
+        build_service_invocation(
+            "model",
+            model_metadata,
+            requested=requested_model,
+            attempts=model_attempts,
+            latency_ms=model_latency_ms,
+            cost_usd=model_cost,
+        )
+    )
+
+    receipt = build_query_execution_receipt(
+        query=query,
+        pack_mounts=mounts,
+        projection=projection,
+        policy=policy,
+        services=services,
+        candidates=candidates,
+        response=response,
+        trace_ref=trace_ref,
+        run_ref=run_ref,
+        query_id=query_id,
+        latency_ms=total_latency_ms,
+        cost_usd=retriever_cost + model_cost,
+    )
+    return response, receipt

--- a/tests/test_execution_receipt.py
+++ b/tests/test_execution_receipt.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+from dkg.answer_eval import DeterministicEvidenceAnswerService
+from dkg.answer_pipeline import LineageResolvedModelService
+from dkg.context_security import UntrustedContextModelService
+from dkg.execution_receipt import (
+    QUERY_EXECUTION_RECEIPT_AUTHORITY,
+    build_query_execution_receipt,
+    build_service_invocation,
+    compare_query_execution_receipts,
+    execute_query_with_receipt,
+)
+from dkg.services import ServiceMetadata
+
+PACK = "pack_receipt_fixture"
+
+
+def _citation(identifier: str) -> dict:
+    return {
+        "schema_version": "fossil.citation.v1",
+        "citation_id": identifier,
+        "snapshot_id": f"snap_{identifier}",
+        "artifact_id": f"art_{identifier}",
+        "byte_start": 0,
+        "byte_end": 12,
+        "passage_hash": {"algorithm": "sha256", "digest": "c" * 64},
+    }
+
+
+def _claim(identifier: str, text: str, state: str) -> dict:
+    return {
+        "id": identifier,
+        "pack_id": PACK,
+        "text": text,
+        "document_type": "claim",
+        "current_state": state,
+        "state_history": [state],
+        "citation": _citation(f"cite_{identifier}"),
+    }
+
+
+def _relation(identifier: str, source_ref: str, target_ref: str) -> dict:
+    return {
+        "id": identifier,
+        "pack_id": PACK,
+        "text": f"{source_ref}\nRelation: DEPENDS_ON\n{target_ref}",
+        "document_type": "relation",
+        "relation_type": "DEPENDS_ON",
+        "source_ref": source_ref,
+        "target_ref": target_ref,
+        "current_state": "active",
+        "state_history": ["active"],
+    }
+
+
+class StaticRetriever:
+    def __init__(self, results):
+        self.results = [dict(item) for item in results]
+
+    def metadata(self):
+        return ServiceMetadata(
+            kind="retriever",
+            provider="fixture",
+            provider_version="1",
+            implementation="static-retriever",
+            implementation_version="1",
+            local=True,
+            estimated_cost_per_call_usd=0.0,
+            runtime={"fixture": "receipt"},
+        ).as_dict()
+
+    def search(self, query, *, pack_ids, limit=20):
+        assert pack_ids == [PACK]
+        output = []
+        for rank, item in enumerate(self.results[:limit], start=1):
+            result = dict(item)
+            result["retrieval"] = {
+                "rank": rank,
+                "score": 1.0 / rank,
+                "service": self.metadata(),
+            }
+            output.append(result)
+        return output
+
+
+def _schema() -> dict:
+    root = Path(__file__).resolve().parents[1]
+    return json.loads(
+        (root / "schemas" / "query-execution-receipt" / "v1.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+def _validate(receipt: dict) -> None:
+    validator = Draft202012Validator(_schema(), format_checker=FormatChecker())
+    errors = sorted(validator.iter_errors(receipt), key=lambda item: list(item.path))
+    assert errors == []
+
+
+def test_service_invocation_records_requested_actual_fallback_without_secrets():
+    invocation = build_service_invocation(
+        "model",
+        {
+            "kind": "model",
+            "provider": "fallback-provider",
+            "provider_version": "2",
+            "implementation": "gateway-model",
+            "implementation_version": "4",
+            "model_id": "actual-model",
+            "local": False,
+            "estimated_cost_per_call_usd": 0.02,
+            "runtime": {
+                "region": "us-east",
+                "api_key": "must-not-survive",
+                "nested": {"authorization": "must-not-survive", "safe": "yes"},
+            },
+        },
+        requested={"provider": "requested-provider", "model_id": "requested-model"},
+        attempts=[
+            {
+                "provider": "requested-provider",
+                "model_id": "requested-model",
+                "outcome": "failed",
+                "error_type": "TimeoutError",
+                "secret": "must-not-survive",
+            },
+            {
+                "provider": "fallback-provider",
+                "model_id": "actual-model",
+                "outcome": "success",
+            },
+        ],
+        latency_ms=12.5,
+    )
+
+    assert invocation["requested"]["model_id"] == "requested-model"
+    assert invocation["actual"]["model_id"] == "actual-model"
+    assert invocation["fallback_used"] is True
+    assert "api_key" not in invocation["actual"]["runtime"]
+    assert "authorization" not in invocation["actual"]["runtime"]["nested"]
+    assert invocation["actual"]["runtime"]["nested"]["safe"] == "yes"
+    assert "secret" not in invocation["attempts"][0]
+
+
+def test_execution_receipt_records_true_model_bound_lineage_context_and_exact_citation():
+    premise = _claim(
+        "clm_premise",
+        "SQLite is the canonical corpus database.",
+        "superseded",
+    )
+    dependent = _claim(
+        "clm_dependent",
+        "The first SQLite prototype is the canonical architecture implementation.",
+        "stale_pending_review",
+    )
+    unrelated = _claim(
+        "clm_unrelated",
+        "Production RAG hardening preserves the durable core.",
+        "supported",
+    )
+    relation = _relation("rel_depends", "clm_dependent", "clm_premise")
+    documents = [premise, dependent, unrelated, relation]
+    retriever = StaticRetriever([relation, unrelated])
+    model = UntrustedContextModelService(
+        LineageResolvedModelService(
+            DeterministicEvidenceAnswerService(),
+            documents=documents,
+        ),
+        documents=documents,
+    )
+
+    response, receipt = execute_query_with_receipt(
+        query="Is the first SQLite prototype the current canonical architecture implementation?",
+        pack_mounts={PACK: "rev_fixture_123"},
+        query_pack_ids=[PACK],
+        projection={
+            "name": "fixture-retrieval-documents",
+            "version": "1",
+            "build_id": "build_fixture_001",
+        },
+        policy={
+            "route_id": "receipt-fixture-route",
+            "retrieval_policy_id": "d021-fixture",
+            "mode": "test",
+        },
+        retriever=retriever,
+        model_service=model,
+        limit=2,
+        trace_ref="trace://receipt-fixture/001",
+        run_ref="test_execution_receipt",
+    )
+
+    assert response["output"]["outcome"] == "current_state_unresolved"
+    assert receipt["authority"] == QUERY_EXECUTION_RECEIPT_AUTHORITY
+    assert receipt["retrieval"]["candidate_count"] == 2
+    assert [item["id"] for item in receipt["retrieval"]["candidates"]] == [
+        "rel_depends",
+        "clm_unrelated",
+    ]
+    assert [item["resolver"] for item in receipt["resolvers"]] == [
+        "fossil-untrusted-context-v1",
+        "fossil-lineage-context-v1",
+    ]
+    assert receipt["resolvers"][1]["added_ids"] == ["clm_dependent", "clm_premise"]
+    assert receipt["context"]["item_ids"] == [
+        "rel_depends",
+        "clm_unrelated",
+        "clm_dependent",
+        "clm_premise",
+    ]
+    assert receipt["result"]["claim_ids"] == ["clm_dependent"]
+    assert receipt["result"]["citation_ids"] == ["cite_clm_dependent"]
+    assert receipt["result"]["abstained"] is True
+    assert receipt["result"]["authority"] == "candidate_only"
+    _validate(receipt)
+
+
+def _minimal_receipt(*, revision: str, route_id: str = "route-a", recorded_at: str, latency: float):
+    service = build_service_invocation(
+        "retriever",
+        ServiceMetadata(
+            kind="retriever",
+            provider="fixture",
+            provider_version="1",
+            implementation="static",
+            implementation_version="1",
+            local=True,
+        ).as_dict(),
+        latency_ms=1.0,
+    )
+    model = build_service_invocation(
+        "model",
+        ServiceMetadata(
+            kind="model",
+            provider="fixture",
+            provider_version="1",
+            implementation="deterministic",
+            implementation_version="1",
+            local=True,
+        ).as_dict(),
+        latency_ms=1.0,
+    )
+    candidate = _claim("clm_truth", "Durable truth remains durable.", "supported")
+    candidate["retrieval"] = {"rank": 1, "score": 2.0}
+    response = {
+        "output": {
+            "outcome": "answer",
+            "claims": [
+                {
+                    "claim_id": "clm_truth",
+                    "text": candidate["text"],
+                    "citation": candidate["citation"],
+                }
+            ],
+            "confidence": 1.0,
+        },
+        "authority": "candidate_only",
+    }
+    return build_query_execution_receipt(
+        query="  What   is durable truth?  ",
+        pack_mounts={PACK: revision},
+        projection={"name": "fixture", "version": "1", "build_id": "build-1"},
+        policy={"route_id": route_id, "retrieval_policy_id": "D021", "mode": "test"},
+        services=[service, model],
+        candidates=[candidate],
+        response=response,
+        trace_ref="trace://fixture",
+        recorded_at=recorded_at,
+        latency_ms=latency,
+    )
+
+
+def test_replay_comparison_separates_telemetry_from_execution_identity():
+    before = _minimal_receipt(
+        revision="rev-a",
+        recorded_at="2026-08-10T20:00:00+00:00",
+        latency=2.0,
+    )
+    after = _minimal_receipt(
+        revision="rev-a",
+        recorded_at="2026-08-10T20:01:00+00:00",
+        latency=9.0,
+    )
+
+    comparison = compare_query_execution_receipts(before, after)
+    assert before["query"]["normalized"] == "What is durable truth?"
+    assert before["query"]["sha256"] == after["query"]["sha256"]
+    assert before["execution_identity_sha256"] == after["execution_identity_sha256"]
+    assert before["result_sha256"] == after["result_sha256"]
+    assert comparison["changed_dimensions"] == []
+    assert comparison["telemetry_changed"] is True
+    assert comparison["execution_identity_match"] is True
+    assert comparison["result_identity_match"] is True
+
+
+def test_replay_comparison_surfaces_corpus_revision_and_route_changes():
+    before = _minimal_receipt(
+        revision="rev-a",
+        route_id="route-a",
+        recorded_at="2026-08-10T20:00:00+00:00",
+        latency=2.0,
+    )
+    after = _minimal_receipt(
+        revision="rev-b",
+        route_id="route-b",
+        recorded_at="2026-08-10T20:00:00+00:00",
+        latency=2.0,
+    )
+
+    comparison = compare_query_execution_receipts(before, after)
+    assert comparison["same_logical_query"] is True
+    assert comparison["same_pack_ids"] is True
+    assert comparison["same_corpus_revision"] is False
+    assert comparison["corpus_revision_changed"] is True
+    assert comparison["replay_comparable"] is True
+    assert {"corpus", "policy"} <= set(comparison["changed_dimensions"])
+    assert comparison["execution_identity_match"] is False


### PR DESCRIPTION
Implements Issue #48 Workstream F: a compact reproducible query execution receipt and replay comparator.

## What changed

- adds `fossil.query-execution-receipt.v1` plus strict JSON Schema;
- records normalized query/hash, mounted stable pack IDs + exact revisions, explicit retrieval pack scope, projection identity, route/policy identity, requested-vs-actual service/model/provider identity, bounded fallback attempts, ordered candidate stable IDs/scores, resolver identities/resolved IDs, final model-bound context IDs, exact citation IDs, outcome/abstention, latency/cost, and trace/run refs;
- sanitizes credential-shaped runtime/attempt fields so the compact receipt does not persist obvious secrets or raw provider telemetry;
- adds execution/result identity hashes and a replay comparator separating query/corpus/scope/projection/policy/service/evidence changes from telemetry-only differences;
- exposes observability-only diagnostics from `fossil-lineage-context-v1` and `fossil-untrusted-context-v1` without changing their authority behavior;
- adds an exact-pin real-corpus replay runner over the six Workstream-B answer cases;
- documents residual risks and the explicit `execution_observability_only` authority boundary.

## Evidence

Final feature-head normal CI:
- run `31437754923`
- job `93615632123`
- **104 passed in 1.04s**

Execution-only PR #65 was closed unmerged after exact-pin proof:
- run `31437447245`
- job `93614630416`
- **104 core tests passed in 2.41s**
- **27 projected documents**
- **6 benchmark queries / 18 receipts**
- answer correctness `1.0`
- exact replay identity `1.0`
- resolver recording `1.0`
- semantic result stability `1.0`
- service-change visibility `1.0`

Exact replay changed telemetry only: execution identity and result identity matched with `changed_dimensions: []`. The controlled variant changed route/retriever implementation identity; the receipt exposed `policy`/`services` changes while preserving result identity and semantic durable answers/citations.

The receipt is observability/replay evidence, not truth authority or a mutation capability. D021 and stable pack IDs remain unchanged.

Completes Workstream F in #48.