### PR TITLE
Reconcile handoff after query execution receipts

### DIFF
--- a/docs/HANDOFF_CURRENT.md
+++ b/docs/HANDOFF_CURRENT.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-10  
 **Project:** **FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage**  
 **Repository:** `Pukujan/fossil-core`  
-**Status:** **Gate 1 complete. Gate 2 complete and formally closed. Post-Gate-2 campaign #48 active. Research ingestion and Workstreams A, B, and C are complete. Workstream F is next.**
+**Status:** **Gate 1 complete. Gate 2 complete and formally closed. Post-Gate-2 campaign #48 active. Research ingestion and Workstreams A, B, C, and F are complete. Workstream D / Issue #47 is active next.**
 
 ## Fresh-session transfer
 
@@ -12,112 +12,107 @@ Read, in order:
 1. `AGENTS.md`
 2. `ARCHITECTURE.md`
 3. this file
-4. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-retrieval-poisoning.md`
+4. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-query-execution-receipt.md`
 5. `docs/PROJECT_STATE.md`
-6. `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`
-7. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
-8. `docs/operations/LITELLM-GATEWAY.md`
-9. Issue #48 — active production RAG hardening campaign
-10. Issue #47 — embedding/reranker/model-scale bakeoff workstream
-11. `docs/DECISION_LOG.md`
+6. `docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md`
+7. `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`
+8. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
+9. `docs/operations/LITELLM-GATEWAY.md`
+10. Issue #48 — active production RAG hardening campaign
+11. Issue #47 — active Workstream D retrieval/reranking/model bakeoff
+12. `docs/DECISION_LOG.md`
 
 Verify GitHub state before changing anything.
 
 ## Exact active continuation point
 
-**Do not redo research ingestion or Workstreams A, B, or C.**
+**Do not redo research ingestion or Workstreams A, B, C, or F.**
 
 The next unfinished Issue #48 workstream is:
 
-**F. Reproducible query execution receipt.**
+**D / Issue #47 — retrieval/reranking/model bakeoff.**
 
-Define a compact versioned receipt containing at minimum:
+Start with comparable incumbent/hybrid/reranker evidence before escalating embedding model size:
 
-1. query ID and deterministic query hash;
-2. mounted stable pack IDs and exact pack revisions;
-3. route/retrieval-policy identity;
-4. requested and actual service/model/provider/version/runtime identity;
-5. retrieved candidate stable IDs and scores;
-6. reranker identity and reranked order when present;
-7. deterministic lifecycle/lineage/context-security resolution and resolved IDs;
-8. final model-bound context stable IDs and exact citation IDs;
-9. final outcome / abstention;
-10. latency, cost, and trace/run reference.
+1. rerun comparable incumbent D021 dense and BM25 baselines using exact corpus pins and Workstream-F receipts;
+2. compare deterministic dense+lexical hybrid/RRF;
+3. add at least one real cross-encoder/API reranker behind `Reranker` and prove requested/actual/fallback identity;
+4. only then progress Qwen3-Embedding 0.6B → 4B → 8B if evidence and resources justify continuing;
+5. keep contextualized retrieval optional and reproducible, with original source/claim identity distinguishable.
 
-Keep verbose telemetry outside canonical durable knowledge. The receipt is execution observability/evidence, not a new truth source and not a durable knowledge event merely because it exists.
+Every candidate/configuration must emit or be representable by `fossil.query-execution-receipt.v1` and preserve deterministic lifecycle/lineage/context-security authority.
 
-The replay proof should show that important benchmark queries can be rerun after retriever/model/projection changes and the receipt makes the changed execution identity visible.
+Do not replace D021 because a candidate is newer/larger or wins an aggregate score. Decision-critical misses and lifecycle/lineage safety remain hard constraints.
 
-## Workstream C proof — complete
+## Workstream F proof — complete
 
-Implementation landed in core PR #61 / squash:
+Implementation landed in core PR #64 / squash:
 
-`f5634412222e8d86173eb6e8e364f3414a6f3cd6`
+`42dab94b51a7b17f20c046f7257b912fe9f0c900`
 
 Landed artifacts:
 
-- `src/dkg/context_security.py`;
-- `src/dkg/poisoning_eval.py`;
-- `benchmarks/post-gate2/retrieval-poisoning-v1.json`;
-- `scripts/run_post_gate2_retrieval_poisoning.py`;
-- `tests/test_context_security.py`;
-- `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`.
+- `src/dkg/execution_receipt.py`;
+- `schemas/query-execution-receipt/v1.schema.json`;
+- `tests/test_execution_receipt.py`;
+- `scripts/run_post_gate2_query_receipt.py`;
+- `docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md`;
+- observability-only resolver diagnostics in `src/dkg/answer_pipeline.py` and `src/dkg/context_security.py`.
 
-The provider-independent structural boundary is `fossil-untrusted-context-v1`:
+The receipt schema is `fossil.query-execution-receipt.v1` and its authority is explicitly `execution_observability_only`.
 
-- known stable IDs are re-resolved from mounted durable documents;
-- retrieved payload metadata cannot self-author lifecycle/relation/citation/pack truth;
-- unknown in-scope payloads are demoted to non-authoritative `untrusted_context`;
-- out-of-scope pack payloads are removed;
-- exact duplicate unknown passages are collapsed;
-- answer/model output is candidate-only with no executable tool/action surface;
-- emitted claim text/citation identity is re-resolved from mounted durable claims;
-- invalid claim IDs are contained as `insufficient_evidence`;
-- proposal-before-commit and deterministic domain gates remain authoritative.
+It records query identity, exact pack mounts and scope, projection/build identity, route/policy, requested and actual services/models/providers, bounded fallback attempts, candidate stable IDs/scores, reranker identity, resolver effects, final context/citation IDs, outcome/abstention, latency/cost, and trace/run references. Credential-shaped diagnostic keys are filtered, but this is not general DLP.
 
 Final normal CI:
 
-- run `31436499505`;
-- job `93611686820`;
-- **100 passed in 1.07s**.
+- run `31437754923`;
+- job `93615632123`;
+- **104 passed in 1.04s**.
 
-Execution-only PR #62 ran the unchanged eight-case adversarial plan against exact pack pins and was closed unmerged.
+Execution-only PR #65 ran the exact-pin replay proof and was closed unmerged.
 
 Proof:
 
-- run `31436425791`;
-- job `93611459472`;
-- **100 core tests passed in 0.96s**;
+- run `31437447245`;
+- job `93614630416`;
+- **104 core tests passed in 2.41s**;
 - **27 projected documents**;
-- benchmark **PASS 8/8**;
-- final-answer correctness `1.0`;
-- outcome accuracy `1.0`;
-- citation correctness `1.0`;
-- completeness `1.0`;
-- appropriate abstention `1.0`;
-- unsupported-claim rate `0.0`;
-- over-abstention `0.0`;
-- Brier score `0.0`;
-- high-confidence error rate `0.0`;
-- pack-isolation preservation `1.0`;
-- candidate-only authority `1.0`;
-- executable-output containment `1.0`;
-- durable-claim output boundary `1.0`;
-- aggregate security-boundary pass rate `1.0`.
+- **6 queries / 18 receipts**;
+- answer correctness `1.0`;
+- exact replay identity `1.0`;
+- resolver recording `1.0`;
+- semantic-result stability `1.0`;
+- service-change visibility `1.0`.
 
-The poisoned SQLite lifecycle case still returned `current_state_unresolved` using `clm_a047d79b8604fadbd44efdf4` with exact citation `cite_b4e13e4e1a809f76527311ba`.
+Exact replay changed telemetry only while execution/result identity remained stable. A controlled route/retriever-version change was visible under policy/services while preserving result identity and durable answers/citations.
 
-Do not claim a universal poisoning defense. See the C proof for residual risks.
+Projection identity used for the proof:
 
-## Workstream B anchor
+- `pack-fixture-retrieval-documents`;
+- version `1`;
+- build ID `packfix_59b82d8d50ab38ea68402db7`.
 
-Workstream B landed in PR #57 / squash:
+The receipt is observability/replay evidence, not truth authority or a mutation capability.
+
+## Workstream C / B authority anchors
+
+C landed in PR #61 / squash:
+
+`f5634412222e8d86173eb6e8e364f3414a6f3cd6`
+
+`fossil-untrusted-context-v1` re-resolves known retrieved IDs from mounted durable documents, demotes unknown context, enforces pack scope, contains executable/output escape, and keeps model output candidate-only. C's exact-pin proof passed 8/8.
+
+B landed in PR #57 / squash:
 
 `483772ac0e1d441719aec42658ae00b62a032c11`
 
-Its failed-first real-corpus proof established that top-k can omit a stale claim even when a durable relation points to it. `fossil-lineage-context-v1` resolves stable relation endpoints before model execution. Final unchanged B benchmark proof: PR #59, run `31433427436`, job `93602011104`, PASS 6/6 with exact citations.
+`fossil-lineage-context-v1` resolves durable relation endpoints before model execution. The failed-first B proof established: **top-k absence is not evidence of nonexistence**.
 
-D021 therefore continues to include: **top-k absence is not evidence of nonexistence**.
+The SQLite regression remains:
+
+- outcome `current_state_unresolved`;
+- claim `clm_a047d79b8604fadbd44efdf4`;
+- exact citation `cite_b4e13e4e1a809f76527311ba`.
 
 ## D021 remains frozen
 
@@ -135,23 +130,45 @@ Current rules:
 - retrieval score is not truth;
 - reranker score is not truth;
 - model confidence is not truth;
-- multi-model consensus is not external evidence.
+- multi-model consensus is not external evidence;
+- query execution receipts are observability/replay evidence, not truth authority.
 
 Stable pack IDs:
 
 - common: `pack_269099f7b2ba43b7a99b9427d64092de`;
 - AI systems: `pack_f024177f89a5442db84171c3dd7f58e5`.
 
-Exact pack revisions used by the B/C proofs:
+Exact pack revisions used by B/C/F proofs:
 
 - `fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
 - `fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`.
 
 Do not casually rename `src/dkg`.
 
+## Workstream D measurement rules
+
+Compare at minimum:
+
+- full retrieval misses / hit rate;
+- recall@k;
+- MRR / ranking quality;
+- final-answer correctness where applicable;
+- exact citation correctness / unsupported-claim rate;
+- current-vs-superseded leakage;
+- lineage / multi-target historical-current failures;
+- poisoning/context-security compatibility;
+- pack isolation violations;
+- latency;
+- memory/resource use;
+- provider/runner cost;
+- outage/fallback behavior;
+- exact requested and actual provider/model/service/runtime identity.
+
+Use the same exact corpus pins and matched candidate budgets where comparisons are meant to be fair. Hardware/runtime/precision/quantization differences must stay visible.
+
 ## LiteLLM / Cortex boundary
 
-Read `docs/operations/LITELLM-GATEWAY.md` before live model work.
+Read `docs/operations/LITELLM-GATEWAY.md` before live provider work.
 
 Recorded LiteLLM defaults at this handoff:
 
@@ -159,19 +176,18 @@ Recorded LiteLLM defaults at this handoff:
 - embeddings: `gemini-embedding-2`;
 - reranking: `rerank-v4-pro`.
 
-For every live benchmark and future Workstream-F receipt, record requested model, actual model, provider, fallback/attempt diagnostics, latency, cost, and runtime identity. A fallback response is not proof that the requested model succeeded. Probe embedding and reranking lanes independently. Do not send secrets, personal information, or confidential documents while gateway retention guarantees remain unverified.
+For every live D candidate, record requested model, actual model, provider, fallback/attempt diagnostics, latency, cost, runtime identity, and exact model/configuration identity where available. A fallback response is not proof that the requested model succeeded. Probe embedding and reranking lanes independently. Do not send secrets, personal information, or confidential documents while gateway retention guarantees remain unverified.
 
-Cortex v4 may be used as a replaceable cognitive-service/orchestration competitor, but FOSSIL durable storage, stable identity, lifecycle/lineage, context-security, proposal-before-commit, and correctness guarantees must not couple to Cortex internals. Multiple agents agreeing does not manufacture truth. Future worker/model invocations should fit the Workstream-F receipt without changing that authority model.
+Cortex v4 remains a replaceable cognitive-service/orchestration competitor. FOSSIL durable storage, stable identity, lifecycle/lineage, context-security, proposal-before-commit, and correctness guarantees must not couple to Cortex internals. Multiple agents agreeing does not manufacture truth.
 
 ## Remaining campaign order
 
-1. **F** — reproducible query execution receipt;
-2. **D / Issue #47** — embeddings, hybrid retrieval, rerankers, model bakeoff;
-3. **E** — conservative adaptive routing, only if benchmark justified;
-4. **G** — ACL/redaction propagation readiness;
-5. final D021/retrieval-policy decision reconciliation;
-6. decision log + residual risks + final handoff.
+1. **D / Issue #47** — embeddings, hybrid retrieval, rerankers, model bakeoff;
+2. **E** — conservative adaptive routing, only if benchmark justified;
+3. **G** — ACL/redaction propagation readiness;
+4. final D021/retrieval-policy decision reconciliation;
+5. decision log + residual risks + final handoff.
 
 ## Suggested next-session prompt
 
-> Continue FOSSIL Issue #48 from this handoff. Verify GitHub first. Workstreams A, B, and C are complete; do not redo them. C landed in PR #61 / squash `f5634412222e8d86173eb6e8e364f3414a6f3cd6`; exact-pin execution proof PR #62 was closed unmerged after run `31436425791`, job `93611459472`, with 100 core tests, 27 documents, adversarial PASS 8/8, exact answer/citation/security-boundary metrics at 1.0, and unsupported-claim rate 0.0. Begin Workstream F: a compact reproducible query execution receipt and replay proof. Preserve D021, stable pack IDs, `fossil-lineage-context-v1`, `fossil-untrusted-context-v1`, proposal-before-commit, and deterministic lifecycle/lineage authority. The receipt is observability/evidence, not truth authority.
+> Continue FOSSIL Issue #48 / Workstream D from this handoff. Verify GitHub first. Workstreams A, B, C, and F are complete; do not redo them. F landed in PR #64 / squash `42dab94b51a7b17f20c046f7257b912fe9f0c900`; final CI run `31437754923`, job `93615632123`, was 104/104 green. Execution-only PR #65 was closed unmerged after exact-pin run `31437447245`, job `93614630416`: 27 documents, 6 queries, 18 receipts, with answer correctness / exact replay identity / resolver recording / semantic-result stability / service-change visibility all 1.0. Issue #47 is active Workstream D. Start with comparable incumbent BM25/dense/hybrid/reranker evidence using `fossil.query-execution-receipt.v1`, then progress Qwen3-Embedding 0.6B → 4B → 8B only if justified. Preserve D021, stable pack IDs, `fossil-lineage-context-v1`, `fossil-untrusted-context-v1`, proposal-before-commit, and deterministic lifecycle/lineage authority. Receipts and model/reranker scores are not truth authority.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -2,9 +2,8 @@
 
 **Project:** **FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage**  
 **Durable substrate:** **DICS — Durable Intellectual Corpus System**  
-**Completed:** **Milestone 0 / Gate 1; Gate 2; Issue #48 research ingestion; Issue #48 Workstreams A, B, and C**  
-**Active work:** **Issue #48 Workstream F — reproducible query execution receipt**  
-**Related workstream:** **Issue #47 — embedding/reranker/model-scale bakeoff**  
+**Completed:** **Milestone 0 / Gate 1; Gate 2; Issue #48 research ingestion; Issue #48 Workstreams A, B, C, and F**  
+**Active work:** **Issue #48 Workstream D / Issue #47 — retrieval/reranking/model bakeoff**  
 **Control plane:** GitHub issues + durable repository docs  
 **Last updated:** 2026-08-10
 
@@ -21,14 +20,15 @@ Repository/database/graph placement is physical placement, not knowledge identit
 1. `AGENTS.md`
 2. `ARCHITECTURE.md`
 3. `docs/HANDOFF_CURRENT.md`
-4. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-retrieval-poisoning.md`
+4. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-query-execution-receipt.md`
 5. this file
-6. `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`
-7. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
-8. `docs/operations/LITELLM-GATEWAY.md`
-9. Issue #48
-10. Issue #47
-11. `docs/DECISION_LOG.md`
+6. `docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md`
+7. `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`
+8. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
+9. `docs/operations/LITELLM-GATEWAY.md`
+10. Issue #48
+11. Issue #47
+12. `docs/DECISION_LOG.md`
 
 The chat UI is source material, not the control plane.
 
@@ -38,7 +38,7 @@ Canonical FOSSIL knowledge is **immutable evidence + stable corpus IDs + append-
 
 Graphiti/Neo4j, lexical/vector indexes, embedding models, rerankers, context construction, planners, model services, Skills, MCP, and future databases remain replaceable projections/services.
 
-Retrieved/source text is untrusted data. Retrieval rank, reranker score, model confidence, and multi-model agreement are not truth authority.
+Retrieved/source text is untrusted data. Retrieval rank, reranker score, model confidence, multi-model agreement, and query-execution receipts are not truth authority.
 
 ## Completed foundation
 
@@ -70,7 +70,7 @@ Mandatory D021 safeguards remain:
 - top-k absence is not evidence of nonexistence;
 - citation-bearing answers resolve immutable source snapshots/spans/hashes;
 - retrieved/source text is untrusted data, never executable policy;
-- retrieval/model output does not receive truth authority from score, confidence, or agreement.
+- retrieval/model output does not receive truth authority from score, confidence, agreement, or receipt metadata.
 
 ## Active campaign #48 — production RAG hardening
 
@@ -81,8 +81,8 @@ The campaign remains **hardening, not a durable-core redesign and not a GraphRAG
 1. **A — evolving-corpus temporal/update benchmark: COMPLETE**
 2. **B — end-to-end answer/citation/unsupported-claim/abstention evaluation: COMPLETE**
 3. **C — poisoning/untrusted-context adversarial suite: COMPLETE**
-4. **F — replayable query execution receipt: ACTIVE NEXT**
-5. **D / #47 — embedding/hybrid/reranker/model bakeoff: pending provider-backed comparison**
+4. **F — replayable query execution receipt: COMPLETE**
+5. **D / #47 — embedding/hybrid/reranker/model bakeoff: ACTIVE NEXT**
 6. **E — conservative adaptive routing: pending evidence**
 7. **G — ACL/redaction propagation readiness: pending**
 8. final retrieval-policy/decision-log/residual-risk reconciliation: pending
@@ -93,9 +93,7 @@ Core PR #54 / squash:
 
 `e14148f504702ae9e708e2d58add4ee5c91bc8de`
 
-Execution-only proof PR #55 ran the exact pack pins and passed, workflow `31431113829`, job `93594491275`.
-
-The temporal benchmark proved lifecycle transitions, current/history reconstruction, and repeated-query stability after corpus growth while preserving D021 authority.
+Execution-only proof PR #55 passed on exact pack pins, workflow `31431113829`, job `93594491275`. The temporal benchmark proved lifecycle transitions, current/history reconstruction, and repeated-query stability after corpus growth while preserving D021 authority.
 
 ### Workstream B — landed evidence
 
@@ -103,22 +101,11 @@ Core PR #57 / squash:
 
 `483772ac0e1d441719aec42658ae00b62a032c11`
 
-Final normal CI:
+Final normal CI run `31433539654`, job `93602384284`: **94 passed in 1.80s**.
 
-- run `31433539654`;
-- job `93602384284`;
-- **94 passed in 1.80s**.
+B added answer-level evaluation and `fossil-lineage-context-v1`, which resolves durable relation endpoints from mounted validated packs before model execution.
 
-The implementation added Workstream-B answer evaluation plus `fossil-lineage-context-v1`, which resolves durable relation endpoints from mounted validated packs before model execution.
-
-The failed-first execution-only PR #58 correctly exposed that top-k can omit a stale dependent claim even when its durable `DEPENDS_ON` relation is present. The unchanged benchmark then passed in execution-only PR #59, run `31433427436`, job `93602011104`:
-
-- **94 core tests passed**;
-- **27 projected documents**;
-- benchmark **PASS 6/6**;
-- final-answer/outcome/citation/completeness/appropriate-abstention rates `1.0`;
-- unsupported-claim and over-abstention rates `0.0`;
-- Brier score and high-confidence error rate `0.0`.
+The failed-first execution PR #58 proved a durable relation can identify a relevant stale claim omitted from top-k. The unchanged benchmark then passed in execution-only PR #59, run `31433427436`, job `93602011104`: 94 core tests, 27 documents, PASS 6/6, answer/outcome/citation/completeness/appropriate-abstention rates `1.0`, unsupported/over-abstention/Brier/high-confidence-error rates `0.0`.
 
 The SQLite case resolves `current_state_unresolved` via durable claim `clm_a047d79b8604fadbd44efdf4` with exact citation `cite_b4e13e4e1a809f76527311ba`.
 
@@ -128,13 +115,9 @@ Core PR #61 / squash:
 
 `f5634412222e8d86173eb6e8e364f3414a6f3cd6`
 
-Final normal CI:
+Final normal CI run `31436499505`, job `93611686820`: **100 passed in 1.07s**.
 
-- run `31436499505`;
-- job `93611686820`;
-- **100 passed in 1.07s**.
-
-The provider-independent `fossil-untrusted-context-v1` boundary:
+`fossil-untrusted-context-v1`:
 
 - re-resolves known retrieved stable IDs from mounted durable documents;
 - prevents retrieved payload metadata from self-authoring lifecycle/relation/citation/pack truth;
@@ -147,50 +130,82 @@ The provider-independent `fossil-untrusted-context-v1` boundary:
 - contains unknown claim IDs as `insufficient_evidence`;
 - leaves proposal-before-commit and deterministic mutation gates authoritative.
 
-Execution-only PR #62 ran the unchanged eight-case plan against:
+Execution-only PR #62 passed the unchanged eight-case plan on the exact B/C pins, run `31436425791`, job `93611459472`: 100 core tests, 27 documents, PASS 8/8, answer/citation/security-boundary metrics `1.0`, unsupported-claim rate `0.0`. This remains a bounded structural proof, not universal poisoning resistance.
 
-- `fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
-- `fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`.
+### Workstream F — landed evidence
 
-Final proof run `31436425791`, job `93611459472`:
+Core PR #64 / squash:
 
-- **100 core tests passed in 0.96s**;
-- **27 projected documents**;
-- adversarial benchmark **PASS 8/8**;
-- final-answer correctness `1.0`;
-- outcome accuracy `1.0`;
-- exact citation correctness `1.0`;
-- completeness `1.0`;
-- appropriate abstention `1.0`;
-- unsupported-claim rate `0.0`;
-- over-abstention `0.0`;
-- Brier score `0.0`;
-- high-confidence error rate `0.0`;
-- pack-isolation preservation `1.0`;
-- candidate-only authority `1.0`;
-- executable-output containment `1.0`;
-- durable-claim output boundary `1.0`;
-- aggregate security-boundary pass rate `1.0`.
+`42dab94b51a7b17f20c046f7257b912fe9f0c900`
 
-The poisoned SQLite case remained `current_state_unresolved` with the same durable claim/citation. This is a bounded structural proof, not universal poisoning resistance; residual risks are explicit in `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`.
+Final normal CI:
 
-### Workstream F — exact active target
+- run `31437754923`;
+- job `93615632123`;
+- **104 passed in 1.04s**.
 
-Define and prove a compact reproducible query execution receipt containing at minimum:
+F added `fossil.query-execution-receipt.v1` with authority `execution_observability_only`.
 
-- deterministic query identity/hash plus human-debuggable query reference;
-- mounted stable pack IDs and exact revisions;
+The receipt records:
+
+- human/debuggable + deterministic query identity;
+- mounted pack IDs/revisions and explicit retrieval pack scope;
+- projection/build identity;
 - route/retrieval-policy identity;
-- requested and actual provider/model/service/runtime identity, including fallback diagnostics;
-- retrieved candidate stable IDs and scores;
-- reranker identity/order when present;
-- lifecycle/lineage/context-security resolver identities and resolved stable IDs;
-- final model-bound context IDs and exact citation IDs;
-- final outcome/abstention;
-- latency/cost;
-- trace/run reference.
+- requested/actual service/model/provider identity and bounded fallback attempts;
+- ordered candidate stable IDs/scores and reranker identity;
+- context-security/lineage resolver identities and stable-ID effects;
+- final context and exact citation IDs;
+- outcome/abstention and candidate-only authority;
+- latency/cost and trace/run reference;
+- execution-identity and result-identity hashes.
 
-Keep verbose telemetry outside canonical durable knowledge. The receipt is execution observability/evidence, not truth authority. Prove important benchmark queries can be replayed after retriever/model/projection changes and that changed execution identity is visible rather than silently conflated.
+Credential-shaped diagnostic keys are filtered, but this is not general DLP. Verbose provider telemetry remains outside canonical durable knowledge.
+
+Execution-only PR #65 ran the exact-pin replay proof and was closed unmerged:
+
+- run `31437447245`;
+- job `93614630416`;
+- **104 core tests passed in 2.41s**;
+- **27 projected documents**;
+- **6 queries / 18 receipts**;
+- answer correctness `1.0`;
+- exact replay identity `1.0`;
+- resolver recording `1.0`;
+- semantic-result stability `1.0`;
+- service-change visibility `1.0`.
+
+Exact replay changed telemetry only. A controlled route/retriever-version change visibly changed execution identity under policy/services while durable result identity stayed stable.
+
+Proof projection identity:
+
+- `pack-fixture-retrieval-documents`;
+- version `1`;
+- build ID `packfix_59b82d8d50ab38ea68402db7`.
+
+See `docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md` for residual risks.
+
+### Workstream D / Issue #47 — exact active target
+
+Issue #47 is active and retitled **Workstream D: retrieval/reranking/model bakeoff (0.6B → 4B → 8B)**.
+
+Begin with comparable incumbent/hybrid/reranker evidence before model-scale escalation.
+
+Required lanes:
+
+- incumbent D021 dense retrieval;
+- BM25 under its explicit fallback/degraded role;
+- deterministic dense+lexical hybrid/RRF;
+- at least one real cross-encoder/API reranker behind `Reranker`;
+- contextualized retrieval only when reproducible and source/claim identity remains distinguishable;
+- Qwen3-Embedding 0.6B class first, then 4B, then 8B only when prior results/resources justify continuation;
+- optional BGE-M3/larger BGE family control when justified.
+
+Every candidate execution must emit or be representable by the Workstream-F receipt and preserve D021 authority boundaries.
+
+Compare at least full misses/hit rate, recall@k, MRR, answer/citation/unsupported-claim behavior where applicable, current-vs-superseded leakage, lineage failures, poisoning/context-security compatibility, pack isolation, latency, memory, cost, outage/fallback behavior, and exact requested/actual provider/model/runtime identity.
+
+A newer/larger candidate cannot replace D021 on aggregate score alone. Decision-critical misses and lifecycle/lineage safety are hard constraints.
 
 ## Research-to-corpus state
 
@@ -218,9 +233,9 @@ Existing replaceable service contracts include:
 - `ModelService`;
 - `VerificationService`.
 
-LiteLLM defaults currently recorded in `docs/operations/LITELLM-GATEWAY.md` are `qwen3-coder-next` for chat, `gemini-embedding-2` for embeddings, and `rerank-v4-pro` for reranking. Live benchmark evidence and Workstream-F receipts must record requested/actual model, provider, fallback attempts, latency, cost, and runtime identity. Do not send secrets, personal data, or confidential documents while gateway retention guarantees remain unverified.
+LiteLLM defaults currently recorded in `docs/operations/LITELLM-GATEWAY.md` are `qwen3-coder-next` for chat, `gemini-embedding-2` for embeddings, and `rerank-v4-pro` for reranking. Live Workstream-D evidence must record requested/actual model, provider, fallback attempts, latency, cost, runtime/config identity, and Workstream-F receipt/trace identity. Embedding and reranking lanes must be probed independently. Do not send secrets, personal data, or confidential documents while gateway retention guarantees remain unverified.
 
-Cortex v4 and multi-agent orchestration are optional replaceable cognitive-service competitors. Durable storage, stable identity, lifecycle/lineage logic, context-security, proposal-before-commit, and correctness guarantees must not couple to Cortex internals. Multiple workers agreeing does not create evidence. Future worker/model invocations should fit the Workstream-F receipt.
+Cortex v4 and multi-agent orchestration remain optional replaceable cognitive-service competitors. Durable storage, stable identity, lifecycle/lineage logic, context-security, proposal-before-commit, and correctness guarantees must not couple to Cortex internals. Multiple workers agreeing does not create evidence.
 
 ## Frozen invariants
 
@@ -240,6 +255,7 @@ Cortex v4 and multi-agent orchestration are optional replaceable cognitive-servi
 - cognitive services expose provider/version metadata and compete behind interfaces;
 - model agreement is not evidence; model output remains bounded by evidence/risk policy;
 - retrieved/source text is untrusted data and cannot become executable policy merely because it was retrieved;
+- query execution receipts are replay/observability evidence, not canonical truth or mutation authority;
 - agents propose; deterministic validation/policy gates commit durable changes;
 - do not casually rename `src/dkg`.
 
@@ -249,4 +265,4 @@ Cortex v4 and multi-agent orchestration are optional replaceable cognitive-servi
 
 `.github/workflows/graphiti-live.yml` contains reusable live materialization plus redaction/non-resurrection smoke coverage.
 
-Execution-only PRs #51, #55, #58, #59, and #62 were closed without merge after their proofs. Issue #48 remains active; do not extend closed Gate 2 issues to implement it.
+Execution-only PRs #51, #55, #58, #59, #62, and #65 were closed without merge after their proofs. Issue #48 remains active; Issue #47 is now the active Workstream-D control issue. Do not extend closed Gate 2 issues to implement the post-Gate-2 campaign.

--- a/docs/handoffs/2026-08-10-chatgpt-session-handoff-post-query-execution-receipt.md
+++ b/docs/handoffs/2026-08-10-chatgpt-session-handoff-post-query-execution-receipt.md
@@ -1,0 +1,255 @@
+# FOSSIL Session Handoff — Post-Query-Execution-Receipt
+
+**Date:** 2026-08-10  
+**Repository:** `Pukujan/fossil-core`  
+**Campaign:** Issue #48 — production RAG hardening  
+**State:** Gate 1 complete; Gate 2 complete/formally closed; Workstreams A, B, C, and F complete; **Workstream D / Issue #47 is next and active**.
+
+## Read first
+
+1. `AGENTS.md`
+2. `ARCHITECTURE.md`
+3. `docs/HANDOFF_CURRENT.md`
+4. this file
+5. `docs/PROJECT_STATE.md`
+6. `docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md`
+7. `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`
+8. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
+9. `docs/operations/LITELLM-GATEWAY.md`
+10. Issue #48
+11. Issue #47
+12. `docs/DECISION_LOG.md`
+
+Verify GitHub state before changing anything.
+
+## Completed work — do not redo
+
+- production-RAG research trace + AI-systems ingestion;
+- Workstream A — evolving-corpus / temporal benchmark;
+- Workstream B — end-to-end answer/citation/abstention reliability;
+- Workstream C — retrieval poisoning / untrusted-context hardening;
+- Workstream F — reproducible query execution receipt + replay proof.
+
+## Workstream F — landed
+
+Core PR #64 landed with squash:
+
+`42dab94b51a7b17f20c046f7257b912fe9f0c900`
+
+Landed artifacts:
+
+- `src/dkg/execution_receipt.py`;
+- `schemas/query-execution-receipt/v1.schema.json`;
+- `tests/test_execution_receipt.py`;
+- `scripts/run_post_gate2_query_receipt.py`;
+- `docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md`;
+- observability-only resolver diagnostics in `src/dkg/answer_pipeline.py` and `src/dkg/context_security.py`.
+
+The receipt contract is:
+
+`fossil.query-execution-receipt.v1`
+
+Its authority is explicitly:
+
+`execution_observability_only`
+
+The receipt is not canonical durable knowledge, does not become truth authority, and cannot authorize mutation.
+
+### Receipt fields
+
+The compact receipt records:
+
+- query ID, text, normalized query, and deterministic SHA-256;
+- mounted stable pack IDs and exact revisions;
+- explicit retrieval pack scope separate from mounts;
+- projection name/version/build ID;
+- route/retrieval-policy identity;
+- requested and actual provider/model/service identity;
+- bounded fallback/attempt diagnostics;
+- candidate stable IDs, pack IDs, rank/score, plus base/rerank scores when available;
+- reranker service identity when present;
+- `fossil-untrusted-context-v1` and `fossil-lineage-context-v1` resolver identities and stable-ID effects;
+- final model-bound context IDs and exact citation IDs;
+- outcome/abstention, emitted durable claim IDs, confidence, and candidate-only authority;
+- latency/cost and trace/run reference;
+- execution-identity and result-identity hashes.
+
+Credential-shaped runtime/attempt fields are recursively removed by key-name filtering. This is a compact safeguard, not general DLP.
+
+### Replay semantics
+
+`execution_identity_sha256` excludes ordinary timing/run-reference telemetry. `result_sha256` covers retrieved candidates, resolver effects, final context, and durable result.
+
+The replay comparator separates query/corpus/scope/projection/policy/service/retrieval/resolver/context/result changes from telemetry-only changes.
+
+This is the observability substrate for Workstream D/#47; it does not make candidate scores authoritative.
+
+## Workstream F proof
+
+Final normal PR #64 CI:
+
+- run `31437754923`;
+- job `93615632123`;
+- **104 passed in 1.04s**.
+
+Execution-only PR #65 ran the exact-pin replay proof and was closed unmerged by design.
+
+Proof:
+
+- run `31437447245`;
+- job `93614630416`;
+- **104 core tests passed in 2.41s**;
+- **27 projected documents**;
+- **6 Workstream-B queries**;
+- **18 receipts** — baseline, exact replay, controlled route/service-version variant for every query;
+- answer correctness `1.0`;
+- exact replay identity `1.0`;
+- resolver recording `1.0`;
+- semantic result stability `1.0`;
+- service-change visibility `1.0`.
+
+Exact replay behavior:
+
+- same logical query/corpus/scope/projection/policy/services;
+- `changed_dimensions: []`;
+- execution identity matches;
+- result identity matches;
+- telemetry changes as expected.
+
+Controlled variant behavior:
+
+- route changed from `d021-answer-baseline-v1` to `workstream-f-service-version-probe`;
+- retriever implementation version changed from `answer-reliability-baseline-v1` to `query-receipt-replay-probe-v2`;
+- execution identity changed visibly under `policy` / `services`;
+- result identity and semantic durable answer remained stable.
+
+Projection used for the proof:
+
+- name `pack-fixture-retrieval-documents`;
+- version `1`;
+- build ID `packfix_59b82d8d50ab38ea68402db7`.
+
+Residual risks are explicit in the proof document. In particular, deterministic local replay does not establish hosted-provider determinism; compact key-name sanitization is not general DLP; trace retention is external; hashes are not trusted signing; and future Cortex/multi-worker runs may need causal child-invocation IDs.
+
+## Workstream C / B authority anchors
+
+C landed in PR #61 / squash:
+
+`f5634412222e8d86173eb6e8e364f3414a6f3cd6`
+
+`fossil-untrusted-context-v1` structurally prevents retrieved payloads from self-authoring lifecycle/relation/citation/pack authority and keeps model output candidate-only.
+
+B landed in PR #57 / squash:
+
+`483772ac0e1d441719aec42658ae00b62a032c11`
+
+`fossil-lineage-context-v1` resolves durable relation endpoints before model execution. The failed-first B proof established the frozen lesson: **top-k absence is not evidence of nonexistence**.
+
+The SQLite regression remains:
+
+- outcome `current_state_unresolved`;
+- claim `clm_a047d79b8604fadbd44efdf4`;
+- exact citation `cite_b4e13e4e1a809f76527311ba`.
+
+## Exact next workstream — D / Issue #47
+
+Issue #47 is now active and retitled:
+
+**Workstream D: retrieval/reranking/model bakeoff (0.6B → 4B → 8B)**
+
+Begin with comparable incumbent/hybrid/reranker evidence before escalating model size.
+
+Required lanes:
+
+1. incumbent D021 dense retrieval;
+2. BM25 in its explicit degraded/fallback role;
+3. deterministic dense+lexical hybrid/RRF;
+4. at least one real cross-encoder/API reranker behind `Reranker`;
+5. contextualized retrieval only if construction is reproducible and source/claim identity remains distinguishable;
+6. Qwen3-Embedding 0.6B class first, then 4B, then 8B only if evidence/resources justify continuing;
+7. optional BGE-M3/larger BGE family control if justified.
+
+Every candidate/configuration must pin exact model/revision/runtime/library/precision/hardware details and emit or be representable by `fossil.query-execution-receipt.v1`.
+
+Compare at minimum:
+
+- full misses / hit rate;
+- recall@k;
+- MRR;
+- final-answer correctness where applicable;
+- exact citation correctness / unsupported claims;
+- current-vs-superseded leakage;
+- lineage/historical-current failures;
+- poisoning/context-security compatibility;
+- pack isolation;
+- latency/memory/cost;
+- outage/fallback behavior;
+- requested versus actual provider/model/runtime identity.
+
+Do not replace D021 because a newer/larger model wins an aggregate score. Decision-critical misses and lifecycle/lineage safety remain hard constraints.
+
+### Suggested immediate D sequence
+
+1. inspect existing Gate-2/post-Gate-2 retrieval benchmark runners and `real_retrieval.py` adapters;
+2. define a versioned Workstream-D comparison plan that reuses exact corpus pins and Workstream-F receipts;
+3. rerun comparable incumbent BM25/dense baseline;
+4. add/measure deterministic hybrid/RRF using existing service interfaces;
+5. add one real reranker candidate behind `Reranker` and independently prove requested/actual/fallback identity;
+6. only then begin the 0.6B → 4B → 8B embedding progression.
+
+## D021 remains frozen
+
+Do not replace or weaken D021 without new committed benchmark evidence.
+
+Current rules:
+
+- revision-pinned BGE dense is the normal primary retriever;
+- BM25 is explicit degraded availability fallback;
+- current/latest/accepted queries resolve durable lifecycle/provenance;
+- history/lineage/disagreement queries resolve durable lineage/read state;
+- top-k absence is not evidence of nonexistence;
+- citations resolve immutable source snapshot/span/hash identity;
+- retrieved/source text is untrusted data, never executable policy;
+- retrieval score is not truth;
+- reranker score is not truth;
+- model confidence is not truth;
+- multi-model consensus is not external evidence;
+- query execution receipts are observability/replay evidence, not truth authority.
+
+Stable pack IDs:
+
+- common: `pack_269099f7b2ba43b7a99b9427d64092de`;
+- AI systems: `pack_f024177f89a5442db84171c3dd7f58e5`.
+
+Exact pack revisions used by B/C/F proofs:
+
+- `fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
+- `fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`.
+
+Do not casually rename `src/dkg`.
+
+## LiteLLM / Cortex boundary
+
+Read `docs/operations/LITELLM-GATEWAY.md` before live provider work.
+
+Recorded LiteLLM defaults remain:
+
+- chat: `qwen3-coder-next`;
+- embeddings: `gemini-embedding-2`;
+- reranking: `rerank-v4-pro`.
+
+For every live D candidate record requested model, actual model, provider, fallback/attempt diagnostics, latency, cost, runtime identity, exact model revision/configuration where available, and the Workstream-F receipt/trace reference. A fallback response is not proof that the requested model succeeded. Probe embedding and reranking lanes independently. Do not send secrets, personal information, or confidential documents while retention guarantees remain unverified.
+
+Cortex v4 remains replaceable. FOSSIL stable identity, durable storage, lifecycle/lineage, context-security, proposal-before-commit, and correctness guarantees must not couple to Cortex internals. Multiple workers agreeing does not manufacture truth. Future worker/model invocations can extend the receipt with causal child-invocation structure without changing FOSSIL authority.
+
+## Remaining campaign order
+
+1. **D / Issue #47** — embeddings, hybrid retrieval, rerankers, model bakeoff;
+2. **E** — conservative adaptive routing, only if benchmark justified;
+3. **G** — ACL/redaction propagation readiness;
+4. final D021/retrieval-policy decision reconciliation;
+5. decision log + residual risks + final handoff.
+
+## Suggested next-session prompt
+
+> Continue FOSSIL Issue #48 / Workstream D from the post-query-execution-receipt handoff. Verify GitHub first. Workstreams A, B, C, and F are complete; do not redo them. F landed in PR #64 / squash `42dab94b51a7b17f20c046f7257b912fe9f0c900`; final CI run `31437754923`, job `93615632123`, was 104/104 green. Execution-only PR #65 was closed unmerged after exact-pin run `31437447245`, job `93614630416`: 27 documents, 6 queries, 18 receipts, with answer correctness / exact replay identity / resolver recording / semantic-result stability / service-change visibility all 1.0. Issue #47 is active Workstream D. Start with comparable incumbent BM25/dense/hybrid/reranker evidence using `fossil.query-execution-receipt.v1`, then progress Qwen3-Embedding 0.6B → 4B → 8B only if justified. Preserve D021, stable pack IDs, `fossil-lineage-context-v1`, `fossil-untrusted-context-v1`, proposal-before-commit, and deterministic lifecycle/lineage authority. Receipts and model/reranker scores are not truth authority.


### PR DESCRIPTION
Reconciles project state after Issue #48 Workstream F.

## What changed

- adds a dated post-query-execution-receipt handoff;
- records PR #64 / squash `42dab94b51a7b17f20c046f7257b912fe9f0c900` and execution-only PR #65 replay proof;
- updates `docs/HANDOFF_CURRENT.md` and `docs/PROJECT_STATE.md` so A/B/C/F are complete and D / Issue #47 is the exact next workstream;
- points the next session at the active Issue #47 retrieval/hybrid/reranker/model bakeoff and Workstream-F receipt requirements.

Docs/state only. No code, D021, pack identity, or authority-policy changes.

Refs #48 and #47.