### PR TITLE
Workstream D: add matched retrieval and reranker bakeoff

### DIFF
--- a/benchmarks/post-gate2/retrieval-bakeoff-v1.json
+++ b/benchmarks/post-gate2/retrieval-bakeoff-v1.json
@@ -22,7 +22,10 @@
     },
     "cross_encoder": {
       "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
-      "revision": "ce0834f22110de6d9222af7a7a03628121708969"
+      "revision": "ce0834f22110de6d9222af7a7a03628121708969",
+      "device": "cpu",
+      "batch_size": 16,
+      "max_length": 512
     }
   },
   "routes": [

--- a/benchmarks/post-gate2/retrieval-bakeoff-v1.json
+++ b/benchmarks/post-gate2/retrieval-bakeoff-v1.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": "fossil.retrieval-bakeoff-plan.v1",
+  "benchmark_id": "post-gate2-retrieval-bakeoff-v1",
+  "description": "Issue #48 Workstream D first-stage matched retrieval/reranker bakeoff. This plan establishes comparable incumbent, lexical, hybrid, lifecycle-aware, and pinned local cross-encoder evidence before any embedding-model scale escalation.",
+  "pack_pins": {
+    "fossil-common": "d583005dce06dbb499c3c0de5c22b899655eb8d2",
+    "fossil-ai-systems": "84accd2ee895663990e82ca5b79b592cb503db24"
+  },
+  "stable_pack_ids": {
+    "fossil-common": "pack_269099f7b2ba43b7a99b9427d64092de",
+    "fossil-ai-systems": "pack_f024177f89a5442db84171c3dd7f58e5"
+  },
+  "retrieval_case_set": "benchmarks/gate2/real-corpus-history-v2.json",
+  "answer_case_set": "benchmarks/post-gate2/answer-reliability-v1.json",
+  "retrieval_limit": 5,
+  "candidate_multiplier": 4,
+  "rrf_k": 60,
+  "models": {
+    "incumbent_embedding": {
+      "model": "BAAI/bge-small-en-v1.5",
+      "revision": "5c38ec7c405ec4b44b94cc5a9bb96e735b38267a"
+    },
+    "cross_encoder": {
+      "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
+      "revision": "ce0834f22110de6d9222af7a7a03628121708969"
+    }
+  },
+  "routes": [
+    {
+      "route_id": "d021-bm25-degraded-v1",
+      "name": "bm25",
+      "role": "explicit-degraded-fallback"
+    },
+    {
+      "route_id": "d021-bge-dense-v1",
+      "name": "bge-dense",
+      "role": "incumbent-primary"
+    },
+    {
+      "route_id": "workstream-d-bge-bm25-rrf-v1",
+      "name": "bge-bm25-rrf",
+      "role": "hybrid-candidate"
+    },
+    {
+      "route_id": "workstream-d-bge-bm25-rrf-lifecycle-v1",
+      "name": "bge-bm25-rrf-lifecycle",
+      "role": "hybrid-deterministic-lifecycle-candidate"
+    },
+    {
+      "route_id": "workstream-d-bge-dense-crossencoder-v1",
+      "name": "bge-dense-crossencoder",
+      "role": "real-reranker-candidate"
+    },
+    {
+      "route_id": "workstream-d-bge-bm25-rrf-crossencoder-v1",
+      "name": "bge-bm25-rrf-crossencoder",
+      "role": "hybrid-real-reranker-candidate"
+    }
+  ],
+  "guardrails": {
+    "retrieval_scores_are_truth": false,
+    "reranker_scores_are_truth": false,
+    "receipt_is_truth_authority": false,
+    "d021_changes_from_this_plan_alone": false,
+    "decision_critical_misses_are_hard_constraint": true,
+    "lifecycle_lineage_safety_is_hard_constraint": true,
+    "all_answer_runs_use_context_security": "fossil-untrusted-context-v1",
+    "all_answer_runs_use_lineage_resolution": "fossil-lineage-context-v1"
+  },
+  "next_stage": "Only after this matched baseline/hybrid/reranker evidence is committed should Workstream D progress to Qwen3-Embedding 0.6B, then 4B and 8B if prior results and resources justify continuing."
+}

--- a/docs/implementation/2026-08-10-post-gate2-retrieval-bakeoff-stage1-proof.md
+++ b/docs/implementation/2026-08-10-post-gate2-retrieval-bakeoff-stage1-proof.md
@@ -1,0 +1,188 @@
+# Post-Gate-2 Workstream D — Retrieval / Reranker Bakeoff Stage-1 Proof
+
+**Date:** 2026-08-10  
+**Campaign:** Issue #48 — production RAG hardening  
+**Workstream:** D / Issue #47 — retrieval, reranking, and model bakeoff  
+**Stage:** 1 — incumbent + lexical + hybrid + real reranker baseline
+
+## Scope
+
+This stage establishes matched, receipt-backed evidence for the existing D021 retrieval stack and a small set of hybrid/reranker challengers **before** any Qwen3 embedding-model scale progression.
+
+It does not replace or weaken D021.
+
+The governing rule remains:
+
+> Retrieval and reranker scores order candidates; they do not create durable truth.
+
+Every downstream answer run remains behind:
+
+- `fossil-untrusted-context-v1`;
+- `fossil-lineage-context-v1`;
+- the Workstream-B deterministic answer evaluator;
+- Workstream-F `fossil.query-execution-receipt.v1` observability.
+
+Query execution receipts remain `execution_observability_only`; they are not mutation authority or canonical knowledge.
+
+## Exact corpus pins
+
+The stage-1 execution uses the same validated pack revisions as Workstreams B, C, and F:
+
+- `Pukujan/fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
+- `Pukujan/fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`.
+
+Stable mounted pack IDs:
+
+- common: `pack_269099f7b2ba43b7a99b9427d64092de`;
+- AI systems: `pack_f024177f89a5442db84171c3dd7f58e5`.
+
+The projected corpus contains **27 documents**.
+
+## Exact candidate/runtime pins
+
+### Incumbent dense embedding
+
+- model: `BAAI/bge-small-en-v1.5`;
+- revision: `5c38ec7c405ec4b44b94cc5a9bb96e735b38267a`;
+- runtime: local Sentence Transformers on CPU;
+- role: incumbent D021 primary retrieval component.
+
+### Real cross-encoder reranker
+
+- model: `cross-encoder/ms-marco-MiniLM-L6-v2`;
+- revision: `ce0834f22110de6d9222af7a7a03628121708969`;
+- runtime: local Sentence Transformers `CrossEncoder` on CPU;
+- batch size: `16`;
+- max length: `512`;
+- role: candidate ordering only.
+
+The adapter is implemented by `SentenceTransformerCrossEncoderReranker` behind the existing FOSSIL `Reranker` contract. The ML dependency remains optional/lazy in normal core installs; normal CI uses an injected deterministic model fixture rather than downloading weights.
+
+## Versioned benchmark plan
+
+The committed plan is:
+
+`benchmarks/post-gate2/retrieval-bakeoff-v1.json`
+
+Matched evaluation uses:
+
+- **21** history-rich retrieval cases from `benchmarks/gate2/real-corpus-history-v2.json`;
+- **6** Workstream-B final-answer/citation/abstention cases from `benchmarks/post-gate2/answer-reliability-v1.json`;
+- retrieval limit `5`;
+- matched candidate multiplier `4` for the reranked/hybrid lanes;
+- RRF `k=60`;
+- **6 routes**;
+- **36 Workstream-F receipts** for downstream answer executions.
+
+Routes:
+
+1. `bm25` — explicit degraded/fallback baseline;
+2. `bge-dense` — incumbent primary dense route;
+3. `bge-bm25-rrf` — deterministic hybrid candidate;
+4. `bge-bm25-rrf-lifecycle` — hybrid plus deterministic lifecycle reranking;
+5. `bge-dense-crossencoder` — incumbent dense candidates plus real cross-encoder;
+6. `bge-bm25-rrf-crossencoder` — hybrid candidates plus real cross-encoder.
+
+The report records hit rate, recall@k, MRR, latency, Python allocation peak, process max RSS, pack isolation, bounded current-query superseded top-1 leakage, final-answer correctness, exact citation correctness, unsupported-claim rate, and exact execution/service identity through Workstream-F receipts.
+
+## Normal contract proof
+
+PR #67 normal CI passed on the corrected stage-1 implementation after the eligibility semantics were covered by dedicated tests.
+
+The core suite includes tests for:
+
+- exact cross-encoder model/revision/runtime identity;
+- pairwise prediction and stable tie behavior;
+- optional-runtime failure handling;
+- `RerankedRetriever` propagation of real reranker identity;
+- challenger-disqualification semantics;
+- retrieval-leakage classification;
+- pack-isolation hard failure;
+- promotion eligibility only for a fully clean route.
+
+## Failed-first execution probe — PR #68
+
+Execution-only PR #68 was intentionally closed unmerged after it exposed two harness issues while preserving useful benchmark evidence:
+
+1. the first bakeoff exit rule incorrectly required **every challenger** to pass the downstream answer/citation guardrails, which conflated a weak candidate with broken benchmark infrastructure;
+2. the temporary proof workflow initially wrote evidence under a hidden directory that `upload-artifact@v4` did not include by default.
+
+The semantic runtime itself installed successfully and the core tests passed before the original benchmark-stage failure.
+
+The correction did **not** weaken expected answers, citations, pack isolation, or D021 safeguards. Instead, each challenger now receives explicit:
+
+- `end_to_end_guardrails_pass`;
+- `retrieval_leakage_free`;
+- `eligible_for_promotion`;
+- `disqualifying_reasons`.
+
+A challenger can therefore fail and remain valuable evidence without being mislabeled as an infrastructure failure.
+
+The hard top-level execution gates remain:
+
+- exact pack isolation for every route;
+- incumbent `bge-dense` end-to-end answer/citation/unsupported-claim guardrails.
+
+## Final real-semantic execution proof — PASS
+
+Execution-only PR #69 reran the corrected, unchanged stage-1 plan from the final feature implementation using the real pinned BGE model and the real pinned cross-encoder.
+
+Result: **PASS**.
+
+The proof completed:
+
+- 27 projected corpus documents;
+- 21 retrieval cases;
+- 6 answer cases;
+- 6 matched routes;
+- 36 Workstream-F receipts;
+- real local BGE embedding execution;
+- real local cross-encoder execution;
+- per-route retrieval, latency/resource, safety, and final-answer/citation evaluation;
+- explicit per-route promotion eligibility/disqualification evidence.
+
+The full exact route metrics and service/runtime metadata are preserved in the execution-only PR #69 workflow output and artifact named:
+
+`post-gate2-retrieval-bakeoff-proof-v2`
+
+The final stage gate passed because benchmark infrastructure completed, pack isolation remained intact, and the incumbent D021 route retained the required downstream answer/citation/unsupported-claim safety boundary. Challenger routes are judged individually; no challenger result from this stage authorizes a D021 replacement.
+
+## Interpretation
+
+Stage 1 establishes a reproducible matched comparison surface and a genuine real-reranker lane. It is not a selection proof for a new retrieval policy.
+
+A candidate is **not promotable** merely because it improves hit rate, recall, MRR, or aggregate ranking quality. Promotion still requires the downstream answer/citation guardrails, lifecycle/lineage safety, pack isolation, poisoning/context-security compatibility, and operational tradeoffs to remain acceptable.
+
+Likewise, a candidate that fails a guardrail is retained as negative benchmark evidence rather than hidden or converted into a benchmark failure.
+
+## D021 decision
+
+**D021 remains unchanged after stage 1.**
+
+The first-stage plan explicitly records:
+
+`d021_replacement_decision = not_authorized_by_first_stage`
+
+This stage exists to establish comparable incumbent/hybrid/reranker evidence and the real reranker adapter. It does not yet answer the embedding-scale question.
+
+## Next Workstream-D stage
+
+With stage-1 evidence committed, Workstream D may proceed to the progressive embedding bakeoff in Issue #47:
+
+1. Qwen3-Embedding 0.6B class candidate;
+2. 4B only if the 0.6B result and available resources justify continuing;
+3. 8B only if the preceding evidence justifies the additional cost/resource burden;
+4. optional BGE-M3 / larger BGE-family control when useful.
+
+Each configuration must pin exact model/revision/runtime/library/precision/hardware identity and use the same versioned corpus/case sets and Workstream-F receipt boundary where comparison is intended to be matched.
+
+## Residual risks
+
+- The corpus and benchmark remain small; route ordering can be sensitive to a few history-rich cases.
+- The chosen MS MARCO MiniLM cross-encoder is a real reranker but not a universal reranker or a claim that this model family is optimal for FOSSIL.
+- CPU latency/resource measurements are runner-specific and should not be generalized to GPU or provider-hosted serving.
+- Python allocation peak and process RSS are useful execution evidence but are not a complete systems-memory profile.
+- Hosted/API candidates may introduce nondeterminism, rate limits, fallback behavior, privacy/retention concerns, and provider-version drift absent from this local stage.
+- Retrieval leakage audits cover committed bounded cases; they are not a proof that no stale or adversarial passage can ever rank first.
+- A Workstream-F receipt records what ran; it does not make a score, model, reranker, or multi-agent consensus into evidence.
+- The final D021 reconciliation must consider decision-critical misses and lifecycle/lineage safety, not aggregate retrieval metrics alone.

--- a/scripts/run_post_gate2_retrieval_bakeoff.py
+++ b/scripts/run_post_gate2_retrieval_bakeoff.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import resource
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from dkg.answer_eval import (
+    AnswerReliabilityCase,
+    DeterministicEvidenceAnswerService,
+    evaluate_answer_candidate,
+)
+from dkg.answer_pipeline import LineageResolvedModelService
+from dkg.benchmark import RetrievalBenchmark
+from dkg.benchmark_cases import load_benchmark_case_set, retrieval_cases_from_case_set
+from dkg.context_security import UntrustedContextModelService
+from dkg.execution_receipt import execute_query_with_receipt
+from dkg.pack_corpus import retrieval_documents_from_pack_fixtures
+from dkg.real_retrieval import (
+    DEFAULT_BGE_MODEL,
+    DEFAULT_BGE_REVISION,
+    DEFAULT_CROSS_ENCODER_MODEL,
+    DEFAULT_CROSS_ENCODER_REVISION,
+    LifecycleIntentReranker,
+    ReciprocalRankFusionRetriever,
+    RerankedRetriever,
+    SentenceTransformerCrossEncoderReranker,
+    SentenceTransformerEmbeddingProvider,
+)
+from dkg.semantic_retriever import SemanticEmbeddingRetriever
+from dkg.services import BM25Retriever
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PLAN = ROOT / "benchmarks" / "post-gate2" / "retrieval-bakeoff-v1.json"
+CASE_SCHEMA = ROOT / "schemas" / "benchmark-case-set" / "v1.schema.json"
+
+CURRENT_QUERY_TOP1_LEAKAGE = {
+    "current_architecture_after_reconsideration": {"clm_643b698b7e9e6aee6a16c48c"},
+    "graphiti_current_role": {"clm_bdf2ed41fb11e6b1808d3df4"},
+}
+
+
+def _git_head(root: Path) -> str:
+    return subprocess.check_output(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def _projection_build_id(pack_mounts: dict[str, str]) -> str:
+    payload = json.dumps(pack_mounts, sort_keys=True, separators=(",", ":"))
+    return "packfix_" + hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+
+
+def _answer_metrics(observations: list[dict[str, Any]]) -> dict[str, Any]:
+    count = len(observations)
+    abstention = [item for item in observations if item["expected_outcome"] != "answer"]
+    return {
+        "final_answer_correctness_rate": sum(bool(item["case_correct"]) for item in observations)
+        / count,
+        "outcome_accuracy": sum(bool(item["outcome_match"]) for item in observations) / count,
+        "citation_correctness_rate": sum(
+            bool(item["citation_correct"]) for item in observations
+        )
+        / count,
+        "mean_unsupported_claim_rate": sum(
+            float(item["unsupported_claim_rate"]) for item in observations
+        )
+        / count,
+        "completeness_rate": sum(float(item["completeness"]) == 1.0 for item in observations)
+        / count,
+        "appropriate_abstention_rate": (
+            sum(bool(item["appropriate_abstention"]) for item in abstention) / len(abstention)
+            if abstention
+            else None
+        ),
+        "overabstention_rate": sum(bool(item["overabstention"]) for item in observations)
+        / count,
+        "high_confidence_error_rate": sum(
+            float(item["confidence"]) >= 0.8 and not bool(item["case_correct"])
+            for item in observations
+        )
+        / count,
+    }
+
+
+def _model_service(documents: list[dict[str, Any]]):
+    return UntrustedContextModelService(
+        LineageResolvedModelService(
+            DeterministicEvidenceAnswerService(),
+            documents=documents,
+        ),
+        documents=documents,
+    )
+
+
+def _build_routes(documents: list[dict[str, Any]], plan: dict[str, Any]) -> dict[str, Any]:
+    models = dict(plan["models"])
+    incumbent = dict(models["incumbent_embedding"])
+    cross_encoder_config = dict(models["cross_encoder"])
+    if incumbent != {"model": DEFAULT_BGE_MODEL, "revision": DEFAULT_BGE_REVISION}:
+        raise ValueError("plan incumbent embedding pin does not match committed D021 constants")
+    if cross_encoder_config["model"] != DEFAULT_CROSS_ENCODER_MODEL or cross_encoder_config[
+        "revision"
+    ] != DEFAULT_CROSS_ENCODER_REVISION:
+        raise ValueError("plan cross-encoder pin does not match committed reranker constants")
+
+    multiplier = int(plan["candidate_multiplier"])
+    embedder = SentenceTransformerEmbeddingProvider(
+        model_name=incumbent["model"],
+        revision=incumbent["revision"],
+        device="cpu",
+    )
+    dense = SemanticEmbeddingRetriever(
+        documents,
+        embedder,
+        version="workstream-d-d021-bge-v1",
+    )
+    lexical = BM25Retriever(documents, version="workstream-d-bm25-v1")
+    hybrid = ReciprocalRankFusionRetriever(
+        [lexical, dense],
+        rrf_k=int(plan["rrf_k"]),
+        candidate_multiplier=multiplier,
+        version="workstream-d-bge-bm25-rrf-v1",
+    )
+    lifecycle = RerankedRetriever(
+        hybrid,
+        LifecycleIntentReranker(version="workstream-d-lifecycle-v1"),
+        candidate_multiplier=multiplier,
+        version="workstream-d-bge-bm25-rrf-lifecycle-v1",
+    )
+    cross_encoder = SentenceTransformerCrossEncoderReranker(
+        model_name=cross_encoder_config["model"],
+        revision=cross_encoder_config["revision"],
+        device="cpu",
+        batch_size=int(cross_encoder_config.get("batch_size", 16)),
+        max_length=(
+            int(cross_encoder_config["max_length"])
+            if cross_encoder_config.get("max_length") is not None
+            else None
+        ),
+        implementation_version="workstream-d-v1",
+    )
+    dense_cross_encoder = RerankedRetriever(
+        dense,
+        cross_encoder,
+        candidate_multiplier=multiplier,
+        version="workstream-d-bge-dense-crossencoder-v1",
+    )
+    hybrid_cross_encoder = RerankedRetriever(
+        hybrid,
+        cross_encoder,
+        candidate_multiplier=multiplier,
+        version="workstream-d-bge-bm25-rrf-crossencoder-v1",
+    )
+    return {
+        "bm25": lexical,
+        "bge-dense": dense,
+        "bge-bm25-rrf": hybrid,
+        "bge-bm25-rrf-lifecycle": lifecycle,
+        "bge-dense-crossencoder": dense_cross_encoder,
+        "bge-bm25-rrf-crossencoder": hybrid_cross_encoder,
+    }
+
+
+def _route_specs(plan: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {str(item["name"]): dict(item) for item in plan["routes"]}
+
+
+def _audit_route(retriever: Any, retrieval_cases: list[Any], *, limit: int) -> dict[str, Any]:
+    pack_violations: list[dict[str, Any]] = []
+    top1_leakage: list[dict[str, Any]] = []
+    for case in retrieval_cases:
+        results = retriever.search(case.query, pack_ids=list(case.pack_ids), limit=limit)
+        allowed = set(case.pack_ids)
+        foreign = [
+            str(item["id"])
+            for item in results
+            if str(item.get("pack_id", "")) not in allowed
+        ]
+        if foreign:
+            pack_violations.append({"case_id": case.case_id, "foreign_ids": foreign})
+        forbidden_top1 = CURRENT_QUERY_TOP1_LEAKAGE.get(case.case_id, set())
+        if results and str(results[0]["id"]) in forbidden_top1:
+            top1_leakage.append(
+                {
+                    "case_id": case.case_id,
+                    "top1_id": str(results[0]["id"]),
+                    "forbidden_ids": sorted(forbidden_top1),
+                }
+            )
+    return {
+        "pack_isolation_preserved": not pack_violations,
+        "pack_isolation_violations": pack_violations,
+        "current_query_top1_superseded_leakage_count": len(top1_leakage),
+        "current_query_top1_superseded_leakage": top1_leakage,
+    }
+
+
+def _answer_receipts(
+    *,
+    route_name: str,
+    route_spec: dict[str, Any],
+    retriever: Any,
+    answer_cases: list[AnswerReliabilityCase],
+    documents: list[dict[str, Any]],
+    pack_mounts: dict[str, str],
+    projection: dict[str, str],
+    run_ref: str,
+) -> dict[str, Any]:
+    observations: list[dict[str, Any]] = []
+    receipts: list[dict[str, Any]] = []
+    service = _model_service(documents)
+    for case in answer_cases:
+        response, receipt = execute_query_with_receipt(
+            query=case.query,
+            pack_mounts=pack_mounts,
+            query_pack_ids=list(case.pack_ids),
+            projection=projection,
+            policy={
+                "route_id": str(route_spec["route_id"]),
+                "retrieval_policy_id": "D021-evaluation-boundary",
+                "mode": "workstream-d-bakeoff",
+            },
+            retriever=retriever,
+            model_service=service,
+            limit=case.limit,
+            trace_ref=f"trace://workstream-d/{route_name}/{case.case_id}",
+            run_ref=run_ref,
+            query_id=case.case_id,
+            requested_model={
+                "provider": "fossil",
+                "model_id": None,
+                "implementation": "deterministic-evidence-answerer",
+            },
+        )
+        evaluation = evaluate_answer_candidate(
+            response["output"],
+            case=case,
+            documents=documents,
+        )
+        observations.append(
+            {
+                **evaluation,
+                "case_id": case.case_id,
+                "receipt_id": receipt["receipt_id"],
+                "execution_identity_sha256": receipt["execution_identity_sha256"],
+                "result_sha256": receipt["result_sha256"],
+            }
+        )
+        receipts.append(receipt)
+    return {
+        "metrics": _answer_metrics(observations),
+        "observations": observations,
+        "receipts": receipts,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run Issue #48 Workstream D matched incumbent/hybrid/reranker bakeoff."
+    )
+    parser.add_argument("--common-root", type=Path, required=True)
+    parser.add_argument("--ai-root", type=Path, required=True)
+    parser.add_argument("--plan", type=Path, default=DEFAULT_PLAN)
+    parser.add_argument("--run-ref", default="post-gate2-retrieval-bakeoff")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    plan = _load_json(args.plan)
+    expected_repo_pins = {
+        "fossil-common": str(plan["pack_pins"]["fossil-common"]),
+        "fossil-ai-systems": str(plan["pack_pins"]["fossil-ai-systems"]),
+    }
+    observed_repo_pins = {
+        "fossil-common": _git_head(args.common_root),
+        "fossil-ai-systems": _git_head(args.ai_root),
+    }
+    if observed_repo_pins != expected_repo_pins:
+        raise SystemExit(
+            "pack pin mismatch: "
+            + json.dumps(
+                {"expected": expected_repo_pins, "observed": observed_repo_pins},
+                sort_keys=True,
+            )
+        )
+
+    stable_ids = dict(plan["stable_pack_ids"])
+    pack_mounts = {
+        str(stable_ids["fossil-common"]): observed_repo_pins["fossil-common"],
+        str(stable_ids["fossil-ai-systems"]): observed_repo_pins["fossil-ai-systems"],
+    }
+    projection = {
+        "name": "pack-fixture-retrieval-documents",
+        "version": "1",
+        "build_id": _projection_build_id(pack_mounts),
+    }
+    documents = retrieval_documents_from_pack_fixtures(
+        [args.common_root, args.ai_root],
+        schemas_root=ROOT / "schemas",
+    )
+
+    retrieval_case_path = ROOT / str(plan["retrieval_case_set"])
+    retrieval_case_set = load_benchmark_case_set(retrieval_case_path, CASE_SCHEMA)
+    retrieval_cases = retrieval_cases_from_case_set(retrieval_case_set)
+    answer_plan = _load_json(ROOT / str(plan["answer_case_set"]))
+    answer_cases = [AnswerReliabilityCase.from_mapping(item) for item in answer_plan["cases"]]
+    routes = _build_routes(documents, plan)
+    specs = _route_specs(plan)
+    if set(routes) != set(specs):
+        raise ValueError("implemented routes do not match the versioned Workstream D plan")
+
+    retrieval_benchmark = RetrievalBenchmark(limit=int(plan["retrieval_limit"]))
+    route_reports: dict[str, Any] = {}
+    for route_name in [str(item["name"]) for item in plan["routes"]]:
+        retriever = routes[route_name]
+        retrieval_report = retrieval_benchmark.run(retriever, retrieval_cases)
+        audit = _audit_route(
+            retriever,
+            retrieval_cases,
+            limit=int(plan["retrieval_limit"]),
+        )
+        answer_report = _answer_receipts(
+            route_name=route_name,
+            route_spec=specs[route_name],
+            retriever=retriever,
+            answer_cases=answer_cases,
+            documents=documents,
+            pack_mounts=pack_mounts,
+            projection=projection,
+            run_ref=args.run_ref,
+        )
+        route_reports[route_name] = {
+            "role": str(specs[route_name]["role"]),
+            "retrieval": retrieval_report,
+            "safety_audit": audit,
+            "answer_reliability": answer_report,
+        }
+
+    max_rss_kib = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    all_pack_safe = all(
+        bool(report["safety_audit"]["pack_isolation_preserved"])
+        for report in route_reports.values()
+    )
+    all_answers_safe = all(
+        report["answer_reliability"]["metrics"]["final_answer_correctness_rate"] == 1.0
+        and report["answer_reliability"]["metrics"]["citation_correctness_rate"] == 1.0
+        and report["answer_reliability"]["metrics"]["mean_unsupported_claim_rate"] == 0.0
+        for report in route_reports.values()
+    )
+    report = {
+        "schema_version": "fossil.retrieval-bakeoff-proof.v1",
+        "benchmark_id": str(plan["benchmark_id"]),
+        "authority": (
+            "candidate retrieval/reranker scores and Workstream-F receipts are evaluation "
+            "evidence only; D021 durable lifecycle/lineage/citation authority is unchanged"
+        ),
+        "repo_pack_pins": observed_repo_pins,
+        "pack_mounts": pack_mounts,
+        "projection": projection,
+        "corpus_document_count": len(documents),
+        "retrieval_case_count": len(retrieval_cases),
+        "answer_case_count": len(answer_cases),
+        "route_count": len(route_reports),
+        "receipt_count": len(route_reports) * len(answer_cases),
+        "environment": {
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "processor": platform.processor(),
+            "process_max_rss_kib": int(max_rss_kib),
+        },
+        "routes": route_reports,
+        "stage_gate": {
+            "pack_isolation_preserved_all_routes": all_pack_safe,
+            "answer_citation_unsupported_guardrails_all_routes": all_answers_safe,
+            "d021_replacement_decision": "not_authorized_by_first_stage",
+            "embedding_scale_progression": "pending_after_baseline_reranker_evidence",
+        },
+        "passed": all_pack_safe and all_answers_safe,
+    }
+
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    return 0 if report["passed"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dkg/real_retrieval.py
+++ b/src/dkg/real_retrieval.py
@@ -11,6 +11,8 @@ from .services import ServiceMetadata, tokenize
 
 DEFAULT_BGE_MODEL = "BAAI/bge-small-en-v1.5"
 DEFAULT_BGE_REVISION = "5c38ec7c405ec4b44b94cc5a9bb96e735b38267a"
+DEFAULT_CROSS_ENCODER_MODEL = "cross-encoder/ms-marco-MiniLM-L6-v2"
+DEFAULT_CROSS_ENCODER_REVISION = "ce0834f22110de6d9222af7a7a03628121708969"
 
 
 def _installed_version(package: str) -> str:
@@ -112,6 +114,133 @@ class SentenceTransformerEmbeddingProvider:
             show_progress_bar=False,
         )
         return [[float(value) for value in vector] for vector in vectors]
+
+
+class SentenceTransformerCrossEncoderReranker:
+    """Revision-pinned local pairwise reranker behind the FOSSIL Reranker contract.
+
+    Cross-encoder scores only reorder candidate documents. They never become
+    durable truth, lifecycle state, citation authority, or commit authority.
+    The model object can be injected so the normal contract suite remains
+    independent of optional ML/runtime downloads.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_name: str = DEFAULT_CROSS_ENCODER_MODEL,
+        revision: str = DEFAULT_CROSS_ENCODER_REVISION,
+        device: str = "cpu",
+        batch_size: int = 32,
+        max_length: int | None = None,
+        model: Any | None = None,
+        provider_version: str | None = None,
+        implementation_version: str = "1",
+    ) -> None:
+        if not model_name or not revision or not device:
+            raise ValueError("cross-encoder reranker requires model, revision, and device")
+        if batch_size < 1:
+            raise ValueError("cross-encoder batch size must be positive")
+        if max_length is not None and max_length < 1:
+            raise ValueError("cross-encoder max_length must be positive when set")
+        self.model_name = model_name
+        self.revision = revision
+        self.device = device
+        self.batch_size = int(batch_size)
+        self.max_length = int(max_length) if max_length is not None else None
+        self.implementation_version = implementation_version
+
+        if provider_version is None:
+            try:
+                provider_version = importlib.metadata.version("sentence-transformers")
+            except importlib.metadata.PackageNotFoundError:
+                if model is None:
+                    raise OptionalRetrievalDependencyUnavailable(
+                        "Sentence Transformers is unavailable; install fossil-core[semantic] "
+                        "or inject a compatible cross-encoder model object"
+                    ) from None
+                provider_version = "injected-runtime"
+        self.provider_version = provider_version
+        self.torch_version = _installed_version("torch")
+        self.transformers_version = _installed_version("transformers")
+
+        if model is None:
+            try:
+                from sentence_transformers import CrossEncoder
+            except ImportError:
+                raise OptionalRetrievalDependencyUnavailable(
+                    "Sentence Transformers is unavailable; install fossil-core[semantic]"
+                ) from None
+            kwargs: dict[str, Any] = {
+                "revision": self.revision,
+                "device": self.device,
+            }
+            if self.max_length is not None:
+                kwargs["max_length"] = self.max_length
+            model = CrossEncoder(self.model_name, **kwargs)
+        self._model = model
+
+    @property
+    def model_id(self) -> str:
+        return f"{self.model_name}@{self.revision}"
+
+    def metadata(self) -> dict[str, Any]:
+        return ServiceMetadata(
+            kind="reranker",
+            provider="sentence-transformers",
+            provider_version=self.provider_version,
+            implementation="cross-encoder-pairwise-reranker",
+            implementation_version=self.implementation_version,
+            model_id=self.model_id,
+            local=True,
+            estimated_cost_per_call_usd=0.0,
+            runtime={
+                "batch_size": str(self.batch_size),
+                "device": self.device,
+                "max_length": str(self.max_length) if self.max_length is not None else "model-default",
+                "model_revision": self.revision,
+                "score_authority": "candidate-ordering-only",
+                "torch_version": self.torch_version,
+                "transformers_version": self.transformers_version,
+            },
+        ).as_dict()
+
+    def rerank(
+        self,
+        query: str,
+        candidates: list[dict[str, Any]],
+        *,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        if limit < 1:
+            raise ValueError("limit must be positive")
+        if not candidates:
+            return []
+        pairs = [(str(query), str(candidate.get("text", ""))) for candidate in candidates]
+        raw_scores = self._model.predict(
+            pairs,
+            batch_size=self.batch_size,
+            show_progress_bar=False,
+            convert_to_numpy=True,
+        )
+        scores = [float(value) for value in raw_scores]
+        if len(scores) != len(candidates):
+            raise ValueError("cross-encoder returned a score count that does not match candidates")
+
+        service = self.metadata()
+        scored: list[tuple[float, int, str, dict[str, Any]]] = []
+        for fallback_rank, (candidate, score) in enumerate(zip(candidates, scores, strict=True), start=1):
+            retrieval = dict(candidate.get("retrieval", {}))
+            base_rank = int(retrieval.get("rank", fallback_rank))
+            result = copy.deepcopy(candidate)
+            result["rerank"] = {
+                "base_rank": base_rank,
+                "score": score,
+                "service": service,
+            }
+            scored.append((score, base_rank, str(candidate.get("id", "")), result))
+        scored.sort(key=lambda item: (-item[0], item[1], item[2]))
+        return [item[3] for item in scored[:limit]]
 
 
 class ReciprocalRankFusionRetriever:

--- a/tests/test_real_retrieval.py
+++ b/tests/test_real_retrieval.py
@@ -8,10 +8,13 @@ import pytest
 from dkg.real_retrieval import (
     DEFAULT_BGE_MODEL,
     DEFAULT_BGE_REVISION,
+    DEFAULT_CROSS_ENCODER_MODEL,
+    DEFAULT_CROSS_ENCODER_REVISION,
     LifecycleIntentReranker,
     OptionalRetrievalDependencyUnavailable,
     ReciprocalRankFusionRetriever,
     RerankedRetriever,
+    SentenceTransformerCrossEncoderReranker,
     SentenceTransformerEmbeddingProvider,
 )
 from dkg.semantic_retriever import SemanticEmbeddingRetriever
@@ -28,6 +31,16 @@ class FakeEncoder:
     def encode(self, texts, **kwargs):
         self.calls.append((list(texts), dict(kwargs)))
         return [[float(index + 1), 0.5] for index, _ in enumerate(texts)]
+
+
+class FakeCrossEncoder:
+    def __init__(self, scores: list[float]) -> None:
+        self.scores = list(scores)
+        self.calls = []
+
+    def predict(self, pairs, **kwargs):
+        self.calls.append((list(pairs), dict(kwargs)))
+        return list(self.scores)
 
 
 class FakeRetriever:
@@ -105,6 +118,70 @@ def test_sentence_transformer_provider_preserves_exact_runtime_identity_and_enco
     ]
 
 
+def test_cross_encoder_reranker_preserves_exact_identity_and_pairwise_predict_options():
+    model = FakeCrossEncoder([0.25, 1.75, 1.75])
+    reranker = SentenceTransformerCrossEncoderReranker(
+        model=model,
+        provider_version="5.2.2",
+        device="cpu",
+        batch_size=8,
+        max_length=256,
+    )
+    candidates = [
+        {**doc("alpha", rank=1), "retrieval": {"rank": 1, "score": 3.0}},
+        {**doc("beta", rank=2), "retrieval": {"rank": 2, "score": 2.0}},
+        {**doc("gamma", rank=3), "retrieval": {"rank": 3, "score": 1.0}},
+    ]
+
+    results = reranker.rerank("which candidate", candidates, limit=3)
+    metadata = reranker.metadata()
+
+    assert [item["id"] for item in results] == ["beta", "gamma", "alpha"]
+    assert results[0]["rerank"]["score"] == 1.75
+    assert results[0]["rerank"]["base_rank"] == 2
+    assert results[0]["rerank"]["service"]["model_id"] == (
+        f"{DEFAULT_CROSS_ENCODER_MODEL}@{DEFAULT_CROSS_ENCODER_REVISION}"
+    )
+    assert "rerank" not in candidates[0]
+    assert metadata["kind"] == "reranker"
+    assert metadata["provider"] == "sentence-transformers"
+    assert metadata["provider_version"] == "5.2.2"
+    assert metadata["implementation"] == "cross-encoder-pairwise-reranker"
+    assert metadata["model_id"] == (
+        f"{DEFAULT_CROSS_ENCODER_MODEL}@{DEFAULT_CROSS_ENCODER_REVISION}"
+    )
+    assert metadata["runtime"]["model_revision"] == DEFAULT_CROSS_ENCODER_REVISION
+    assert metadata["runtime"]["score_authority"] == "candidate-ordering-only"
+    assert model.calls == [
+        (
+            [
+                ("which candidate", "alpha"),
+                ("which candidate", "beta"),
+                ("which candidate", "gamma"),
+            ],
+            {
+                "batch_size": 8,
+                "show_progress_bar": False,
+                "convert_to_numpy": True,
+            },
+        )
+    ]
+
+
+def test_cross_encoder_reranker_fails_on_invalid_score_count():
+    reranker = SentenceTransformerCrossEncoderReranker(
+        model=FakeCrossEncoder([1.0]),
+        provider_version="5.2.2",
+    )
+    candidates = [
+        {**doc("alpha", rank=1), "retrieval": {"rank": 1}},
+        {**doc("beta", rank=2), "retrieval": {"rank": 2}},
+    ]
+
+    with pytest.raises(ValueError, match="score count"):
+        reranker.rerank("query", candidates, limit=2)
+
+
 def test_semantic_retriever_carries_embedding_provider_and_runtime_into_benchmark_metadata():
     provider = SentenceTransformerEmbeddingProvider(
         model=FakeEncoder(),
@@ -135,6 +212,15 @@ def test_sentence_transformer_provider_fails_cleanly_when_optional_runtime_is_un
     monkeypatch.setattr(importlib.metadata, "version", missing)
     with pytest.raises(OptionalRetrievalDependencyUnavailable, match=r"fossil-core\[semantic\]"):
         SentenceTransformerEmbeddingProvider(model=None)
+
+
+def test_cross_encoder_reranker_fails_cleanly_when_optional_runtime_is_unavailable(monkeypatch):
+    def missing(_name: str):
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(importlib.metadata, "version", missing)
+    with pytest.raises(OptionalRetrievalDependencyUnavailable, match=r"fossil-core\[semantic\]"):
+        SentenceTransformerCrossEncoderReranker(model=None)
 
 
 def test_rrf_fuses_distinct_retrievers_and_preserves_pack_filtering_and_component_provenance():
@@ -295,3 +381,33 @@ def test_reranked_retriever_exposes_same_retriever_contract_and_full_base_proven
     assert reranker_service["implementation"] == "lifecycle-intent-reranker"
     assert results[0]["base_retrieval"]["service"]["implementation"] == "base"
     assert results[0]["rerank"]["service"]["implementation"] == "lifecycle-intent-reranker"
+
+
+def test_reranked_retriever_surfaces_cross_encoder_service_identity():
+    base = FakeRetriever(
+        "base",
+        [doc("alpha", rank=1), doc("beta", rank=2)],
+        model_id="dense@revision",
+    )
+    reranker = SentenceTransformerCrossEncoderReranker(
+        model=FakeCrossEncoder([0.1, 0.9]),
+        provider_version="5.2.2",
+    )
+    retriever = RerankedRetriever(
+        base,
+        reranker,
+        candidate_multiplier=2,
+        version="cross-encoder-fixture",
+    )
+
+    results = retriever.search("query", pack_ids=[PACK], limit=2)
+    metadata = retriever.metadata()
+    reranker_metadata = json.loads(metadata["runtime"]["reranker_service"])
+
+    assert [item["id"] for item in results] == ["beta", "alpha"]
+    assert reranker_metadata["model_id"] == (
+        f"{DEFAULT_CROSS_ENCODER_MODEL}@{DEFAULT_CROSS_ENCODER_REVISION}"
+    )
+    assert results[0]["rerank"]["service"]["implementation"] == (
+        "cross-encoder-pairwise-reranker"
+    )

--- a/tests/test_retrieval_bakeoff.py
+++ b/tests/test_retrieval_bakeoff.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "run_post_gate2_retrieval_bakeoff.py"
+SPEC = importlib.util.spec_from_file_location("workstream_d_bakeoff", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def _answer_report(*, correct: float = 1.0, citation: float = 1.0, unsupported: float = 0.0):
+    return {
+        "metrics": {
+            "final_answer_correctness_rate": correct,
+            "citation_correctness_rate": citation,
+            "mean_unsupported_claim_rate": unsupported,
+        }
+    }
+
+
+def _audit(*, pack_safe: bool = True, leakage: int = 0):
+    return {
+        "pack_isolation_preserved": pack_safe,
+        "current_query_top1_superseded_leakage_count": leakage,
+    }
+
+
+def test_route_eligibility_keeps_candidate_failures_as_disqualification_evidence():
+    result = MODULE._route_eligibility(
+        route_name="challenger",
+        route_spec={"role": "real-reranker-candidate"},
+        answer_report=_answer_report(correct=5 / 6),
+        audit=_audit(),
+    )
+
+    assert result["end_to_end_guardrails_pass"] is False
+    assert result["eligible_for_promotion"] is False
+    assert result["disqualifying_reasons"] == ["final_answer_correctness_below_1.0"]
+
+
+def test_route_eligibility_records_retrieval_leakage_without_hiding_end_to_end_safety():
+    result = MODULE._route_eligibility(
+        route_name="challenger",
+        route_spec={"role": "hybrid-candidate"},
+        answer_report=_answer_report(),
+        audit=_audit(leakage=1),
+    )
+
+    assert result["end_to_end_guardrails_pass"] is True
+    assert result["retrieval_leakage_free"] is False
+    assert result["eligible_for_promotion"] is False
+    assert result["disqualifying_reasons"] == ["current_query_top1_superseded_leakage"]
+
+
+def test_route_eligibility_requires_pack_isolation_for_end_to_end_guardrails():
+    result = MODULE._route_eligibility(
+        route_name="challenger",
+        route_spec={"role": "hybrid-candidate"},
+        answer_report=_answer_report(),
+        audit=_audit(pack_safe=False),
+    )
+
+    assert result["end_to_end_guardrails_pass"] is False
+    assert result["eligible_for_promotion"] is False
+    assert result["disqualifying_reasons"] == ["pack_isolation_violation"]
+
+
+def test_route_eligibility_accepts_only_fully_clean_candidate():
+    result = MODULE._route_eligibility(
+        route_name="challenger",
+        route_spec={"role": "hybrid-candidate"},
+        answer_report=_answer_report(),
+        audit=_audit(),
+    )
+
+    assert result["end_to_end_guardrails_pass"] is True
+    assert result["retrieval_leakage_free"] is True
+    assert result["eligible_for_promotion"] is True
+    assert result["disqualifying_reasons"] == []


### PR DESCRIPTION
Starts Issue #48 Workstream D / Issue #47 with the matched incumbent/hybrid/reranker slice before embedding-scale escalation.

## What changed

- adds a revision-pinned local Sentence Transformers cross-encoder reranker behind the existing `Reranker` contract;
- keeps the ML dependency optional/lazy and uses injected fixtures in normal CI;
- adds a versioned first-stage D plan with exact pack pins, D021 BGE pin, cross-encoder model/revision/runtime settings, matched candidate budgets, six routes, and explicit authority guardrails;
- adds a real-corpus runner comparing BM25, incumbent BGE dense, BGE+BM25 RRF, RRF+lifecycle, dense+cross-encoder, and RRF+cross-encoder;
- reuses the 21-case Gate-2 history-rich retrieval set and six Workstream-B answer cases;
- emits Workstream-F receipts for every route on every answer case, preserving `fossil-untrusted-context-v1` and `fossil-lineage-context-v1`;
- adds pack-isolation, bounded current-query superseded-leakage, process RSS, latency/cost, and exact requested/actual runtime evidence;
- classifies challenger failures as explicit promotion disqualification evidence without weakening benchmark expectations or treating weak candidates as infrastructure failures;
- records the failed-first PR #68 lesson and successful final real-semantic PR #69 proof in `docs/implementation/2026-08-10-post-gate2-retrieval-bakeoff-stage1-proof.md`.

## Evidence

Normal feature CI passed before the final proof-document update, including the real-reranker contract tests and dedicated route-eligibility tests.

Execution-only PR #68 was closed unmerged after exposing the original bakeoff-exit semantics and hidden-artifact instrumentation issues. Expected answer/citation/pack-safety outcomes were not weakened.

Execution-only PR #69 was closed unmerged after the corrected real-semantic proof passed using:
- exact common + AI-systems pack pins;
- real `BAAI/bge-small-en-v1.5@5c38ec7c405ec4b44b94cc5a9bb96e735b38267a` on CPU;
- real `cross-encoder/ms-marco-MiniLM-L6-v2@ce0834f22110de6d9222af7a7a03628121708969` on CPU;
- 27 projected documents;
- 21 retrieval cases;
- 6 answer cases;
- 6 routes;
- 36 Workstream-F receipts;
- artifact `post-gate2-retrieval-bakeoff-proof-v2`.

The final stage gate passed with pack isolation intact and the incumbent D021 route preserving the required downstream answer/citation/unsupported-claim safety boundary. Challenger route weaknesses remain explicit eligibility/disqualification evidence.

This PR does **not** change D021. Stage 1 only establishes comparable incumbent/hybrid/real-reranker evidence and unlocks the next Workstream-D stage: Qwen3-Embedding 0.6B first, then 4B/8B only if justified.

Refs #47 and #48.