### PR TITLE
Document Cortex–FOSSIL ownership and legacy SSC retirement

### DIFF
--- a/docs/HANDOFF_CURRENT.md
+++ b/docs/HANDOFF_CURRENT.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-10  
 **Project:** **FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage**  
 **Repository:** `Pukujan/fossil-core`  
-**Status:** **Gate 1 complete. Gate 2 complete and formally closed. Post-Gate-2 campaign #48 active. Research ingestion and Workstreams A, B, C, and F are complete. Workstream D / Issue #47 is active next.**
+**Status:** **Gate 1 complete. Gate 2 complete/formally closed. Post-Gate-2 campaign #48 active. Workstreams A/B/C/F complete. Workstream D stage 1 complete. D stage 2 is active next. Cortex↔FOSSIL ownership boundary is now explicitly documented; legacy `stupidly-simple-cortex` is being retired as a live memory/runtime authority while its evaluation estate is preserved separately.**
 
 ## Fresh-session transfer
 
@@ -12,121 +12,280 @@ Read, in order:
 1. `AGENTS.md`
 2. `ARCHITECTURE.md`
 3. this file
-4. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-query-execution-receipt.md`
-5. `docs/PROJECT_STATE.md`
-6. `docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md`
-7. `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`
-8. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
-9. `docs/operations/LITELLM-GATEWAY.md`
-10. Issue #48 — active production RAG hardening campaign
-11. Issue #47 — active Workstream D retrieval/reranking/model bakeoff
-12. `docs/DECISION_LOG.md`
+4. `docs/architecture/2026-08-10-cortex-fossil-ownership-boundary.md`
+5. `docs/research/2026-08-10-legacy-ssc-evaluation-estate-inventory.md`
+6. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-retrieval-bakeoff-stage1.md`
+7. `docs/PROJECT_STATE.md`
+8. `docs/implementation/2026-08-10-post-gate2-retrieval-bakeoff-stage1-proof.md`
+9. `docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md`
+10. `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`
+11. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
+12. `docs/operations/LITELLM-GATEWAY.md`
+13. Issue #48 — active production RAG hardening campaign
+14. Issue #47 — active Workstream D retrieval/reranking/model bakeoff
+15. `docs/DECISION_LOG.md`
 
 Verify GitHub state before changing anything.
 
-## Exact active continuation point
+## Do not redo
 
-**Do not redo research ingestion or Workstreams A, B, C, or F.**
+Do not redo:
 
-The next unfinished Issue #48 workstream is:
+- Gate 1 or Gate 2;
+- production-RAG research ingestion;
+- Workstream A — evolving-corpus temporal/update benchmark;
+- Workstream B — answer/citation/abstention reliability;
+- Workstream C — retrieval poisoning/untrusted context;
+- Workstream F — query execution receipts;
+- Workstream D stage 1 — incumbent/hybrid/real-reranker matched bakeoff.
 
-**D / Issue #47 — retrieval/reranking/model bakeoff.**
+## Workstream D stage 1 — complete
 
-Start with comparable incumbent/hybrid/reranker evidence before escalating embedding model size:
+Core PR #67 landed the first matched retrieval/reranker comparison surface.
 
-1. rerun comparable incumbent D021 dense and BM25 baselines using exact corpus pins and Workstream-F receipts;
-2. compare deterministic dense+lexical hybrid/RRF;
-3. add at least one real cross-encoder/API reranker behind `Reranker` and prove requested/actual/fallback identity;
-4. only then progress Qwen3-Embedding 0.6B → 4B → 8B if evidence and resources justify continuing;
-5. keep contextualized retrieval optional and reproducible, with original source/claim identity distinguishable.
+Execution-only PR #68 was a failed-first instrumentation/exit-semantics probe and was closed unmerged.
 
-Every candidate/configuration must emit or be representable by `fossil.query-execution-receipt.v1` and preserve deterministic lifecycle/lineage/context-security authority.
+Execution-only PR #69 was the corrected final real-semantic proof and was closed unmerged after PASS.
 
-Do not replace D021 because a candidate is newer/larger or wins an aggregate score. Decision-critical misses and lifecycle/lineage safety remain hard constraints.
+Stage-1 proof inputs:
 
-## Workstream F proof — complete
+- common pack revision `d583005dce06dbb499c3c0de5c22b899655eb8d2`;
+- AI-systems pack revision `84accd2ee895663990e82ca5b79b592cb503db24`;
+- 27 projected documents;
+- 21 history-rich retrieval cases;
+- 6 Workstream-B answer cases;
+- 6 routes;
+- 36 Workstream-F receipts;
+- real D021 `BAAI/bge-small-en-v1.5@5c38ec7c405ec4b44b94cc5a9bb96e735b38267a` on CPU;
+- real `cross-encoder/ms-marco-MiniLM-L6-v2@ce0834f22110de6d9222af7a7a03628121708969` on CPU, batch 16, max length 512.
 
-Implementation landed in core PR #64 / squash:
+The final stage gate passed with pack isolation intact and the incumbent D021 downstream answer/citation/unsupported-claim guardrails intact. Challenger routes have explicit promotion eligibility/disqualification evidence. Stage 1 does **not** authorize replacing D021.
 
-`42dab94b51a7b17f20c046f7257b912fe9f0c900`
+## Live LiteLLM retrieval-lane checkpoint
 
-Landed artifacts:
+Execution-only PR #71 was used only to probe the shared LiteLLM gateway and was closed unmerged.
 
-- `src/dkg/execution_receipt.py`;
-- `schemas/query-execution-receipt/v1.schema.json`;
-- `tests/test_execution_receipt.py`;
-- `scripts/run_post_gate2_query_receipt.py`;
-- `docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md`;
-- observability-only resolver diagnostics in `src/dkg/answer_pipeline.py` and `src/dkg/context_security.py`.
+Final probe:
 
-The receipt schema is `fossil.query-execution-receipt.v1` and its authority is explicitly `execution_observability_only`.
+- run `31441469357`;
+- job `93626893009`;
+- `POST /v1/embeddings` with `gemini-embedding-2` -> HTTP 200, non-empty 3072-dimensional embedding, response model `google/gemini-embedding-2`;
+- `POST /v1/rerank` with `rerank-v4-pro` -> HTTP 200 and ranked results;
+- privacy-warning header present on the live retrieval lanes;
+- `/v1/models` and `/v1/model/info` -> HTTP 500;
+- chat/responses probes for Qwen and Gemini aliases -> HTTP 500.
 
-It records query identity, exact pack mounts and scope, projection/build identity, route/policy, requested and actual services/models/providers, bounded fallback attempts, candidate stable IDs/scores, reranker identity, resolver effects, final context/citation IDs, outcome/abstention, latency/cost, and trace/run references. Credential-shaped diagnostic keys are filtered, but this is not general DLP.
+Conclusion: embedding and reranking lanes are live and usable for Workstream D. Chat/model-discovery failure is a separate gateway issue and must not be represented as proof that Gemini chat itself is unavailable.
 
-Final normal CI:
+Do not infer that hosted reranking is free from zero token counters; hosted rerank billing may use a different unit. If the gateway does not expose actual upstream reranker identity, record provenance as unresolved rather than inventing it.
 
-- run `31437754923`;
-- job `93615632123`;
-- **104 passed in 1.04s**.
+## Exact next Workstream-D task
 
-Execution-only PR #65 ran the exact-pin replay proof and was closed unmerged.
+Run a matched D stage-2 benchmark with the existing exact corpus pins and Workstream-F receipts.
 
-Proof:
+Minimum candidate set:
 
-- run `31437447245`;
-- job `93614630416`;
-- **104 core tests passed in 2.41s**;
-- **27 projected documents**;
-- **6 queries / 18 receipts**;
-- answer correctness `1.0`;
-- exact replay identity `1.0`;
-- resolver recording `1.0`;
-- semantic-result stability `1.0`;
-- service-change visibility `1.0`.
+1. incumbent pinned BGE D021 baseline;
+2. Qwen3-Embedding 0.6B, after resolving an immutable official model revision and pinning runtime/prompt/dimension/precision/device settings;
+3. live LiteLLM `gemini-embedding-2` embedding lane with requested/actual identity recorded;
+4. comparable local cross-encoder rerank route;
+5. live LiteLLM `rerank-v4-pro` route, with actual upstream identity explicitly recorded when available or marked unresolved.
 
-Exact replay changed telemetry only while execution/result identity remained stable. A controlled route/retriever-version change was visible under policy/services while preserving result identity and durable answers/citations.
+Reuse the stage-1 21 retrieval cases and six Workstream-B answer cases unless a versioned benchmark change is explicitly justified.
 
-Projection identity used for the proof:
+Compare at minimum:
 
-- `pack-fixture-retrieval-documents`;
-- version `1`;
-- build ID `packfix_59b82d8d50ab38ea68402db7`.
+- full retrieval misses/hit rate;
+- recall@k;
+- MRR/ranking quality;
+- decision-critical misses;
+- current-vs-superseded leakage;
+- lineage/multi-target failures;
+- final-answer correctness;
+- exact citation correctness;
+- unsupported-claim/abstention behavior;
+- poisoning/context-security compatibility;
+- pack isolation;
+- latency;
+- memory/resource use;
+- provider cost;
+- outage/fallback behavior;
+- exact requested and actual provider/model/service/runtime identity;
+- Workstream-F receipt identity.
 
-The receipt is observability/replay evidence, not truth authority or a mutation capability.
+Do not automatically progress to Qwen 4B or 8B. The preceding result and resource evidence must justify escalation.
 
-## Workstream C / B authority anchors
+## Cortex ↔ FOSSIL ownership boundary
 
-C landed in PR #61 / squash:
+The durable boundary is now:
 
-`f5634412222e8d86173eb6e8e364f3414a6f3cd6`
+> **Cortex owns execution. FOSSIL owns knowledge. FOSSIL projections retrieve knowledge. Infrastructure runs the components. Models propose; deterministic gates commit.**
 
-`fossil-untrusted-context-v1` re-resolves known retrieved IDs from mounted durable documents, demotes unknown context, enforces pack scope, contains executable/output escape, and keeps model output candidate-only. C's exact-pin proof passed 8/8.
+And:
 
-B landed in PR #57 / squash:
+> **Cortex may decide when and why to ask memory; it cannot decide what durable memory means. FOSSIL may use replaceable cognitive services internally; it cannot decide what an agent is allowed to do next.**
 
-`483772ac0e1d441719aec42658ae00b62a032c11`
+See `docs/architecture/2026-08-10-cortex-fossil-ownership-boundary.md` for the full contract.
 
-`fossil-lineage-context-v1` resolves durable relation endpoints before model execution. The failed-first B proof established: **top-k absence is not evidence of nonexistence**.
+### Cortex owns
 
-The SQLite regression remains:
+- agent/session/mission state;
+- task classification and executable methodology selection;
+- preflight/tool/risk gates;
+- model/worker dispatch;
+- retry/decomposition/fan-out/merge strategy;
+- context-window/resource budgets;
+- compression/decomposition decisions;
+- operational checkpoints/closeouts.
 
-- outcome `current_state_unresolved`;
-- claim `clm_a047d79b8604fadbd44efdf4`;
-- exact citation `cite_b4e13e4e1a809f76527311ba`.
+### FOSSIL owns
+
+- immutable evidence;
+- persistent semantic memory;
+- stable claim/source/relation/citation IDs;
+- provenance;
+- lifecycle/current-state semantics;
+- disagreement/supersession/history;
+- lineage reconstruction;
+- pack boundaries;
+- exact citations;
+- redaction/suppression;
+- proposal validation and durable commit;
+- corpus retrieval semantics and rebuildable graph/vector/lexical projections.
+
+Prevent double routing: Cortex provides task intent, pack scope, risk/resource/context constraints; FOSSIL executes the approved retrieval/lifecycle/lineage/citation semantics. Cortex must not bypass FOSSIL by querying a graph/vector index and treating that result as knowledge authority.
+
+## Gravebuster + local-PC deployment
+
+Treat the cluster as **one logical FOSSIL**, even when services run on multiple machines.
+
+Initial rule: use **one logical durable FOSSIL commit authority**, not independent multi-master semantic writers.
+
+Gravebuster and the local PC may host replaceable:
+
+- Graphiti/Neo4j projections;
+- BM25/vector indexes;
+- embedding/reranking services;
+- model servers/LiteLLM;
+- caches;
+- replicas/backups;
+- benchmark workers.
+
+Hosting does not confer semantic authority. Stable IDs and pack identity remain independent of machine/database placement.
+
+A future multi-writer topology requires a separate concurrency/consensus decision and proof.
+
+## Compression boundary
+
+Cortex owns model-context budgeting and the decision to compress/direct-read/decompose.
+
+FOSSIL owns the exact evidence/stable identities that compression is forbidden to corrupt.
+
+Required rules:
+
+- summaries never replace source evidence;
+- protected citation/source/claim identities survive verbatim where required;
+- numbers/code identifiers/provenance IDs may be protected spans;
+- compressed packets remain temporary untrusted context;
+- required-span loss fails closed;
+- if safe compression cannot meet budget, raise budget/direct-read/decompose instead of silent destructive compression;
+- a durable summary is a new derived proposal with provenance, never replacement evidence.
+
+The legacy SSC protected-span compressor is prior art only, not a live dependency.
+
+## Legacy `stupidly-simple-cortex` retirement
+
+The old SSC runtime should be retired rather than maintained as a second live memory system.
+
+Do **not** import the following as FOSSIL truth:
+
+- old SSC living-ontology/current-state values;
+- SSC BM25/vector ranking results;
+- generated conclusions/summaries;
+- old research prose merely because it was labeled research/reviewed/accepted/current;
+- old task/project state;
+- model consensus/judge conclusions.
+
+Old SSC research prose can remain historical/unverified source material for manual discovery, but no automatic ingestion into normal FOSSIL knowledge is required.
+
+## Legacy SSC evaluation estate — preserve separately
+
+A substantial valuable evaluation estate is actually committed in SSC and should be extracted separately from the retired runtime.
+
+Verified source revision inspected:
+
+`Pukujan/stupidly-simple-cortex@3b6668eff7a1859c37f1aa50c565f0387fdc4ffe`
+
+Verified asset classes include:
+
+- checker-decided `hard_gold` datasets;
+- generated 73-lane objective manifest with deterministic verdict paths and `judge_in_verdict_path=false`;
+- third-party-derived objective benchmark slices;
+- semi-ground/semi-truth judgment data;
+- rubrics/calibration anchors;
+- oracle/checker code;
+- frozen tests;
+- checker cores/resolvers;
+- promotion/quarantine/results-ledger machinery;
+- live/trainable hard-gold references and holdouts;
+- durable evaluation artifact indexes.
+
+Directly inspected examples include:
+
+- `evals/objective_tool_calling/hard_gold.jsonl` — real rows with objective verdict, BFCL AST checker authority, error/perturbation metadata, source/case ID, hard-gold provenance and reproducibility hash metadata;
+- `evals/hf_datasets/gsm_plus/hard_gold.jsonl` — committed prompt/reference-solution/reference-answer rows;
+- `evals/fable_capture/prompt_evals_semitruth.jsonl` — explicitly provisional candidate-only rows with `human_reviewed=false` and `ground_truth_for_now=false`.
+
+### Important stale-index finding
+
+Do not trust SSC's narrative artifact counts as the archive manifest.
+
+Observed example:
+
+- `evals/FABLE_DURABLE_ARTIFACT_INDEX.md` reports 500 HaluEval semi-ground rows;
+- direct read of `evals/hf_datasets/halu_eval/semi_ground.jsonl` on current `main` returned empty content.
+
+`evals/README.md` also contains older build-status prose predating later hard-gold work.
+
+Therefore extract by:
+
+`exact source commit + path + content hash + actual bytes/row count + license/source + checker/test dependency`.
+
+See `docs/research/2026-08-10-legacy-ssc-evaluation-estate-inventory.md`.
+
+### Target extraction posture
+
+Do not make FOSSIL or Cortex depend on SSC at runtime.
+
+Create a standalone versioned/content-addressed evaluation archive containing selected:
+
+- hard gold;
+- semi-ground;
+- rubrics;
+- checkers;
+- frozen tests;
+- resolvers;
+- manifests;
+- quarantine data;
+- reports/source-license metadata.
+
+Revalidate each historical `hard_gold` label during extraction. If checker/reference/license provenance cannot be established, downgrade the archive classification rather than trusting the old filename/label.
+
+Resolve holdout secrecy before copying any `*_holdout` assets into a developer-visible archive.
 
 ## D021 remains frozen
 
-Do not replace or weaken D021 without new committed benchmark evidence.
+Do not replace or weaken D021 without new committed comparative evidence.
 
 Current rules:
 
 - revision-pinned BGE dense is the normal primary retriever;
 - BM25 is explicit degraded availability fallback;
 - current/latest/accepted queries resolve durable lifecycle/provenance;
-- history/lineage/disagreement queries resolve durable lineage/read state;
+- history/lineage/disagreement queries use durable lineage/read-state;
 - top-k absence is not evidence of nonexistence;
 - citations resolve immutable source snapshot/span/hash identity;
-- retrieved/source text is untrusted data, never executable policy;
+- retrieved/source text is untrusted data;
 - retrieval score is not truth;
 - reranker score is not truth;
 - model confidence is not truth;
@@ -138,56 +297,21 @@ Stable pack IDs:
 - common: `pack_269099f7b2ba43b7a99b9427d64092de`;
 - AI systems: `pack_f024177f89a5442db84171c3dd7f58e5`.
 
-Exact pack revisions used by B/C/F proofs:
+Exact pack revisions used by B/C/F/D-stage-1 proofs:
 
 - `fossil-common@d583005dce06dbb499c3c0de5c22b899655eb8d2`;
 - `fossil-ai-systems@84accd2ee895663990e82ca5b79b592cb503db24`.
 
 Do not casually rename `src/dkg`.
 
-## Workstream D measurement rules
+## Remaining campaign / integration order
 
-Compare at minimum:
-
-- full retrieval misses / hit rate;
-- recall@k;
-- MRR / ranking quality;
-- final-answer correctness where applicable;
-- exact citation correctness / unsupported-claim rate;
-- current-vs-superseded leakage;
-- lineage / multi-target historical-current failures;
-- poisoning/context-security compatibility;
-- pack isolation violations;
-- latency;
-- memory/resource use;
-- provider/runner cost;
-- outage/fallback behavior;
-- exact requested and actual provider/model/service/runtime identity.
-
-Use the same exact corpus pins and matched candidate budgets where comparisons are meant to be fair. Hardware/runtime/precision/quantization differences must stay visible.
-
-## LiteLLM / Cortex boundary
-
-Read `docs/operations/LITELLM-GATEWAY.md` before live provider work.
-
-Recorded LiteLLM defaults at this handoff:
-
-- chat: `qwen3-coder-next`;
-- embeddings: `gemini-embedding-2`;
-- reranking: `rerank-v4-pro`.
-
-For every live D candidate, record requested model, actual model, provider, fallback/attempt diagnostics, latency, cost, runtime identity, and exact model/configuration identity where available. A fallback response is not proof that the requested model succeeded. Probe embedding and reranking lanes independently. Do not send secrets, personal information, or confidential documents while gateway retention guarantees remain unverified.
-
-Cortex v4 remains a replaceable cognitive-service/orchestration competitor. FOSSIL durable storage, stable identity, lifecycle/lineage, context-security, proposal-before-commit, and correctness guarantees must not couple to Cortex internals. Multiple agents agreeing does not manufacture truth.
-
-## Remaining campaign order
-
-1. **D / Issue #47** — embeddings, hybrid retrieval, rerankers, model bakeoff;
-2. **E** — conservative adaptive routing, only if benchmark justified;
-3. **G** — ACL/redaction propagation readiness;
-4. final D021/retrieval-policy decision reconciliation;
-5. decision log + residual risks + final handoff.
-
-## Suggested next-session prompt
-
-> Continue FOSSIL Issue #48 / Workstream D from this handoff. Verify GitHub first. Workstreams A, B, C, and F are complete; do not redo them. F landed in PR #64 / squash `42dab94b51a7b17f20c046f7257b912fe9f0c900`; final CI run `31437754923`, job `93615632123`, was 104/104 green. Execution-only PR #65 was closed unmerged after exact-pin run `31437447245`, job `93614630416`: 27 documents, 6 queries, 18 receipts, with answer correctness / exact replay identity / resolver recording / semantic-result stability / service-change visibility all 1.0. Issue #47 is active Workstream D. Start with comparable incumbent BM25/dense/hybrid/reranker evidence using `fossil.query-execution-receipt.v1`, then progress Qwen3-Embedding 0.6B → 4B → 8B only if justified. Preserve D021, stable pack IDs, `fossil-lineage-context-v1`, `fossil-untrusted-context-v1`, proposal-before-commit, and deterministic lifecycle/lineage authority. Receipts and model/reranker scores are not truth authority.
+1. **D stage 2** — BGE vs Qwen3-Embedding 0.6B vs Gemini Embedding 2, with matched reranker routes and Workstream-F receipts.
+2. **Legacy SSC evaluation-estate extraction** — separate archive/inventory track; not a live runtime dependency and not a blocker for basic D retrieval benchmarking unless an extracted eval is intentionally used.
+3. **Context-budget/compression benchmark** — preservation-safe Cortex context handling against direct/uncompressed baselines.
+4. **D 4B/8B only if justified** by prior evidence/resources.
+5. **E** — conservative adaptive routing, including direct-read vs retrieve vs retrieve+compress vs decompose where evidence supports it.
+6. **G** — ACL/redaction propagation readiness, including proof that retrieval/reranking/compression/replicas cannot resurrect suppressed data.
+7. **Cortex↔FOSSIL live integration proof** — Cortex persistent memory uses FOSSIL without SSC runtime dependency; exact IDs/citations/lifecycle/lineage survive the boundary; FOSSIL outage yields pending/uncommitted state rather than false success.
+8. final D021/retrieval-policy decision reconciliation;
+9. decision log + residual risks + final handoff.

--- a/docs/HANDOFF_CURRENT.md
+++ b/docs/HANDOFF_CURRENT.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-10  
 **Project:** **FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage**  
 **Repository:** `Pukujan/fossil-core`  
-**Status:** **Gate 1 complete. Gate 2 complete/formally closed. Post-Gate-2 campaign #48 active. Workstreams A/B/C/F complete. Workstream D stage 1 complete. D stage 2 is active next. Cortex↔FOSSIL ownership boundary is now explicitly documented; legacy `stupidly-simple-cortex` is being retired as a live memory/runtime authority while its evaluation estate is preserved separately.**
+**Status:** **Gate 1 complete. Gate 2 complete/formally closed. Post-Gate-2 campaign #48 active. Workstreams A/B/C/F complete. Workstream D stage 1 complete. D stage 2 is active next. Cortex↔FOSSIL ownership boundary is explicitly documented; legacy `stupidly-simple-cortex` is being retired as a live memory/runtime authority while its evaluation estate and engineering lessons are preserved separately.**
 
 ## Fresh-session transfer
 
@@ -13,17 +13,21 @@ Read, in order:
 2. `ARCHITECTURE.md`
 3. this file
 4. `docs/architecture/2026-08-10-cortex-fossil-ownership-boundary.md`
-5. `docs/research/2026-08-10-legacy-ssc-evaluation-estate-inventory.md`
-6. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-retrieval-bakeoff-stage1.md`
-7. `docs/PROJECT_STATE.md`
-8. `docs/implementation/2026-08-10-post-gate2-retrieval-bakeoff-stage1-proof.md`
-9. `docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md`
-10. `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`
-11. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
-12. `docs/operations/LITELLM-GATEWAY.md`
-13. Issue #48 — active production RAG hardening campaign
-14. Issue #47 — active Workstream D retrieval/reranking/model bakeoff
-15. `docs/DECISION_LOG.md`
+5. `docs/architecture/2026-08-10-context-construction-compression-boundary.md`
+6. `docs/research/2026-08-10-legacy-ssc-engineering-retrospective.md`
+7. `docs/research/2026-08-10-legacy-ssc-evaluation-estate-inventory.md`
+8. `docs/research/2026-08-10-legacy-eval-estate-deduplication-policy.md`
+9. `docs/handoffs/2026-08-10-chatgpt-session-handoff-post-retrieval-bakeoff-stage1.md`
+10. `docs/PROJECT_STATE.md`
+11. `docs/implementation/2026-08-10-post-gate2-retrieval-bakeoff-stage1-proof.md`
+12. `docs/implementation/2026-08-10-post-gate2-query-execution-receipt-proof.md`
+13. `docs/implementation/2026-08-10-post-gate2-retrieval-poisoning-proof.md`
+14. `docs/implementation/2026-08-10-post-gate2-answer-reliability-proof.md`
+15. `docs/operations/LITELLM-GATEWAY.md`
+16. Issue #73 — master integration tracker
+17. Issue #48 — active production RAG hardening campaign
+18. Issue #47 — active Workstream D retrieval/reranking/model bakeoff
+19. `docs/DECISION_LOG.md`
 
 Verify GitHub state before changing anything.
 
@@ -38,6 +42,8 @@ Do not redo:
 - Workstream C — retrieval poisoning/untrusted context;
 - Workstream F — query execution receipts;
 - Workstream D stage 1 — incumbent/hybrid/real-reranker matched bakeoff.
+
+Do not treat old SSC research, ontology, current-state conclusions, or runtime components as current FOSSIL/Cortex authority. The historical retrospective exists to preserve lessons and failed experiments without reintroducing the monolith.
 
 ## Workstream D stage 1 — complete
 
@@ -117,7 +123,7 @@ Do not automatically progress to Qwen 4B or 8B. The preceding result and resourc
 
 ## Cortex ↔ FOSSIL ownership boundary
 
-The durable boundary is now:
+The durable boundary is:
 
 > **Cortex owns execution. FOSSIL owns knowledge. FOSSIL projections retrieve knowledge. Infrastructure runs the components. Models propose; deterministic gates commit.**
 
@@ -133,9 +139,10 @@ See `docs/architecture/2026-08-10-cortex-fossil-ownership-boundary.md` for the f
 - task classification and executable methodology selection;
 - preflight/tool/risk gates;
 - model/worker dispatch;
-- retry/decomposition/fan-out/merge strategy;
-- context-window/resource budgets;
-- compression/decomposition decisions;
+- retry/fan-out/merge strategy;
+- task-level context-window/resource budget;
+- the decision to direct-read, request bounded context, decompose, or escalate;
+- compression of Cortex-owned operational/session notes;
 - operational checkpoints/closeouts.
 
 ### FOSSIL owns
@@ -151,9 +158,10 @@ See `docs/architecture/2026-08-10-cortex-fossil-ownership-boundary.md` for the f
 - exact citations;
 - redaction/suppression;
 - proposal validation and durable commit;
-- corpus retrieval semantics and rebuildable graph/vector/lexical projections.
+- corpus retrieval semantics and rebuildable graph/vector/lexical projections;
+- evidence-safe context construction/compression of FOSSIL-sourced material through `ContextProvider`.
 
-Prevent double routing: Cortex provides task intent, pack scope, risk/resource/context constraints; FOSSIL executes the approved retrieval/lifecycle/lineage/citation semantics. Cortex must not bypass FOSSIL by querying a graph/vector index and treating that result as knowledge authority.
+Prevent double routing: Cortex provides task intent, pack scope, risk/resource/context constraints; FOSSIL executes the approved retrieval/lifecycle/lineage/citation/context-construction semantics. Cortex must not bypass FOSSIL by querying a graph/vector index and treating that result as knowledge authority.
 
 ## Gravebuster + local-PC deployment
 
@@ -175,23 +183,29 @@ Hosting does not confer semantic authority. Stable IDs and pack identity remain 
 
 A future multi-writer topology requires a separate concurrency/consensus decision and proof.
 
-## Compression boundary
+## Compression/context-construction boundary
 
-Cortex owns model-context budgeting and the decision to compress/direct-read/decompose.
+Cortex owns the task-level context budget and chooses among direct read, bounded context construction, larger-context execution, decomposition, and escalation.
 
-FOSSIL owns the exact evidence/stable identities that compression is forbidden to corrupt.
+FOSSIL `ContextProvider` owns evidence-safe context construction/compression for FOSSIL-sourced material because ACLs, redaction, stable IDs, exact citation spans, lifecycle, and lineage must remain enforceable through the transformation.
 
 Required rules:
 
+- **filter first, compress second**;
 - summaries never replace source evidence;
 - protected citation/source/claim identities survive verbatim where required;
 - numbers/code identifiers/provenance IDs may be protected spans;
+- source→compressed mapping and a preservation report are required for lossy/structured transformations;
 - compressed packets remain temporary untrusted context;
 - required-span loss fails closed;
-- if safe compression cannot meet budget, raise budget/direct-read/decompose instead of silent destructive compression;
-- a durable summary is a new derived proposal with provenance, never replacement evidence.
+- if safe context construction cannot meet budget, Cortex raises budget/direct-reads/decomposes instead of silently dropping evidence;
+- a durable summary is a new derived proposal with provenance, never replacement evidence;
+- uncompressed retrieve-then-read and selection-only baselines remain mandatory in the benchmark;
+- any lossy compressor must earn itself under matched answer/citation/security/resource evidence.
 
-The legacy SSC protected-span compressor is prior art only, not a live dependency.
+The legacy SSC protected-span/deep-audit research is historical prior art only, not a live dependency or current evidence for accepting compression.
+
+See `docs/architecture/2026-08-10-context-construction-compression-boundary.md`.
 
 ## Legacy `stupidly-simple-cortex` retirement
 
@@ -206,7 +220,33 @@ Do **not** import the following as FOSSIL truth:
 - old task/project state;
 - model consensus/judge conclusions.
 
-Old SSC research prose can remain historical/unverified source material for manual discovery, but no automatic ingestion into normal FOSSIL knowledge is required.
+Old SSC research prose can remain historical/unverified source material for project archaeology, but no automatic ingestion into normal FOSSIL knowledge is required.
+
+## Legacy SSC engineering retrospective — preserve lessons, not components
+
+Historical research and reviews have now been explicitly preserved in:
+
+`docs/research/2026-08-10-legacy-ssc-engineering-retrospective.md`
+
+The retrospective records useful methodology and failure evidence without authorizing integration. Important observed themes include:
+
+- early Fable evidence-tier discipline and correction of bad imported research;
+- the SSRF sequence of live exploit → independent TDD contract → separate implementation → live adversarial verification → residual DNS-rebinding finding;
+- system-coherence failures where the corpus could not index its own critical planning docs;
+- retrieval false negatives that demonstrate why absence from top-k cannot imply nonexistence;
+- documentation/runtime and MCP-contract drift;
+- concurrency/operational-state concerns mixed into the corpus domain;
+- a state-machine design with good single-writer/event-sourcing/policy-separation ideas but an overly broad “server DB is the only truth” statement;
+- deep-audit/context research that correctly recognized provenance-never-replacement and context-growth problems but lacked today's explicit Cortex/FOSSIL ownership boundary;
+- later provenance/ownership designs that were careful to state they provided zero protection until actually built/anchored.
+
+The principal lesson carried forward is:
+
+> **Good local designs do not compose safely when ownership is ambiguous.**
+
+Operational truth, semantic knowledge truth, evaluation-label authority, and infrastructure state are separate domains.
+
+Future owner-supplied historical material should arrive as separate immutable source bundles and be classified as `validated_methodology_example`, `historical_lesson`, `failed_experiment`, `superseded_design`, `obsolete_unverified`, or `historical_source_only` rather than silently becoming current architecture.
 
 ## Legacy SSC evaluation estate — preserve separately
 
@@ -269,9 +309,13 @@ Create a standalone versioned/content-addressed evaluation archive containing se
 - quarantine data;
 - reports/source-license metadata.
 
+Raw source bundles remain immutable. Normalization/deduplication is derived and provenance-preserving; intentional mutation/counterexample families and conflicting labels are not silently collapsed. Cross-dataset leakage/holdout exposure must be measured explicitly.
+
 Revalidate each historical `hard_gold` label during extraction. If checker/reference/license provenance cannot be established, downgrade the archive classification rather than trusting the old filename/label.
 
 Resolve holdout secrecy before copying any `*_holdout` assets into a developer-visible archive.
+
+See `docs/research/2026-08-10-legacy-eval-estate-deduplication-policy.md`.
 
 ## D021 remains frozen
 
@@ -306,12 +350,17 @@ Do not casually rename `src/dkg`.
 
 ## Remaining campaign / integration order
 
+The master checklist is Issue #73. Current high-level order:
+
 1. **D stage 2** — BGE vs Qwen3-Embedding 0.6B vs Gemini Embedding 2, with matched reranker routes and Workstream-F receipts.
-2. **Legacy SSC evaluation-estate extraction** — separate archive/inventory track; not a live runtime dependency and not a blocker for basic D retrieval benchmarking unless an extracted eval is intentionally used.
-3. **Context-budget/compression benchmark** — preservation-safe Cortex context handling against direct/uncompressed baselines.
-4. **D 4B/8B only if justified** by prior evidence/resources.
-5. **E** — conservative adaptive routing, including direct-read vs retrieve vs retrieve+compress vs decompose where evidence supports it.
-6. **G** — ACL/redaction propagation readiness, including proof that retrieval/reranking/compression/replicas cannot resurrect suppressed data.
-7. **Cortex↔FOSSIL live integration proof** — Cortex persistent memory uses FOSSIL without SSC runtime dependency; exact IDs/citations/lifecycle/lineage survive the boundary; FOSSIL outage yields pending/uncommitted state rather than false success.
-8. final D021/retrieval-policy decision reconciliation;
-9. decision log + residual risks + final handoff.
+2. **Legacy SSC evaluation-estate extraction** — separate archive/inventory track; incorporate later owner-supplied missing assets as separate immutable bundles.
+3. **Dataset normalization/dedupe/leakage proof** — preserve raw bytes, derive deduped/family-aware views, expose holdout leakage honestly.
+4. **Context-budget/compression benchmark** — FOSSIL ContextProvider safety/integrity against direct/uncompressed and selection-only baselines.
+5. **D 4B/8B only if justified** by prior evidence/resources.
+6. **E** — conservative adaptive routing, including direct-read vs retrieve vs retrieve+safe-context-construction vs decompose where evidence supports it.
+7. **G** — ACL/redaction propagation readiness, including proof that retrieval/reranking/context construction/replicas cannot resurrect suppressed data.
+8. **Cortex↔FOSSIL live integration proof** — Cortex persistent memory uses FOSSIL without SSC runtime dependency; exact IDs/citations/lifecycle/lineage survive the boundary; FOSSIL outage yields pending/uncommitted state rather than false success.
+9. **Gravebuster/local-PC deployment proof** — one logical durable writer initially, rebuildable projections/services on either node, backup/recovery proven.
+10. final D021/context/retrieval-policy decision reconciliation;
+11. decision log + residual risks + final handoff;
+12. legacy SSC formally cold after eval recovery and live dependency removal are proven.

--- a/docs/architecture/2026-08-10-context-construction-compression-boundary.md
+++ b/docs/architecture/2026-08-10-context-construction-compression-boundary.md
@@ -1,0 +1,243 @@
+# Context Construction and Compression Boundary
+
+**Date:** 2026-08-10  
+**Status:** accepted design boundary; benchmark and implementation pending  
+**Refines:** `docs/architecture/2026-08-10-cortex-fossil-ownership-boundary.md`
+
+## Decision
+
+Compression is split into **control policy** and **evidence-safe context construction**.
+
+- **Cortex owns the task-level budget decision:** how much context a worker may receive, latency/cost preference, whether compression is allowed, and whether the task should instead direct-read, expand the budget, or decompose.
+- **FOSSIL owns evidence-safe context construction over FOSSIL knowledge:** selection, retrieval-resolved source/claim/citation identity, protected-span handling, and any lossy compression applied to FOSSIL-sourced context.
+- A FOSSIL implementation should live behind the replaceable `ContextProvider`/context-construction service boundary rather than becoming durable-storage logic.
+- Cortex may independently compress its own operational/session notes because those are Cortex working memory, not FOSSIL evidence.
+
+This split prevents Cortex from becoming a second RAG implementation while keeping orchestration decisions in the harness.
+
+## Invariant
+
+**A compressed packet is a temporary execution view. It never replaces, rewrites, or upgrades the authority of its source evidence.**
+
+The source snapshot/span/hash remains the citation target. A summary is derived context, not the cited original.
+
+## Prior art being retained
+
+The legacy `stupidly-simple-cortex` GAP-CORTEX-0011 work is useful prior art, especially:
+
+1. select/retrieve before compressing;
+2. retain protected/high-relevance material verbatim;
+3. content-type-specific reduction rather than one universal compressor;
+4. fail closed when protected material disappears;
+5. explicitly decompose/escalate when safe compression cannot fit the target budget.
+
+That implementation is **not** imported as authority and the old SSC runtime is not a dependency. The ideas must be re-expressed behind the FOSSIL context contract and re-evaluated.
+
+## Required pipeline
+
+Conceptually:
+
+```text
+Cortex request
+  task/query class
+  readable pack/sensitivity scope
+  target context budget
+  direct-read/compression/decompose permissions
+        |
+        v
+FOSSIL retrieval + lifecycle/lineage resolution
+        |
+        v
+ACL/redaction/suppression filter
+        |
+        v
+selection/ranking of eligible evidence
+        |
+        v
+FOSSIL ContextProvider
+  protected-span registry
+  content-aware skeletonization/extraction
+  optional lossy prose compression
+  preservation verification
+        |
+        +--> context packet fits -> return packet + mapping/receipt
+        |
+        +--> cannot fit safely -> explicit NEEDS_DECOMPOSITION / LARGER_CONTEXT
+
+Cortex then decides whether to decompose, direct-read, change worker/model, or request a larger budget.
+```
+
+Compression never runs before pack/sensitivity filtering.
+
+## Protected material
+
+At minimum the preservation contract must be able to protect:
+
+- stable FOSSIL source IDs;
+- claim/relation IDs when supplied to the model;
+- citation IDs;
+- exact citation spans required by the task;
+- source snapshot hashes/revision identifiers where present;
+- numbers and units when material to a claim;
+- dates when material to temporal reasoning;
+- code identifiers, symbols, API names, file paths, and exact configuration keys when material;
+- explicit lifecycle terms needed to distinguish current/superseded/disputed/retracted state;
+- provenance identifiers required to reconstruct source → derived context lineage.
+
+Not every number/token in a large document must always be protected. Protection is task/context-contract driven, and the preservation report must record what was designated protected.
+
+## Content-type handling
+
+The initial benchmark should distinguish at least:
+
+- prose;
+- code/configuration;
+- tables/structured records;
+- numeric/financial material;
+- citation-heavy research;
+- lifecycle/lineage histories.
+
+A single lossy prose compressor must not be assumed safe for all of them.
+
+Preferred order:
+
+1. **selection first** — remove irrelevant evidence before transforming relevant evidence;
+2. **verbatim protected/high-value slices**;
+3. **structure-preserving extraction/skeletonization** where possible;
+4. **optional lossy prose compression** only on eligible surviving prose;
+5. **verification** of protected spans and source mapping;
+6. **decomposition/escalation** if the budget remains impossible.
+
+## Failure semantics
+
+Compression must fail closed when:
+
+- a required protected span cannot be restored exactly;
+- source→compressed mapping is missing or ambiguous for cited material;
+- compression crosses a pack/ACL/sensitivity boundary;
+- redacted/suppressed material appears in the packet;
+- a claimed citation can no longer resolve to the original immutable source span;
+- required lifecycle/lineage distinction is lost;
+- the target budget can be reached only by violating the preservation contract.
+
+The terminal outcome is not `best_effort_success`. It is an explicit result such as:
+
+- `larger_context_required`;
+- `direct_source_read_required`;
+- `decompose_required`;
+- `unsafe_to_compress`.
+
+## Untrusted-context rule
+
+Compressed text remains untrusted model context and must remain compatible with `fossil-untrusted-context-v1`.
+
+Compression cannot:
+
+- turn source instructions into harness policy;
+- generate a new trusted claim merely by summarizing several sources;
+- bypass the deterministic lifecycle/lineage resolver;
+- convert model confidence/consensus into evidence;
+- silently invent or regenerate stable IDs/citations.
+
+## Context-budget benchmark
+
+A dedicated benchmark is required before enabling lossy compression in normal operation.
+
+Suggested budgets:
+
+- 8k;
+- 16k;
+- 32k;
+- 64k;
+- optionally a larger direct-read control when the selected model supports it.
+
+Compare, under matched selected evidence where possible:
+
+1. uncompressed retrieve-then-read;
+2. selection-only context construction;
+3. structure-preserving/extractive reduction;
+4. safe compressed context;
+5. decompose/direct-read route when compression cannot safely fit.
+
+Measure at least:
+
+- final-answer correctness;
+- exact citation/source-snapshot correctness;
+- unsupported-claim rate;
+- current-vs-superseded leakage;
+- lineage/history reconstruction correctness;
+- numeric/date/code-identifier preservation;
+- protected-span preservation rate;
+- source→compressed mapping completeness;
+- compression ratio;
+- context tokens/bytes before and after;
+- latency;
+- memory/resource use;
+- model/provider cost when applicable;
+- decomposition frequency;
+- fail-closed frequency and reason;
+- poisoning/untrusted-context compatibility;
+- ACL/redaction non-leakage.
+
+The simple uncompressed/selection-only baseline is mandatory. Compression earns deployment only if it improves the quality/resource frontier without weakening evidence guarantees.
+
+## Query execution receipt extension
+
+Workstream-F receipts should be extended or versioned to record context construction when compression is used:
+
+- requested context budget;
+- actual context size;
+- ContextProvider/compressor name + version/revision;
+- exact runtime/provider/model if a model-based compressor is used;
+- selected input stable IDs;
+- protected-span policy/version;
+- protected-span count/hash or bounded preservation summary;
+- compression stages/strategy;
+- source→compressed mapping identity;
+- final context IDs;
+- preservation verification result;
+- compression/decomposition/fallback outcome;
+- latency/cost/resource observations;
+- run/trace reference.
+
+The receipt remains observability/replay evidence, not truth authority.
+
+## Security dependency
+
+Workstream G must prove that every context-construction route obeys the same pack/ACL/redaction boundary.
+
+Hard rule:
+
+**filter first, compress second.**
+
+A compressor must never receive inaccessible source material and then be expected to redact it afterward. This limits accidental leakage through summaries, embeddings, caches, or restoration buffers.
+
+## Relationship to retrieval/model bakeoff
+
+Do not mix compression changes into the matched Workstream-D embedding/reranker benchmark until the context-budget benchmark is versioned. Finish a clean D stage-2 comparison first or run compression as a separately named/receipted factor.
+
+Better retrieval may reduce the need for aggressive compression. Safe context construction may reduce the need to escalate embedding/model size. Therefore the 4B/8B decision should consider results from the context-budget benchmark rather than assume larger models are the next step.
+
+## Implementation sequence
+
+1. freeze this preservation/context contract;
+2. add preservation-report data model + tests;
+3. implement selection-only ContextProvider baseline;
+4. add content-type-aware structure-preserving reduction;
+5. add optional lossy prose compressor behind an adapter only if justified;
+6. extend Workstream-F receipts for context construction;
+7. run matched context-budget benchmark;
+8. run poisoning + lifecycle/lineage + citation regression suites;
+9. run ACL/redaction tests before shared deployment;
+10. accept, reject, or constrain compression with an explicit decision record.
+
+## Non-goals
+
+This decision does not authorize:
+
+- replacing immutable source evidence with summaries;
+- storing compressed packets as canonical snapshots of the source;
+- soft-token/activation compression as durable knowledge;
+- a model summarizer becoming truth authority;
+- compressor access around pack/ACL rules;
+- universal claims that compression is safe.

--- a/docs/architecture/2026-08-10-cortex-fossil-ownership-boundary.md
+++ b/docs/architecture/2026-08-10-cortex-fossil-ownership-boundary.md
@@ -28,6 +28,8 @@ The new architecture must not recreate the old monolith by allowing Cortex and F
 | Task classification / methodology selection | Cortex | Executable control policy belongs to the harness |
 | Tool/risk gates / preflight / retries | Cortex | FOSSIL does not schedule or authorize agent actions |
 | Model/worker dispatch | Cortex | Models remain replaceable workers |
+| Model/API capability registry | Cortex control plane + replaceable transport adapters | Shared machine-readable limits/capabilities/errors; methodology must not guess provider behavior |
+| Provider transport / LiteLLM / local model servers | Replaceable infrastructure service | API wiring, serialization, bounded transport failover, quota/capacity reporting; never methodology-loop authority |
 | Context-window budget | Cortex | Chooses budget and whether compression/decomposition is needed |
 | Compression/decomposition strategy | Cortex | May transform temporary context but may not rewrite FOSSIL evidence |
 | Immutable source evidence | FOSSIL | Canonical durable bytes + stable identity |
@@ -41,6 +43,65 @@ The new architecture must not recreate the old monolith by allowing Cortex and F
 | Graphiti/Neo4j knowledge graph | FOSSIL projection layer | Rebuildable view, never canonical identity/truth |
 | Gravebuster / local PC / future nodes | Infrastructure | Host services/projections; hosting does not confer semantic authority |
 | Legacy `stupidly-simple-cortex` | Retired migration source | No new runtime or truth authority |
+
+## Replaceable model/API boundary
+
+LiteLLM, provider APIs, local model servers, embedding services, rerankers, and future gateways are replaceable execution infrastructure. They expose capabilities and perform bounded invocations; they do not own the methodology loop.
+
+Cortex owns logical execution policy, including:
+
+- which methodology state runs next;
+- whether another model turn is allowed;
+- whole-task and per-turn deadlines;
+- same-route retry budget;
+- cross-route fallback/escalation budget;
+- checkpoint/recovery generation;
+- decomposition/fan-out/merge;
+- terminal completion/block/failure after mechanical verification.
+
+The transport/gateway layer owns provider mechanics only, including endpoint/auth wiring, request serialization, provider-specific parameter translation, bounded low-level node/provider failover when explicitly allowed, and normalized reporting of actual route/model/error/usage.
+
+**Hidden provider/gateway logical retry loops are forbidden.** Any transport retry/failover must be bounded, visible in the execution receipt, and charged against Cortex's explicit policy budget.
+
+### Shared capability/limit registry
+
+Workers and methodologies must not guess provider/model behavior. Cortex should consume a shared versioned machine-readable registry for invokable routes. Where known, the registry records:
+
+- route/profile identity;
+- provider/service/protocol kind;
+- requested alias and actual/upstream model identity;
+- supported modalities, tool calling, structured output, streaming and endpoint type;
+- context-window and max-output limits;
+- payload, batch, document-count and embedding/reranker limits;
+- embedding dimensions/normalization/prompt policy where applicable;
+- supported parameters/ranges;
+- model/provider/key-pool concurrency and rate-limit scope;
+- quota/cooldown/`retry-after` behavior;
+- timeout bounds;
+- cost/accounting unit where known;
+- privacy/retention/ZDR status where known;
+- canonical normalized error classes;
+- retryability/fallback eligibility per error class;
+- health/probe status and registry provenance/version.
+
+Unknown fields remain explicitly unknown/unverified rather than inferred from model names or old behavior.
+
+Shared quotas and API limits are centrally coordinated. A WorkOrder requests a capability/profile; it does not invent sleeps, rate-limit heuristics, alternate endpoints, provider-specific loops, or error-string parsing.
+
+Conceptually:
+
+```text
+Cortex methodology step
+  -> summon(capability/profile, task constraints, budget)
+  -> shared dispatcher resolves approved route/capacity
+  -> one bounded mechanical invocation
+  -> normalized result/error + requested/actual identity + usage/limit metadata
+  -> Cortex decides next logical state
+```
+
+Provider errors should be normalized into shared classes such as `rate_limited`, `quota_exhausted`, `context_limit_exceeded`, `unsupported_feature`, `invalid_request`, `authentication_failed`, `provider_unavailable`, `transport_timeout`, `model_timeout`, `content_policy_rejected`, `capacity_exhausted`, `response_malformed`, and `unknown_provider_error`, with structured retry/fallback/cooldown metadata.
+
+Methodologies should describe the capability and success contract, not vendor recipes. Replacing LiteLLM/provider/model/local runtime should change the adapter/registry and require relevant evals, but should not require rewriting Cortex methodology or FOSSIL semantics.
 
 ## Memory classes
 

--- a/docs/architecture/2026-08-10-cortex-fossil-ownership-boundary.md
+++ b/docs/architecture/2026-08-10-cortex-fossil-ownership-boundary.md
@@ -1,0 +1,278 @@
+# Cortex–FOSSIL Ownership Boundary
+
+**Date:** 2026-08-10  
+**Status:** accepted architecture boundary, pending implementation wiring  
+**Scope:** Cortex v4, FOSSIL, Gravebuster/local-PC deployment, and retirement of the legacy `stupidly-simple-cortex` runtime
+
+## One-sentence invariant
+
+**Cortex owns execution. FOSSIL owns knowledge. FOSSIL projections retrieve knowledge. Infrastructure runs the components. Models propose; deterministic gates commit.**
+
+A second rule prevents future overlap:
+
+**Cortex may decide when and why to ask memory; it cannot decide what durable memory means. FOSSIL may use replaceable models/retrievers internally; it cannot decide what an agent is allowed to do next.**
+
+## Why this boundary exists
+
+The legacy `stupidly-simple-cortex` system combined corpus/RAG, living ontology/current-state graph, audit/write paths, task coordination, project state, evaluation machinery, and harness behavior in one workspace. Cortex v4 has already moved toward a narrower role by owning live-session classification, preflight, gating, and closeout while treating the old SSC corpus as a dependency.
+
+FOSSIL was designed around the opposite durability rule: immutable evidence, stable corpus-owned identities, append-only knowledge-changing events, provenance, lifecycle/lineage, and reconstructable projections. Graph databases, indexes, embedding models, rerankers, model services, and harnesses are replaceable.
+
+The new architecture must not recreate the old monolith by allowing Cortex and FOSSIL to become competing memory systems.
+
+## Ownership table
+
+| Concern | Owner | Boundary |
+|---|---|---|
+| Agent session / mission state | Cortex | Operational and resumable; not canonical knowledge |
+| Task classification / methodology selection | Cortex | Executable control policy belongs to the harness |
+| Tool/risk gates / preflight / retries | Cortex | FOSSIL does not schedule or authorize agent actions |
+| Model/worker dispatch | Cortex | Models remain replaceable workers |
+| Context-window budget | Cortex | Chooses budget and whether compression/decomposition is needed |
+| Compression/decomposition strategy | Cortex | May transform temporary context but may not rewrite FOSSIL evidence |
+| Immutable source evidence | FOSSIL | Canonical durable bytes + stable identity |
+| Persistent semantic memory | FOSSIL | Claims, relations, provenance, lifecycle, lineage, disagreement |
+| Stable claim/source/citation IDs | FOSSIL | Survive database/model/machine changes |
+| Lifecycle / supersession / current-state semantics | FOSSIL | Never inferred solely from retrieval rank or Cortex state |
+| Knowledge packs / read-write scope | FOSSIL | Logical identity independent of physical placement |
+| Proposal validation / durable commit | FOSSIL | Deterministic gate owns knowledge-changing transaction |
+| Retrieval semantics | FOSSIL | Corpus-specific retrieval policy, lineage/lifecycle resolution, citation semantics |
+| BM25/vector/reranker implementations | FOSSIL projection/service layer | Replaceable and benchmarked; scores are not truth |
+| Graphiti/Neo4j knowledge graph | FOSSIL projection layer | Rebuildable view, never canonical identity/truth |
+| Gravebuster / local PC / future nodes | Infrastructure | Host services/projections; hosting does not confer semantic authority |
+| Legacy `stupidly-simple-cortex` | Retired migration source | No new runtime or truth authority |
+
+## Memory classes
+
+### Cortex working memory
+
+Examples:
+
+- active task and task class;
+- current mission/sub-agent assignments;
+- preflight status;
+- tool calls and gate outcomes;
+- retry/decomposition state;
+- selected context budget;
+- temporary compressed context;
+- local pending proposals while FOSSIL is unavailable.
+
+This state may be checkpointed, compressed, resumed, or discarded. It is not durable truth merely because it persisted on disk.
+
+### FOSSIL persistent memory
+
+Examples:
+
+- immutable evidence/source snapshots;
+- claims and relationships;
+- explicit provenance;
+- accepted/rejected/disputed/superseded/retracted state;
+- historical lineage and intellectual path;
+- exact citations/spans/hashes;
+- pack identity and dependencies;
+- redaction/suppression state;
+- knowledge-changing audit/provenance events.
+
+This state survives agents, models, indexes, graphs, and physical machines.
+
+### Operational telemetry
+
+High-volume traces, token/tool events, stack traces, timing, CPU/GPU measurements, and verbose provider diagnostics stay outside canonical knowledge. FOSSIL may retain durable run/trace references and knowledge-changing provenance where appropriate.
+
+## Retrieval responsibility: prevent double routing
+
+Cortex and FOSSIL must not both independently implement semantic retrieval policy.
+
+Cortex may specify **intent and constraints**, for example:
+
+- task/query class;
+- readable pack scope;
+- risk class;
+- latency/resource preference;
+- desired context budget;
+- whether direct-source reading or decomposition is acceptable.
+
+FOSSIL owns **knowledge retrieval semantics**, including:
+
+- the approved retrieval profile (currently D021 until superseded by evidence);
+- lexical/dense/hybrid/reranker execution behind replaceable interfaces;
+- lifecycle/provenance resolution for current/latest/accepted questions;
+- lineage/read-state resolution for history/disagreement/supersession questions;
+- exact citation/source identity;
+- pack isolation;
+- fallback identity and degraded-mode disclosure.
+
+Cortex must not bypass those semantics by directly querying a vector index or graph and treating its result as authoritative knowledge.
+
+## Cortex → FOSSIL durable-memory promotion
+
+An agent saying “remember this” does not create truth.
+
+The normal path is:
+
+```text
+Cortex session / model
+    -> structured proposal
+    -> source/session/run references
+    -> evidence/provenance
+    -> FOSSIL schema + stable-reference validation
+    -> pack/write-scope validation
+    -> evidence/risk/policy gate
+    -> atomic durable FOSSIL event
+    -> asynchronous projection update
+```
+
+A Cortex closeout, research result, compressed context packet, or multi-model consensus remains candidate material unless it passes this path.
+
+If FOSSIL is unavailable, Cortex may retain a visibly **pending/uncommitted proposal**. It must never claim that a durable memory write succeeded.
+
+## Compression boundary
+
+Cortex owns the decision to fit a task into a model context window. FOSSIL owns the evidence identities that must survive intact.
+
+Required rules:
+
+- source snapshots are never replaced by summaries;
+- claim/source/citation IDs and required citation spans are protected;
+- numbers/code identifiers/provenance IDs may be designated protected spans;
+- a compression result is temporary untrusted context, not canonical evidence;
+- loss of required protected material fails closed;
+- if safe compression cannot meet the budget, Cortex must raise the budget, direct-read, or decompose rather than silently over-compress;
+- any durable summary produced from compression is a new derived proposal with provenance, never a replacement for its source.
+
+The legacy SSC protected-span/fail-closed compressor is useful prior art, not a component FOSSIL must import or trust.
+
+## Cluster topology: Gravebuster + local PC
+
+For the first persistent deployment, use **one logical FOSSIL commit authority** rather than independent multi-master semantic writers.
+
+Gravebuster and the local PC may independently host:
+
+- Neo4j/Graphiti projections;
+- BM25/vector indexes;
+- embedding/reranking services;
+- LiteLLM/model services;
+- caches;
+- benchmark workers;
+- backup/replica copies.
+
+These are physical placements. Stable FOSSIL pack/claim/source identity does not change when a projection or service moves machines.
+
+Failure rules:
+
+- graph loss -> rebuild from durable events/evidence;
+- vector/index loss -> rebuild or use explicit degraded retrieval;
+- model/reranker loss -> route/fallback with requested-vs-actual identity visible;
+- Cortex crash -> resume/reconstruct operational state;
+- FOSSIL durable-write outage -> no false durable-memory success; queue/persist only an explicit pending proposal;
+- loss of FOSSIL durable evidence/events -> actual memory loss and therefore the primary backup/recovery concern.
+
+Multi-writer/multi-master durable commits require a separate concurrency/consensus decision and proof; they are not implied by running FOSSIL on multiple machines.
+
+## Legacy `stupidly-simple-cortex` retirement
+
+The legacy SSC runtime is **not** a third live authority.
+
+Retire as active architecture:
+
+- SSC corpus/RAG service;
+- SSC living ontology/current-state graph;
+- SSC BM25/vector indexes;
+- SSC generated current-state conclusions;
+- SSC project/task state as system authority;
+- SSC memory sidecars;
+- any direct Cortex-v4 dependency on SSC for persistent memory after FOSSIL wiring lands.
+
+Do not migrate old SSC ontology/current-state values as FOSSIL truth. If historically useful, preserve them only as source artifacts/candidates with explicit provenance.
+
+### Legacy SSC evaluation estate is different
+
+SSC contains potentially valuable evaluation assets that are **not semantic memory**:
+
+- checker-decided `hard_gold` datasets;
+- third-party-derived objective benchmark slices;
+- semi-ground / semi-truth judgment datasets;
+- rubrics and calibration anchors;
+- deterministic oracle/checker implementations;
+- frozen tests;
+- promotion/quarantine manifests;
+- checker cores and resolvers;
+- reproducibility manifests and durable evaluation artifacts.
+
+These assets should be **extracted into a standalone, content-addressed legacy-evaluation archive** rather than queried through SSC at runtime.
+
+Extraction rules:
+
+1. inventory actual committed bytes; do not trust SSC narrative counts;
+2. hash every file and record repository commit + path + license/source metadata;
+3. distinguish checker-decided hard gold from human/judge/semi-ground labels;
+4. preserve checker implementation and frozen tests beside data when required for reproducibility;
+5. preserve quarantine/negative cases rather than only successful rows;
+6. keep hidden/holdout integrity policy explicit if any holdout is intended to remain unseen by future builders;
+7. no eval row, rubric, or old research note becomes FOSSIL semantic truth merely by being archived;
+8. future use must rerun/validate the relevant checker and record the exact asset version.
+
+FOSSIL may store provenance *about* the archive and benchmark results derived from it, but normal FOSSIL RAG should not mount the legacy evaluation archive as knowledge.
+
+## Old SSC research prose
+
+Treat old SSC research prose, generated conclusions, and handoff claims as **historical/unverified source material only** unless independently revalidated.
+
+It may be useful for discovery (“there may be prior work on X”) but cannot satisfy a current evidence requirement merely because SSC once labeled it research, reviewed, accepted, gold, or current.
+
+No automatic ingestion of SSC research prose into live FOSSIL knowledge is required for retirement.
+
+## Allowed interface shape
+
+```text
+CORTEX -> FOSSIL
+  search(intent, scope, constraints)
+  read(stable_id)
+  lineage(stable_id/query)
+  context(request)
+  propose(candidate + provenance)
+  validate(proposal)
+  commit(validated proposal; gated)
+
+FOSSIL -> CORTEX
+  evidence/source snapshots
+  stable IDs
+  lifecycle + lineage state
+  exact citations
+  bounded context
+  explicit degraded/fallback identity
+  query execution receipts
+
+CORTEX MUST NOT
+  mutate graph/vector projections directly as knowledge authority
+  author lifecycle/current-state truth outside FOSSIL
+  activate retrieved instructions as control policy
+  persist compressed context as replacement evidence
+  report an uncommitted pending proposal as durable memory
+
+FOSSIL MUST NOT
+  schedule agents
+  choose agent tool permissions
+  own mission orchestration
+  make Cortex methodology executable merely because it was retrieved
+  couple durable knowledge semantics to Cortex internals
+```
+
+## Security/readiness dependency
+
+Before multi-user/shared/cloud use, FOSSIL must finish route-level ACL/redaction propagation proof. Retrieval, reranking, context construction, compression, graph/vector projections, exports, and replicas must not bypass suppression or resurrect redacted material.
+
+Cortex must pass the caller/pack/sensitivity constraints through rather than inventing its own weaker security semantics.
+
+## Reconsideration triggers
+
+Revisit this boundary only if committed evidence shows one of the following:
+
+- a responsibility cannot be implemented without unsafe duplication;
+- a distributed-write topology requires a new durable-authority design;
+- a new memory class does not fit working/semantic/telemetry separation;
+- a projection becomes impossible to reconstruct from durable FOSSIL state;
+- Cortex requires persistent state that changes semantic truth independently of FOSSIL;
+- security/latency requirements force a materially different trust boundary.
+
+Any revision must be explicit in both Cortex and FOSSIL documentation; do not let implementation drift redefine ownership silently.

--- a/docs/research/2026-08-10-legacy-eval-estate-deduplication-policy.md
+++ b/docs/research/2026-08-10-legacy-eval-estate-deduplication-policy.md
@@ -1,0 +1,294 @@
+# Legacy Evaluation Estate — Deduplication and Dataset Integrity Policy
+
+**Date:** 2026-08-10  
+**Status:** accepted extraction policy; execution pending  
+**Applies to:** legacy SSC eval assets plus any later owner-supplied eval/gold archive
+
+## Purpose
+
+The retired `stupidly-simple-cortex` repository contains useful evaluation assets, but the source estate is noisy, historically layered, and may contain duplicate or near-duplicate cases across Fable capture, objective lanes, imported benchmark slices, live-generation sets, promotion outputs, and historical exports.
+
+Future owner-supplied assets may contain additional rows not present on GitHub.
+
+The extraction process therefore needs a **deduped evaluation view without destroying the raw source estate or laundering conflicting labels.**
+
+## Core rule
+
+**Preserve raw bytes first. Deduplicate into derived views second. Never overwrite source rows merely because two cases appear equivalent.**
+
+A deduped dataset is a projection with provenance, not the canonical raw archive.
+
+## Archive layers
+
+The standalone evaluation estate should expose at least four logical layers:
+
+```text
+raw/
+  immutable extracted/uploaded source assets
+
+normalized/
+  schema-normalized rows with source-preserving IDs
+
+deduped/
+  exact/near-duplicate-aware evaluation views
+
+splits/
+  train/dev/eval/holdout views after leakage analysis
+```
+
+Checkers, frozen tests, rubrics, quarantine records, manifests, and license/source metadata remain versioned beside the data rather than being flattened into one dataset file.
+
+## Source identity
+
+Every raw asset and every normalized row must retain provenance sufficient to reconstruct origin.
+
+At minimum:
+
+- archive asset ID;
+- source repository/upload bundle;
+- source commit/version when applicable;
+- original path/file name;
+- file content hash;
+- row number or source-native case ID;
+- source dataset/benchmark name;
+- label authority;
+- source/license metadata;
+- extraction/import timestamp;
+- parent asset ID.
+
+Normalization must mint archive-owned row IDs without discarding source-native IDs.
+
+## Exact deduplication
+
+Exact duplicates should be detected using more than one representation where practical:
+
+1. exact raw-row byte/content hash;
+2. canonical JSON hash for structured rows with deterministic key ordering;
+3. task-content hash after explicitly versioned normalization of irrelevant formatting.
+
+Exact duplicate detection must not simply delete all but one row. Instead create a duplicate cluster containing:
+
+- canonical cluster ID;
+- all member row IDs;
+- source origins;
+- labels/verdicts;
+- checker authorities;
+- selected representative row for a particular derived view;
+- reason the members are considered exact duplicates.
+
+If exact duplicates carry conflicting labels or materially different authorities, the conflict is preserved and surfaced rather than silently choosing one.
+
+## Near-duplicate / semantic-overlap detection
+
+Near duplicates are more dangerous because they can cause train/eval leakage while looking superficially different.
+
+Detect candidate overlap using separately recorded methods such as:
+
+- normalized text fingerprints;
+- n-gram/MinHash or equivalent lexical similarity;
+- AST/signature comparison for code tasks;
+- normalized tool/function schema + argument task identity;
+- reference-answer/task-template signatures;
+- embedding similarity as a **candidate clustering signal only**;
+- benchmark-native IDs and known mutation/perturbation relationships.
+
+Embedding similarity or model judgment must never by itself authorize deletion or declare two tasks semantically identical.
+
+Near-duplicate clusters require explicit method/version/threshold metadata and should default to `candidate_overlap` until deterministically or manually resolved.
+
+## Mutation families are not ordinary duplicates
+
+Many objective datasets intentionally contain related cases:
+
+- canonical pass case;
+- wrong-value mutation;
+- missing-required-field mutation;
+- adversarial/poisoned variant;
+- security mutant;
+- perturbation or counterexample;
+- positive/negative pair.
+
+These belong to a **case family**, not a duplicate-removal bucket.
+
+Family relationships must be retained because collapsing them can destroy the evaluator's ability to test boundaries and failure detection.
+
+The archive manifest should support fields such as:
+
+- `family_id`;
+- `parent_case_id`;
+- `variant_type`;
+- `mutation_type`;
+- `expected_relation_to_parent`.
+
+## Label conflicts
+
+When duplicate/overlapping rows disagree, do not majority-vote them into one truth label.
+
+Record:
+
+- each label;
+- each label authority;
+- checker/model/human source;
+- checker version;
+- whether the underlying source/reference changed;
+- conflict classification.
+
+Recommended classifications:
+
+- `same_case_same_label_same_authority`;
+- `same_case_same_label_different_authority`;
+- `same_case_conflicting_label`;
+- `source_revision_changed`;
+- `checker_revision_changed`;
+- `semi_ground_vs_hard_gold`;
+- `candidate_vs_verified`;
+- `unknown_conflict`.
+
+A lower-authority semi-ground label must not overwrite a reproducible deterministic hard-gold verdict. Conversely, an old `hard_gold` string is not privileged if its checker/provenance cannot be reproduced.
+
+## Hard-gold handling
+
+A deduped hard-gold view may include one representative per exact duplicate cluster only after the cluster's authority has been revalidated.
+
+Preserve separately:
+
+- raw member rows;
+- checker outputs;
+- reference inputs;
+- checker/test versions;
+- quarantine/disagreement records.
+
+Hard-gold counts reported after extraction must distinguish:
+
+- raw rows;
+- exact-unique rows;
+- family-unique tasks;
+- revalidated hard-gold rows;
+- unresolved/quarantined rows.
+
+This prevents inflated counts from duplicate or mutation-heavy corpora.
+
+## Semi-ground and rubric data
+
+Semi-ground, Fable-provisional, cross-vendor synthetic, rubric-anchor, and judge-calibration rows remain separate classes.
+
+Deduplication may reduce repeated examples for a derived calibration set, but their provisional authority remains unchanged.
+
+Never promote a semi-ground row to hard gold because it is duplicated across several files or several models agreed with it.
+
+## Cross-dataset contamination
+
+The extraction pipeline must scan for overlap across:
+
+- hard-gold lanes;
+- imported third-party benchmark slices;
+- Fable/generated candidate sets;
+- live-generated training gold;
+- training exports;
+- evaluation sets;
+- holdouts;
+- any later owner-supplied archive.
+
+The key question is not only “is this row duplicated?” but also **“did an evaluation/holdout case leak into training or prompt/rubric construction?”**
+
+## Train/eval/holdout leakage policy
+
+Before creating final splits:
+
+1. build exact duplicate clusters across the entire estate;
+2. build candidate near-duplicate/family clusters;
+3. group all members of a case family before splitting;
+4. ensure the same case/family does not cross train and evaluation boundaries unless a benchmark explicitly defines that relationship;
+5. treat sealed holdout membership as sensitive benchmark metadata;
+6. record contamination findings rather than quietly removing evidence of them.
+
+If a historical holdout has already been exposed in the old public/private repository to builders being evaluated, label it `historically_exposed` and do not pretend it remains unseen.
+
+## Deduped view reproducibility
+
+Every deduped dataset release must have a manifest containing:
+
+- raw archive root/version;
+- normalization policy version;
+- dedupe algorithm/version;
+- thresholds/settings;
+- cluster IDs and member mappings;
+- representative-selection rule;
+- excluded/quarantined rows and reasons;
+- raw/normalized/deduped row counts;
+- family counts;
+- leakage findings;
+- split policy/version;
+- output hashes.
+
+A future release must be reproducible from the raw archive plus the manifest/code.
+
+## Representative selection
+
+Representative selection should be deterministic and policy driven, for example preferring in order:
+
+1. reproducible deterministic-checker row with complete source/license metadata;
+2. higher-fidelity source/reference representation;
+3. newer explicitly superseding checker/data revision when documented;
+4. otherwise a stable lexical/ID ordering.
+
+Selection does not delete the other cluster members.
+
+## Future owner-supplied missing assets
+
+Additional assets supplied later should enter as a **new raw source bundle**, not be manually pasted over the SSC extraction.
+
+For each bundle:
+
+- hash the bundle/files before normalization;
+- record source/context supplied by the owner;
+- mark whether source commit/history is known or unknown;
+- run the same classification/dedup/leakage pipeline;
+- merge only at the derived manifest/view layer;
+- preserve source-bundle boundaries permanently.
+
+This lets the project recover assets that never reached GitHub without making them indistinguishable from committed historical bytes.
+
+## Relationship to FOSSIL
+
+The raw/deduped evaluation estate is **not normal FOSSIL semantic memory**.
+
+FOSSIL may store:
+
+- archive version/root hash;
+- benchmark provenance;
+- benchmark run receipts/results;
+- decisions derived from evaluated evidence.
+
+Normal semantic RAG should not retrieve arbitrary gold/holdout rows as factual knowledge.
+
+## Relationship to Cortex
+
+Cortex may consume explicit versioned evaluation views when benchmarking agents/models/checkers.
+
+Cortex must not:
+
+- train/evaluate on a hidden holdout in the same run path;
+- infer `hard_gold` from filename alone;
+- use dedupe similarity score as label authority;
+- silently mix provisional and deterministic labels;
+- mutate the raw estate during evaluation.
+
+## Minimum acceptance tests for the extractor
+
+Before the standalone estate is trusted:
+
+- exact duplicate test with stable cluster IDs;
+- conflicting-label duplicate test;
+- mutation-family preservation test;
+- train/eval leakage detection test;
+- holdout exposure flag test;
+- empty/stale historical manifest entry test;
+- source-bundle separation test;
+- reproducible output-root hash test;
+- hard-gold downgrade test when checker/provenance is missing;
+- round-trip row provenance test from deduped representative back to every raw source member.
+
+## Non-goal
+
+The purpose of deduplication is dataset integrity, not maximizing a headline row count. A smaller, traceable, leakage-aware evaluation set is preferable to a larger set whose duplicates and authority cannot be explained.

--- a/docs/research/2026-08-10-legacy-ssc-engineering-retrospective.md
+++ b/docs/research/2026-08-10-legacy-ssc-engineering-retrospective.md
@@ -1,0 +1,327 @@
+# Legacy SSC Engineering Retrospective — Lessons Without Integration
+
+**Date:** 2026-08-10  
+**Source system:** `Pukujan/stupidly-simple-cortex`  
+**Primary source revision inspected:** `3b6668eff7a1859c37f1aa50c565f0387fdc4ffe`  
+**Status:** historical engineering retrospective only  
+**Authority:** non-normative; not a source of current FOSSIL/Cortex architecture or semantic truth
+
+## Purpose
+
+This document preserves engineering lessons from earlier `stupidly-simple-cortex` (SSC) development without importing SSC as a runtime dependency, architecture authority, or source of current semantic truth.
+
+The old project contains substantial research, reviews, experiments, security work, state-machine design, retrieval work, evaluation machinery, orchestration ideas, provenance work, and audit history. Much of that work is useful for understanding *why* the current Cortex/FOSSIL ownership boundary exists. It should therefore be retained as project history even when its mechanisms are obsolete, failed, incomplete, or superseded.
+
+The governing rule is:
+
+> **Preserve the lesson and the evidence of the experiment. Do not inherit the old subsystem merely because the old research was thoughtful.**
+
+This retrospective is deliberately separate from the legacy SSC evaluation-estate extraction. The evaluation estate contains potentially reusable benchmark/checker assets. This document instead records architectural and methodological learning.
+
+## Non-integration rule
+
+Nothing in this retrospective authorizes:
+
+- copying SSC runtime components into FOSSIL or Cortex;
+- mounting old SSC research prose as normal FOSSIL semantic memory;
+- treating old SSC current-state/ontology values as truth;
+- treating historical research claims as current evidence without independent revalidation;
+- reintroducing the old SSC database, FTS/vector indexes, ontology, state engine, or MCP server as a live dependency;
+- changing current Cortex/FOSSIL ownership merely because a prior design chose a different boundary.
+
+Historical source material may be cited when documenting what happened in the project. Current architectural decisions still require current evidence, contracts, and tests.
+
+## What the early research did well
+
+### Evidence-tier discipline
+
+The early Fable research handoff (`docs/research/fable-research-handoff-2026-07-03.md`) explicitly distinguished production-deployed evidence from design-only/WIP references and asked later reviewers to label those evidence tiers rather than blur them.
+
+It also preserved correction history when imported research was wrong. The handoff describes prior uploaded research where quantitative or descriptive claims about PASTE, NabaOS, MARCH, and Letta were checked rather than trusted, and where errors were corrected before the material was allowed to influence the roadmap.
+
+**Lesson that survives:** derived research is not self-authenticating. Decision-driving claims should be traceable to stronger sources and corrected openly when verification fails.
+
+This principle is consistent with current FOSSIL provenance rules, but this retrospective does not claim the old research itself is current evidence.
+
+### Adversarial, executable review
+
+The July 2026 SSRF/fetch episode is a strong methodology example.
+
+The sequence was approximately:
+
+1. an independent deep review dogfooded the installed system;
+2. a real `file://` local-file exfiltration path was demonstrated;
+3. a separate TDD/fix contract was written;
+4. implementation was performed against that contract;
+5. another review exercised real local servers, redirects, large bodies, and the original exploit;
+6. the follow-up review discovered a residual DNS-rebinding check/use gap even though the nominal contract suite passed.
+
+Relevant historical artifacts include:
+
+- `reviewed/opus-deep-review-2026-07-03.md`;
+- `reviewed/ssrf-fix-contract-2026-07-03.md`;
+- `reviewed/ssrf-fix-review-2026-07-03.md`;
+- `reviewed/ssrf-r1-pinning-fix-contract-2026-07-03.md`;
+- `reviewed/ssrf-r1-r2-pinning-fix-review-2026-07-04.md`;
+- `evals/objective_ssrf_path_traversal_behavioral/`.
+
+The follow-up review is particularly instructive: the initial critical primitive was closed, but live verification showed that validation-time DNS resolution and connection-time DNS resolution were still independent, leaving a DNS-rebinding TOCTOU path.
+
+**Lesson that survives:** passing tests are not automatically proof of the security property. For important boundaries, independently attack the property itself, and record residual risk rather than declaring universal closure.
+
+Current FOSSIL poisoning/security work follows a similar philosophy, but no old fetch implementation is adopted from SSC.
+
+### Recognition of provenance and evidence preservation
+
+Later SSC work explored owner directives, engineering logs, transcript audit, hashes/Merkle roots, and external timestamping in `docs/design/ownership-provenance/`.
+
+One healthy property of that design is that it explicitly stated its own limit: until built and externally anchored, it provided zero cryptographic protection. It also distinguished what cryptography could prove (for example byte integrity/existence upper bounds) from what it could only corroborate or not prove at all.
+
+**Lesson that survives:** a proposed control is not an implemented control, and an implemented mechanism should state precisely which proposition it establishes.
+
+The current project should preserve that epistemic precision without inheriting the old design wholesale.
+
+## What failed at the system level
+
+The central retrospective conclusion is that SSC accumulated many individually reasonable subsystems without a sufficiently hard ownership model.
+
+The resulting problem was not simply “too much code.” It was **multiple overlapping definitions of authority, state, retrieval, and contract ownership inside one project**.
+
+### The corpus could not reliably know itself
+
+The July 3 deep review found that the search/index discovery logic did not include several of the repository's own most important planning documents, including `docs/ROADMAP.md`, `docs/BUILD-PLAN.md`, `docs/PHASE-GATES.md`, and `docs/ARCHITECTURE.md`.
+
+That produced an especially important failure mode:
+
+> A system intended to be the project's memory could be unable to retrieve the documents that defined how the system itself should work.
+
+No amount of reindexing could solve a discovery contract that excluded the relevant paths.
+
+**Ownership lesson:** corpus discovery, project-control documentation, and runtime behavior need explicit contracts and tests. A memory system must not silently infer that its index coverage equals the set of authoritative project state.
+
+### Retrieval false negatives looked like absence
+
+The same deep review found a natural-language retrieval failure caused by the FTS5 query normalizer joining all terms with strict AND semantics. Queries for concepts that existed in the corpus returned zero results while an OR formulation returned many relevant hits.
+
+This is a direct historical example of why current FOSSIL freezes the rule:
+
+> top-k absence is not evidence of nonexistence.
+
+**Lesson that survives:** retrieval is an access mechanism, not an ontology of what exists or what is true.
+
+The current D021 policy and lifecycle/lineage resolution are current FOSSIL decisions; the historical SSC retrieval implementation is not reused.
+
+### Documentation and runtime contracts diverged
+
+The deep review also found that documented commands and installed commands diverged. For example, documentation referred to `cortex-write-log` as if it were a CLI command while the installed entrypoint was `cortex-audit` and `cortex-write-log` was a skill/protocol concept.
+
+Separately, the Fable research handoff called out multiple non-reconciled MCP tool-name lists across different design documents, including naming that conflicted with the intended client/tool constraints.
+
+**Ownership lesson:** one contract must own a public interface. Multiple documents may explain it, but they cannot each independently define it.
+
+This is one reason the current Cortex/FOSSIL boundary assigns semantic APIs to FOSSIL and mission/tool orchestration to Cortex rather than allowing both to define overlapping surfaces.
+
+### Concurrency and state responsibilities were mixed into the corpus
+
+The early system used SQLite for search/index state and encountered concurrent writer crashes during normal multi-agent interleavings. At the same time, the project was evolving toward task state, agent orchestration, audit history, and corpus writes in the same overall system boundary.
+
+SQLite itself was not the architectural failure. The problem was that operational concurrency, retrieval indexing, persistent memory, and orchestration were all becoming responsibilities of the same product without clearly distinct authority planes.
+
+**Ownership lesson:** operational execution state and semantic knowledge state have different consistency/recovery requirements and should not be conflated merely because one database can physically store both.
+
+## The state-machine research: a useful near-miss
+
+The Fable state-machine design (`docs/research/STATE-MACHINE-DESIGN-fable-research-2026-07-06.md`) contains several strong bounded ideas:
+
+- server-interpreted operational state;
+- event sourcing;
+- single-writer discipline;
+- optimistic sequence fencing;
+- idempotency keys;
+- explicit task intent;
+- legal-tool gating;
+- deterministic gate checks before model/rubric checks;
+- mechanism-vs-policy separation;
+- versioned policy tables;
+- referential-integrity validation before loading a routing/execution bundle;
+- worker leases/heartbeats;
+- explicit merge/single-writer behavior.
+
+Those are useful historical ideas about **agent execution control**.
+
+However, the same design also states that the server DB is “the only truth.” Inside a task-state engine, that statement can be read as “the only authority for operational task state.” Inside legacy SSC as a whole, it was dangerously ambiguous because SSC simultaneously contained or planned:
+
+- corpus knowledge;
+- ontology/current-state knowledge;
+- audit history;
+- project/task state;
+- model/routing policy;
+- retrieval indexes;
+- evaluation results;
+- provenance records;
+- MCP orchestration.
+
+The missing abstraction was not better state-machine theory. It was **truth-domain ownership**.
+
+The current correction is explicit:
+
+- **Cortex owns operational/execution truth** for a session/mission/task;
+- **FOSSIL owns durable semantic knowledge truth** and its provenance/lifecycle/lineage;
+- **versioned evaluation assets/checkers own benchmark-label authority within their stated scope**;
+- **infrastructure/projections own no semantic truth merely because they host state**.
+
+This is a retrospective interpretation, not a claim that the old state-machine design should be ported.
+
+## Deep-audit, summarization, and context research
+
+Early SSC research around “Deep Audit Mode” explored:
+
+- recursive/hierarchical summarization;
+- checkpointed intermediate summaries;
+- source IDs carried through digests;
+- “provenance, never replacement”;
+- context-budget-aware batching;
+- RAPTOR-style recursive structures;
+- RAGAS-style faithfulness gates;
+- Letta/MemGPT-style growing-memory analogies;
+- direct-source drillback.
+
+The important retrospective lesson is not that any one of those mechanisms is correct for current FOSSIL.
+
+It is that the project correctly encountered a fundamental problem that remains relevant:
+
+> persistent history grows faster than model context, so a control plane needs bounded context construction without allowing lossy summaries to become replacement evidence.
+
+Current policy now places this at a cleaner boundary:
+
+- Cortex owns task-level context budget and the decision to direct-read/decompose/escalate;
+- FOSSIL `ContextProvider` owns evidence-safe context construction/compression of FOSSIL-sourced material;
+- immutable FOSSIL evidence, IDs, citations, ACLs, redaction, lifecycle, and lineage remain authoritative;
+- context compression must earn itself under matched benchmarks.
+
+Therefore old deep-audit research is historical prior art only. It should not be cited as proof that the current compression strategy is correct.
+
+## Research-mode and multi-agent lessons
+
+Early research repeatedly explored lead/worker fan-out, model-tiering, boundary contracts, single-writer synthesis, worker isolation, checkpointing, and external research collection.
+
+A recurring concern in those documents was duplicated agent work and coordination drift. Several designs attempted to solve this with stronger orchestration, worker claims, blackboards, reducers, or state machines.
+
+The retrospective lesson is broader:
+
+> stronger orchestration does not fix an ambiguous ownership boundary between subsystems.
+
+A perfectly coordinated set of workers can still produce inconsistent system state when the corpus, task engine, ontology, audit system, and project-state documents each believe they own the same concept.
+
+Current Cortex should coordinate agents; FOSSIL should resolve durable knowledge. Cross-plane integration should happen through narrow contracts instead of shared internal state.
+
+## Why “one big smart system” failed despite good ideas
+
+The old architecture can be summarized as a composition failure:
+
+```text
+reasonable local subsystem A
++ reasonable local subsystem B
++ reasonable local subsystem C
++ more policies, indexes, logs, agents, gates, and docs
+--------------------------------------------------------
+without explicit authority ownership
+=
+multiple competing sources of truth and hidden coupling
+```
+
+Symptoms included:
+
+- search could not see critical control documents;
+- retrieval false negatives looked like missing knowledge;
+- multiple MCP interface definitions drifted;
+- docs and executable entrypoints diverged;
+- operational state, audit, memory, and retrieval lived too close together;
+- security-sensitive fetch content could become searchable persistent corpus material;
+- future designs kept adding new logs, state engines, provenance systems, evaluators, and orchestration layers to the same ownership domain;
+- individually strong research recommendations accumulated without a single composition contract saying which subsystem had final authority for each concern.
+
+The architectural correction is not “never build rich systems.” It is:
+
+> **Every durable or executable concern gets one explicit owner, and all other components cross that boundary through versioned interfaces.**
+
+## Principles that survived independently into the current design
+
+The following principles appear in old SSC work and also make sense in the current architecture, but they are retained because they are independently justified by current FOSSIL/Cortex contracts—not because SSC established them as authority:
+
+1. **Single writer per authoritative state domain.**
+2. **Proposal/evidence before durable commit.**
+3. **Provenance never replacement.**
+4. **Deterministic checks before subjective model judgment where possible.**
+5. **Adversarial/live verification for important security and correctness properties.**
+6. **Explicit residual risk rather than universal-success claims.**
+7. **Versioned policy and interface identities.**
+8. **Reproducible evaluation assets and checker authority separated from model consensus.**
+9. **Context budgets are real architectural constraints, but compression cannot redefine evidence.**
+10. **Replaceable indexes/models/projections must not become truth merely because they are convenient.**
+11. **Interface drift should fail visibly rather than silently producing divergent behavior.**
+12. **Dogfood the system against its own real workflows; a memory/control system that cannot retrieve or obey its own current contracts is not coherent.**
+
+## Classification scheme for future historical inventory
+
+When more old SSC research or owner-supplied historical material is reviewed, classify it as one or more of:
+
+- `validated_methodology_example` — an old process/experiment that demonstrated a useful evaluation/review method;
+- `historical_lesson` — useful evidence about why a current principle exists;
+- `failed_experiment` — a mechanism/design that materially failed or produced unacceptable behavior;
+- `superseded_design` — coherent at the time but replaced by a newer ownership/contract model;
+- `obsolete_unverified` — historical content whose decision-driving claims were not sufficiently verified;
+- `historical_source_only` — worth preserving for project archaeology but not otherwise actionable.
+
+These labels describe historical use, not semantic truth authority.
+
+## Future source bundles
+
+The GitHub revision above is not assumed complete. Additional historical research, transcripts, reports, datasets, or artifacts may exist outside the repository.
+
+When the owner provides them later:
+
+1. preserve each upload as a separate immutable source bundle;
+2. record its source/date/context when known;
+3. hash the raw bytes before normalization;
+4. do not silently merge it into the GitHub-derived corpus;
+5. classify historical lessons separately from reusable eval assets;
+6. preserve contradictions and failed ideas rather than rewriting history into one clean narrative;
+7. keep the no-integration rule unless a new, current decision explicitly authorizes a specific independently validated idea.
+
+## Relationship to the evaluation estate
+
+The evaluation estate has a different preservation path.
+
+Potentially reusable hard-gold/semi-ground datasets, checkers, oracle gates, rubrics, frozen tests, resolvers, and related assets are being inventoried for standalone extraction under a separate content-addressed archive and deduplication policy.
+
+This retrospective should not be used to decide that an eval asset is valid. Eval authority must be established from actual bytes, provenance, checker/test reproducibility, source/license status, and holdout/leakage controls.
+
+## Relationship to normal FOSSIL memory
+
+This retrospective may live in the FOSSIL repository as project documentation, but that does not mean historical SSC research should be mounted as normal semantic-memory evidence.
+
+If FOSSIL later stores facts about this history, they should be explicit historical/provenance statements such as:
+
+- a particular review occurred;
+- a particular exploit was demonstrated;
+- a particular design document existed at a particular revision;
+- a particular mechanism was superseded or retired.
+
+Do not convert old research conclusions directly into current claims such as “this architecture is correct” or “this model/library should be used.”
+
+## Current architectural conclusion
+
+The most important preserved lesson from SSC is:
+
+> **Good local designs do not compose safely when ownership is ambiguous.**
+
+The current architecture therefore keeps these ownership statements explicit:
+
+> **Cortex owns execution. FOSSIL owns knowledge. FOSSIL projections retrieve knowledge. Infrastructure runs the components. Models propose; deterministic gates commit.**
+
+and:
+
+> **Operational truth, semantic knowledge truth, evaluation-label authority, and infrastructure state are different domains. No subsystem becomes owner of another domain merely because it stores, retrieves, summarizes, or executes data from it.**
+
+That boundary is the principal architectural learning being carried forward. The old monolith itself is not.

--- a/docs/research/2026-08-10-legacy-ssc-evaluation-estate-inventory.md
+++ b/docs/research/2026-08-10-legacy-ssc-evaluation-estate-inventory.md
@@ -1,0 +1,267 @@
+# Legacy SSC Evaluation Estate — Verified Inventory
+
+**Date:** 2026-08-10  
+**Source repository:** `Pukujan/stupidly-simple-cortex`  
+**Source revision inspected:** `3b6668eff7a1859c37f1aa50c565f0387fdc4ffe`  
+**Status:** discovery inventory only; no live dependency and no semantic-truth authority
+
+## Purpose
+
+The legacy `stupidly-simple-cortex` runtime is being retired as a live corpus/memory/ontology authority. Before retirement, verify which evaluation assets are actually committed and worth extracting into a standalone archive.
+
+This document records **observed repository bytes and paths**, not SSC's claims about itself. It exists so future work can extract the useful evaluation estate without mounting or querying SSC at runtime.
+
+## High-level result
+
+A substantial evaluation estate **is committed on GitHub**. It includes:
+
+- checker-decided hard-gold JSONL datasets;
+- deterministic objective-lane checkers;
+- frozen tests tied to those lanes;
+- third-party-derived benchmark slices;
+- live/trainable hard-gold sets and some holdout sets;
+- semi-truth / provisional judgment datasets;
+- rubrics and calibration anchors;
+- reusable checker cores and domain resolvers;
+- oracle adapters, cross-validation machinery, and health reports;
+- promotion/quarantine conventions and results-ledger specs;
+- durable artifact indexes pointing to the above.
+
+The estate should be extracted and independently revalidated. It should **not** be treated as FOSSIL knowledge merely because it lived in SSC.
+
+## Verified objective-lane surface
+
+`docs/OBJECTIVE-LANES.md` at the inspected revision is generated and reports **73 objective lanes**. It declares that each lane's verdict path is deterministic and that `judge_in_verdict_path` is `false`.
+
+Examples present in the generated manifest include:
+
+- tool calling — BFCL AST checker;
+- coding — subprocess test execution;
+- architecture — static import graph/AST;
+- authorization bypass — reference policy-engine execution;
+- cryptographic misuse — functional/known-answer/property execution;
+- CWE patch execution — functional + exploit regression execution;
+- datetime correctness — stdlib datetime recomputation;
+- GSM-style math — exact numeric answer;
+- ledger balances — double-entry arithmetic checker;
+- PII redaction — deterministic PII pattern detector;
+- prompt-injection trace — trace-invariant checker;
+- RAG evaluation — deterministic grounding match;
+- SQL correctness and many other structured/executable domains.
+
+Each manifest row names the checker/verdict module, frozen test, label authority, promotion source, and judge-in-verdict-path flag.
+
+## Verified hard-gold bytes
+
+Concrete committed hard-gold files found include, among many others:
+
+- `evals/objective_tool_calling/hard_gold.jsonl`;
+- `evals/objective_coding/hard_gold.jsonl`;
+- `evals/objective_security/hard_gold.jsonl`;
+- `evals/objective_research/hard_gold.jsonl`;
+- `evals/objective_architecture/hard_gold.jsonl`;
+- `evals/objective_pii_redaction/hard_gold.jsonl`;
+- `evals/objective_dockerfile_lint/hard_gold.jsonl`;
+- `evals/objective_ledger_balances/hard_gold.jsonl`;
+- `evals/objective_secret_detection/hard_gold.jsonl`;
+- `evals/objective_number_grounding/hard_gold.jsonl`;
+- `evals/objective_tenant_isolation/hard_gold.jsonl`;
+- many additional `evals/objective_*/hard_gold.jsonl` lanes listed in `docs/OBJECTIVE-LANES.md`.
+
+The tool-calling hard-gold file was directly inspected and contains rows with fields such as:
+
+- `objective_verdict`;
+- `label_authority: bfcl_ast_checker`;
+- exact checker path;
+- error type/details;
+- perturbation type;
+- source/case ID;
+- `provenance_tier: hard_gold`;
+- cross-checker agreement;
+- reproducibility metadata including ground-truth hash.
+
+This is materially different from model-judged prose and is worth preserving subject to license/source/reproduction verification.
+
+## Verified third-party-derived objective slices
+
+The legacy durable-artifact index points to and current GitHub bytes confirm at least some third-party-derived hard-gold datasets under `evals/hf_datasets/`.
+
+One directly inspected example:
+
+- `evals/hf_datasets/gsm_plus/hard_gold.jsonl` — contains task IDs, prompts, reference solutions, and reference answers.
+
+The historical artifact index also names additional paths such as HumanEval, CRUXEval, DS1000, MBPP, APPS, BigCodeBench, code contests, and others. **Do not assume every historical count is still correct; verify each file and its license/source metadata during extraction.**
+
+## Verified semi-ground / provisional judgment data
+
+Semi-ground/provisional material also exists and must remain clearly lower-authority.
+
+Directly inspected:
+
+- `evals/fable_capture/prompt_evals_semitruth.jsonl` — rows explicitly label themselves `fable_semi_ground_truth`, `fable_provisional (pending human verification)`, `authority: candidate`, `human_reviewed: false`, and `ground_truth_for_now: false`.
+
+Other paths named by the durable-artifact index include:
+
+- `evals/fable_capture/rubric_evals_semitruth.jsonl`;
+- `evals/fable_capture/deep_eval_semitruth.jsonl`;
+- `evals/fable_capture/golden_deep_audit.jsonl`.
+
+These are useful for judge calibration, disagreement analysis, rubric design, or future re-labeling. They are **not hard gold** and should not silently become training/evaluation authority.
+
+## Verified rubrics and calibration material
+
+Committed rubric/evaluation-design assets include examples such as:
+
+- `evals/fable_capture/tdd_rubric_spec.md`;
+- `evals/fable_capture/handoff_rubric_spec.md`;
+- `evals/fable_capture/code_quality_rubric_spec.md`;
+- `evals/fable_capture/agentic_task_state_rubric.md`;
+- `evals/fable_capture/cybersecurity_rubric_spec.md` and expanded variant;
+- `evals/rubrics/rubric_c_layer1.py`;
+- `evals/objective_security/rubric_access.json`;
+- `evals/objective_rubric_grading/run.py` and `gold.py`;
+- `calibration/rubrics/` material;
+- `calibration/anchors/` soft-anchor packets and checker-design documents referenced by the durable-artifact index.
+
+Rubrics are methodology/evaluation assets, not semantic truth. Their future executable/current versions belong with the evaluation/harness system; FOSSIL may preserve provenance about them when useful.
+
+## Verified checker/oracle machinery
+
+Committed deterministic/oracle-related machinery includes:
+
+- `evals/oracle_adapter.py`;
+- `cortex_core/oracle_crossval.py`;
+- `cortex_core/oracle_report.py`;
+- `evals/objective_tool_calling/checker.py` and `run_bfcl.py`;
+- many `evals/objective_*/checker*.py` modules named by the generated lane manifest;
+- frozen tests under `tests/test_objective_*.py`;
+- `evals/checker_cores/` reusable deterministic primitives;
+- `evals/resolvers/` domain-specific resolvers;
+- external oracle adapters under `evals/external/` referenced by the durable-artifact index;
+- reports including `evals/reports/ORACLE_HEALTH.md` and strength reports.
+
+The legacy `docs/DURABLE-ARTIFACTS-INDEX.md` describes five reusable checker cores:
+
+- differential execution;
+- mutation/seeded-error checking;
+- resolver joins/recomputation;
+- schema presence;
+- lexicon/grammar rules.
+
+These may be valuable code assets, but future use should freeze exact versions and rerun their tests rather than trusting historical reports.
+
+## Verified promotion/training/evidence infrastructure
+
+Committed support material includes:
+
+- `evals/RESULTS-LEDGER-SPEC.md`;
+- promotion consolidation/check scripts;
+- evidence-bundle checks;
+- training export machinery;
+- live hard-gold sets referenced by `docs/DURABLE-ARTIFACTS-INDEX.md`;
+- promotion/quarantine conventions and manifests;
+- stage reports and oracle-health reports.
+
+Some live-gold lanes also reference holdout files. Extraction must decide whether those holdouts remain sealed. A dataset intended to test future builders should not be casually exposed to those builders merely because it is being archived.
+
+## Critical reliability caveat: SSC indexes are stale in places
+
+Do **not** use `evals/FABLE_DURABLE_ARTIFACT_INDEX.md`, README counts, reports, or search-index summaries as the extraction manifest without checking bytes.
+
+Observed example:
+
+- the legacy artifact index reports `evals/hf_datasets/halu_eval/semi_ground.jsonl` with 500 rows;
+- direct read of that path on `main` at the inspected revision returned an empty file.
+
+Similarly, `evals/README.md` contains an older build-status statement saying no gold had been produced yet, while later commits clearly contain hard-gold datasets and a 73-lane generated objective manifest.
+
+Therefore the authoritative extraction unit is:
+
+```text
+repository commit + exact path + blob hash + actual byte/row count + license/source metadata + checker/test dependency
+```
+
+Narrative documents are orientation only.
+
+## Recommended standalone archive structure
+
+Do not make FOSSIL or Cortex depend on the legacy SSC repository at runtime.
+
+Create a standalone content-addressed evaluation estate, for example conceptually:
+
+```text
+legacy-eval-estate/
+  MANIFEST.jsonl
+  hard_gold/
+  semi_ground/
+  rubrics/
+  checkers/
+  frozen_tests/
+  resolvers/
+  manifests/
+  quarantine/
+  reports/
+  source_license/
+```
+
+Each manifest row should record at minimum:
+
+- asset ID;
+- class (`hard_gold`, `semi_ground`, `rubric`, `checker`, `frozen_test`, `resolver`, `quarantine`, `report`, etc.);
+- source repo and exact commit;
+- original path;
+- content hash;
+- byte count and row count where applicable;
+- source benchmark/dataset;
+- license/redistribution status;
+- label authority;
+- checker implementation/version;
+- required frozen test(s);
+- trainable/eval-only/holdout status;
+- verification status;
+- extraction date;
+- notes about missing dependencies or stale historical claims.
+
+## Authority policy after extraction
+
+### Hard-gold candidate
+
+A legacy row may retain a `hard_gold` classification only when the extraction can establish:
+
+- the bytes exist;
+- the claimed checker exists;
+- the checker/test path is reproducible enough to rerun or independently validate;
+- source/license provenance is recorded;
+- no judge/model was the sole verdict authority;
+- any required reference data is available and hashed.
+
+If any of those fail, downgrade the archive classification rather than preserving the old label by trust.
+
+### Semi-ground / judged material
+
+Keep as provisional/calibration material. Never use it as final correctness authority without a new validation step.
+
+### Reports and research prose
+
+Keep only if useful for historical orientation. Reports do not override the underlying data/checker outputs and should not be ingested into normal FOSSIL semantic memory automatically.
+
+## Relationship to FOSSIL and Cortex
+
+- **FOSSIL:** may store provenance about benchmark assets and durable benchmark results. It should not mount this estate as normal semantic-memory RAG.
+- **Cortex:** may use versioned evaluation assets/checkers when evaluating agents/models, but should reference the standalone archive/version rather than the retired SSC runtime.
+- **Legacy SSC:** after extraction verification, remains a cold historical source and is not required for live operation.
+
+## Next extraction gate
+
+Before deleting/archiving access to SSC locally:
+
+1. enumerate all relevant files from the exact source revision;
+2. compute hashes/actual row counts;
+3. resolve license/source metadata;
+4. pair hard-gold files with checker + frozen tests + manifests;
+5. identify empty/missing/stale-index entries;
+6. decide holdout sealing policy;
+7. copy verified assets into a standalone archive;
+8. run integrity/reproduction smoke tests from the archive without importing SSC runtime code implicitly;
+9. record the archive root hash/version;
+10. only then declare SSC unnecessary for evaluation recovery.


### PR DESCRIPTION
## What changed

- defines the Cortex v4 ↔ FOSSIL ownership boundary: Cortex owns execution/control; FOSSIL owns persistent semantic knowledge and retrieval semantics;
- records the initial Gravebuster/local-PC topology as one logical FOSSIL durable commit authority with replaceable projections/services on either machine;
- defines working-memory vs persistent-memory vs telemetry boundaries;
- defines the Cortex→FOSSIL proposal-before-commit path and explicit outage behavior;
- refines compression ownership: Cortex owns task-level budget/direct-read/decompose/escalation decisions; FOSSIL `ContextProvider` owns evidence-safe context construction/compression over FOSSIL-sourced material;
- defines protected-evidence, fail-closed, `filter first, compress second`, receipt, and matched context-budget benchmark requirements;
- retires legacy `stupidly-simple-cortex` as a live memory/RAG/ontology authority;
- inventories the actually committed SSC evaluation estate and separates it from SSC research/runtime;
- defines the eval-estate deduplication model: immutable raw bundles → normalized rows → provenance-preserving exact/near-duplicate views → leakage-aware splits;
- preserves mutation/counterexample families and conflicting labels rather than collapsing them;
- records how later owner-supplied missing assets enter as separate immutable source bundles;
- records the stale-index finding: SSC narrative counts are not an extraction manifest, so assets must be copied by exact commit/path/hash/actual bytes/license/checker/test dependency;
- adds a historical SSC engineering retrospective that preserves Fable/SSRF/state-machine/deep-audit/ownership lessons and concrete system-coherence failures without authorizing any old architecture or research as current evidence;
- reconciles `docs/HANDOFF_CURRENT.md` with Workstream D stage 1, the live LiteLLM embedding/rerank probe, the ownership boundary, compression/dedupe policies, the retrospective, and master tracker #73.

## Why

FOSSIL is about to become persistent memory for Cortex across Gravebuster and the local PC. Without an explicit boundary, Cortex, FOSSIL, and the retired SSC system could drift into competing definitions of memory, RAG, current state, and authority.

The old SSC runtime also has known noisy/false-positive corpus behavior, but its deterministic eval estate is materially useful. Separately, its development history contains valuable methodology and failure evidence. This PR preserves those two categories without reviving SSC: eval assets are candidates for standalone revalidated extraction; research/history is retained only as a non-authoritative engineering retrospective.

Compression is kept out of durable truth: Cortex chooses the task-level budget/strategy outcome, while FOSSIL performs evidence-safe context construction so ACLs, redaction, stable IDs, citation spans, lifecycle and lineage remain enforceable.

## Files

Docs-only change. Current branch adds/updates:

- `docs/HANDOFF_CURRENT.md`
- `docs/architecture/2026-08-10-cortex-fossil-ownership-boundary.md`
- `docs/architecture/2026-08-10-context-construction-compression-boundary.md`
- `docs/research/2026-08-10-legacy-ssc-engineering-retrospective.md`
- `docs/research/2026-08-10-legacy-ssc-evaluation-estate-inventory.md`
- `docs/research/2026-08-10-legacy-eval-estate-deduplication-policy.md`

## Tracker

Master cross-cutting implementation checklist: #73.

Focused benchmark campaign remains #47 / #48.

No runtime, schema, retrieval, D021, pack identity, or authority implementation changes are made by this PR.