### PR TITLE
Define persistent OpenCode executor contract

### DIFF
--- a/.github/workflows/executor-contract.yml
+++ b/.github/workflows/executor-contract.yml
@@ -1,0 +1,30 @@
+name: Persistent executor contract
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/opencode-persistent-path-20260811
+    paths:
+      - "contracts/executor/**"
+      - "scripts/validate_executor_contract.py"
+      - ".github/workflows/executor-contract.yml"
+  pull_request:
+    paths:
+      - "contracts/executor/**"
+      - "scripts/validate_executor_contract.py"
+      - ".github/workflows/executor-contract.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python scripts/validate_executor_contract.py

--- a/contracts/executor/opencode-persistent-v1.json
+++ b/contracts/executor/opencode-persistent-v1.json
@@ -1,0 +1,42 @@
+{
+  "schema": "fossil.executor.contract.v1",
+  "id": "opencode-persistent-v1",
+  "purpose": "Long-running mechanical coding work using CKFF inference through LiteLLM without coupling task lifetime to a CLI subprocess.",
+  "transport": "http",
+  "session_lifetime_owner": "opencode_server",
+  "task_submission": {
+    "method": "POST",
+    "path": "/session/{session_id}/prompt_async",
+    "blocking": false
+  },
+  "required_endpoints": [
+    {"method": "GET", "path": "/global/health"},
+    {"method": "POST", "path": "/session"},
+    {"method": "POST", "path": "/session/{session_id}/prompt_async"},
+    {"method": "GET", "path": "/session/status"},
+    {"method": "GET", "path": "/session/{session_id}/message"},
+    {"method": "GET", "path": "/session/{session_id}/diff"},
+    {"method": "POST", "path": "/session/{session_id}/abort"}
+  ],
+  "timeout_policy": {
+    "control_plane_requests_must_be_short": true,
+    "whole_task_timeout": "caller_explicit_only",
+    "default_whole_task_timeout_seconds": null,
+    "model_request_deadline_is_separate_from_task_lifetime": true
+  },
+  "completion_policy": {
+    "primary": "session_idle",
+    "stale_busy_fallback": "completed_assistant_message_with_completed_timestamp_and_verified_artifact",
+    "status_alone_is_not_a_liveness_oracle": true
+  },
+  "runtime_dependencies": {
+    "ssc_allowed": false,
+    "opencode_server_required": true,
+    "litellm_gateway_required": true,
+    "ckff_upstream_expected": true
+  },
+  "orchestration": {
+    "multi_agent_strategy": "one_independent_opencode_session_per_agent",
+    "parent_process_must_not_own_agent_process_lifetime": true
+  }
+}

--- a/scripts/validate_executor_contract.py
+++ b/scripts/validate_executor_contract.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REQUIRED_ENDPOINTS = {
+    ("GET", "/global/health"),
+    ("POST", "/session"),
+    ("POST", "/session/{session_id}/prompt_async"),
+    ("GET", "/session/status"),
+    ("GET", "/session/{session_id}/message"),
+    ("GET", "/session/{session_id}/diff"),
+    ("POST", "/session/{session_id}/abort"),
+}
+
+
+def main() -> int:
+    path = Path("contracts/executor/opencode-persistent-v1.json")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["schema"] == "fossil.executor.contract.v1"
+    assert data["session_lifetime_owner"] == "opencode_server"
+    assert data["task_submission"]["blocking"] is False
+    assert data["timeout_policy"]["whole_task_timeout"] == "caller_explicit_only"
+    assert data["timeout_policy"]["default_whole_task_timeout_seconds"] is None
+    assert data["runtime_dependencies"]["ssc_allowed"] is False
+    assert data["orchestration"]["parent_process_must_not_own_agent_process_lifetime"] is True
+    actual = {(row["method"], row["path"]) for row in data["required_endpoints"]}
+    missing = REQUIRED_ENDPOINTS - actual
+    if missing:
+        raise SystemExit(f"executor contract missing endpoints: {sorted(missing)}")
+    print(f"validated {data['id']} with {len(actual)} required endpoints")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Introduces the narrow executor contract Fossil needs from V4: server-owned OpenCode sessions, asynchronous task submission, explicit-only whole-task deadlines, observable status/messages/diffs, and no SSC runtime dependency. Adds a small validator and GitHub Actions check. This is an experimental contract branch; no production behavior changes.