### PR TITLE
Add GitHub-hosted Tailscale control plane for #79

### DIFF
--- a/.github/workflows/cross-repo-contracts.yml
+++ b/.github/workflows/cross-repo-contracts.yml
@@ -1,0 +1,32 @@
+name: Cross-repository control-plane contracts
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - "config/integrations/**"
+      - "scripts/private_probe.py"
+      - "scripts/probe-*.sh"
+      - "scripts/probe_inference.py"
+      - "tests/test_github_control_plane_contract.py"
+
+permissions:
+  contents: read
+
+jobs:
+  contracts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install
+        run: python -m pip install -e '.[test]'
+      - name: Validate FOSSIL contracts and probes
+        run: pytest -q tests/test_github_control_plane_contract.py
+      - name: Run the normal FOSSIL suite
+        run: pytest -q

--- a/.github/workflows/fossil-private-health.yml
+++ b/.github/workflows/fossil-private-health.yml
@@ -1,0 +1,56 @@
+name: Fossil private health
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 * * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: fossil-private-health
+  cancel-in-progress: false
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      FOSSIL_TAILSCALE_HOST: ${{ vars.FOSSIL_TAILSCALE_HOST }}
+      FOSSIL_HEALTH_URL: ${{ vars.FOSSIL_HEALTH_URL }}
+      FOSSIL_HEALTH_JSON_KEY: ${{ vars.FOSSIL_HEALTH_JSON_KEY }}
+      FOSSIL_HEALTH_TOKEN: ${{ secrets.FOSSIL_HEALTH_TOKEN }}
+      FOSSIL_PROBE_OUTPUT: ${{ runner.temp }}/fossil-private-health.json
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate private endpoint configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$FOSSIL_TAILSCALE_HOST"
+          test -n "$FOSSIL_HEALTH_URL"
+          case "$FOSSIL_HEALTH_URL" in
+            *\?*|*\#*) echo 'FOSSIL_HEALTH_URL must not contain query or fragment data'; exit 1 ;;
+          esac
+
+      - name: Join tailnet ephemerally
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ secrets.TS_AUDIENCE }}
+          tags: tag:ci
+          ping: ${{ vars.FOSSIL_TAILSCALE_HOST }}
+
+      - name: Probe Fossil without mutating durable state
+        run: bash scripts/probe-fossil.sh
+
+      - name: Upload sanitized probe evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fossil-private-health-${{ github.run_id }}
+          path: ${{ runner.temp }}/fossil-private-health.json
+          if-no-files-found: warn

--- a/.github/workflows/gravebuster-private-health.yml
+++ b/.github/workflows/gravebuster-private-health.yml
@@ -1,0 +1,59 @@
+name: Gravebuster private health
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "29 * * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: gravebuster-private-health
+  cancel-in-progress: false
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GRAVEBUSTER_TAILSCALE_HOST: ${{ vars.GRAVEBUSTER_TAILSCALE_HOST }}
+      GRAVEBUSTER_HEALTH_URL: ${{ vars.GRAVEBUSTER_HEALTH_URL }}
+      GRAVEBUSTER_HEALTH_JSON_KEY: ${{ vars.GRAVEBUSTER_HEALTH_JSON_KEY }}
+      GRAVEBUSTER_HEALTH_TOKEN: ${{ secrets.GRAVEBUSTER_HEALTH_TOKEN }}
+      GRAVEBUSTER_OTEL_HEALTH_URL: ${{ vars.GRAVEBUSTER_OTEL_HEALTH_URL }}
+      GRAVEBUSTER_OTEL_HEALTH_JSON_KEY: ${{ vars.GRAVEBUSTER_OTEL_HEALTH_JSON_KEY }}
+      GRAVEBUSTER_OTEL_HEALTH_TOKEN: ${{ secrets.GRAVEBUSTER_OTEL_HEALTH_TOKEN }}
+      GRAVEBUSTER_LANGFUSE_HEALTH_URL: ${{ vars.GRAVEBUSTER_LANGFUSE_HEALTH_URL }}
+      GRAVEBUSTER_LANGFUSE_HEALTH_JSON_KEY: ${{ vars.GRAVEBUSTER_LANGFUSE_HEALTH_JSON_KEY }}
+      GRAVEBUSTER_LANGFUSE_HEALTH_TOKEN: ${{ secrets.GRAVEBUSTER_LANGFUSE_HEALTH_TOKEN }}
+      GRAVEBUSTER_PROBE_OUTPUT_DIR: ${{ runner.temp }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate private endpoint configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$GRAVEBUSTER_TAILSCALE_HOST"
+          test -n "$GRAVEBUSTER_HEALTH_URL"
+
+      - name: Join tailnet ephemerally
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ secrets.TS_AUDIENCE }}
+          tags: tag:ci
+          ping: ${{ vars.GRAVEBUSTER_TAILSCALE_HOST }}
+
+      - name: Probe required Gravebuster service
+        run: bash scripts/probe-gravebuster.sh
+
+      - name: Upload sanitized probe evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gravebuster-private-health-${{ github.run_id }}
+          path: ${{ runner.temp }}/gravebuster-*-private-health.json
+          if-no-files-found: warn

--- a/.github/workflows/langfuse-synthetic-trace.yml
+++ b/.github/workflows/langfuse-synthetic-trace.yml
@@ -1,0 +1,51 @@
+name: Langfuse synthetic trace
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  trace:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      LANGFUSE_TAILSCALE_HOST: ${{ vars.LANGFUSE_TAILSCALE_HOST }}
+      LANGFUSE_BASE_URL: ${{ vars.LANGFUSE_BASE_URL }}
+      LANGFUSE_OTEL_PATH: ${{ vars.LANGFUSE_OTEL_PATH }}
+      LANGFUSE_OBSERVATIONS_PATH: ${{ vars.LANGFUSE_OBSERVATIONS_PATH }}
+      LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+      LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate private observability configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$LANGFUSE_TAILSCALE_HOST"
+          test -n "$LANGFUSE_BASE_URL"
+      - name: Join tailnet ephemerally
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ secrets.TS_AUDIENCE }}
+          tags: tag:ci
+          ping: ${{ vars.LANGFUSE_TAILSCALE_HOST }}
+      - name: Install trace exporter
+        run: python -m pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+      - name: Emit and verify one synthetic trace
+        run: |
+          python scripts/emit_langfuse_trace.py \
+            --base-url "$LANGFUSE_BASE_URL" \
+            --otel-path "${LANGFUSE_OTEL_PATH:-/api/public/otel}" \
+            --observations-path "${LANGFUSE_OBSERVATIONS_PATH:-/api/public/observations}" \
+            --output "$RUNNER_TEMP/langfuse-synthetic-trace.json"
+      - name: Upload sanitized trace evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: langfuse-synthetic-trace-${{ github.run_id }}
+          path: ${{ runner.temp }}/langfuse-synthetic-trace.json
+          if-no-files-found: warn

--- a/.github/workflows/live-inference-probe.yml
+++ b/.github/workflows/live-inference-probe.yml
@@ -1,0 +1,56 @@
+name: Live inference false-success probe
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      LITELLM_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
+      LITELLM_MODEL: ${{ vars.LITELLM_MODEL }}
+      LITELLM_CHAT_PATH: ${{ vars.LITELLM_CHAT_PATH }}
+      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+      OPENCODE_BASE_URL: ${{ vars.OPENCODE_BASE_URL }}
+      OPENCODE_MODEL: ${{ vars.OPENCODE_MODEL }}
+      OPENCODE_CHAT_PATH: ${{ vars.OPENCODE_CHAT_PATH }}
+      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate gateway configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$LITELLM_BASE_URL"
+          test -n "$LITELLM_MODEL"
+      - name: Probe direct LiteLLM path
+        run: |
+          python scripts/probe_inference.py \
+            --name litellm \
+            --base-url "$LITELLM_BASE_URL" \
+            --path "${LITELLM_CHAT_PATH:-/v1/chat/completions}" \
+            --model "$LITELLM_MODEL" \
+            --api-key-env LITELLM_API_KEY \
+            --output "$RUNNER_TEMP/litellm-inference-probe.json"
+      - name: Probe OpenCode path when configured
+        if: ${{ env.OPENCODE_BASE_URL != '' }}
+        run: |
+          test -n "$OPENCODE_MODEL"
+          python scripts/probe_inference.py \
+            --name opencode \
+            --base-url "$OPENCODE_BASE_URL" \
+            --path "${OPENCODE_CHAT_PATH:-/v1/chat/completions}" \
+            --model "$OPENCODE_MODEL" \
+            --api-key-env OPENCODE_API_KEY \
+            --output "$RUNNER_TEMP/opencode-inference-probe.json"
+      - name: Upload sanitized inference evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-inference-probe-${{ github.run_id }}
+          path: ${{ runner.temp }}/*-inference-probe.json
+          if-no-files-found: warn

--- a/config/integrations/github-control-plane.json
+++ b/config/integrations/github-control-plane.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "fossil.github-control-plane.v1",
+  "control_plane": "github-hosted-actions",
+  "runner": "github-hosted-ubuntu-latest",
+  "private_network": "tailscale",
+  "runner_identity": {
+    "mode": "ephemeral-workload-identity",
+    "action": "tailscale/github-action@v4",
+    "tag": "tag:ci"
+  },
+  "ownership": {
+    "github_actions": ["orchestration", "validation", "sync", "evidence"],
+    "tailscale": ["private-reachability"],
+    "fossil": ["persistent-semantic-memory", "knowledge-graph", "lineage"],
+    "gravebuster": ["required-persistent-runtime", "minimal-observability"],
+    "cortex_v4": ["execution", "routing", "lifecycle"],
+    "litellm_ckff": ["inference-transport", "actual-provider-facts"],
+    "langfuse_otel": ["observability-only"]
+  },
+  "forbidden_dependencies": ["ssc-runtime", "kubernetes", "cluster", "self-hosted-runner"],
+  "required_private_variables": [
+    "FOSSIL_TAILSCALE_HOST",
+    "FOSSIL_HEALTH_URL",
+    "GRAVEBUSTER_TAILSCALE_HOST",
+    "GRAVEBUSTER_HEALTH_URL"
+  ],
+  "required_tailscale_secrets": ["TS_OAUTH_CLIENT_ID", "TS_AUDIENCE"],
+  "durable_state": "outside-github-actions",
+  "routine_health_checks_mutate_knowledge_graph": false
+}

--- a/docs/HANDOFF_CURRENT.md
+++ b/docs/HANDOFF_CURRENT.md
@@ -1,5 +1,13 @@
 # Current Handoff
 
+## Issue #79 control-plane continuation
+
+Draft PR [#80](https://github.com/Pukujan/fossil-core/pull/80) adds the GitHub-hosted Tailscale workflows, fail-closed private service/inference probes, Langfuse synthetic-trace verification, ownership contract, and bootstrap runbook for `Pukujan/fossil-core#79`.
+
+Discovery confirmed local Codex can reach the remote Gravebuster host over Tailscale and found the Fossil source checkout there. No running Fossil health/API service or durable Fossil database endpoint was observed, and no separate Gravebuster GitHub source repository was identified. The live workflows are intentionally fail-closed until those facts are configured in GitHub variables/secrets and Tailscale ACL/trust policy.
+
+Validation: the new control-plane tests pass 12/12; the rest of the suite passes 120 tests when the unrelated retrieval-bakeoff test is excluded. GitHub CI also reports 120 passed and four pre-existing retrieval-bakeoff failures because `main` lacks `_route_eligibility`. Do not widen #79 to repair that separate Workstream-D baseline without a separate decision.
+
 **Date:** 2026-08-10  
 **Project:** **FOSSIL — Fault-tolerant Open Semantic Store for Intellectual Lineage**  
 **Repository:** `Pukujan/fossil-core`  

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -5,7 +5,13 @@
 **Completed:** **Milestone 0 / Gate 1; Gate 2; Issue #48 research ingestion; Issue #48 Workstreams A, B, C, and F**  
 **Active work:** **Issue #48 Workstream D / Issue #47 — retrieval/reranking/model bakeoff**  
 **Control plane:** GitHub issues + durable repository docs  
-**Last updated:** 2026-08-10
+**Last updated:** 2026-08-11
+
+## Issue #79 integration lane
+
+Draft PR [#80](https://github.com/Pukujan/fossil-core/pull/80) implements the narrow GitHub-hosted Actions + ephemeral Tailscale control plane for Fossil/Gravebuster. It adds private health probes, Langfuse synthetic-trace verification, false-success inference detection, cross-repo contract checks, and the required bootstrap/runbook contract. No cluster, Kubernetes, mandatory self-hosted runner, SSC runtime dependency, or Fossil KG redesign was added.
+
+The live acceptance gate is not yet proven: discovery found the remote Gravebuster host and Fossil source checkout, but no running Fossil health/API service or durable Fossil database endpoint, and no separate Gravebuster GitHub source repository identity. GitHub/Tailscale variables, secrets, tags/ACLs, and service endpoints remain to be configured. The new contract tests pass 12/12. Existing repository CI still has four unrelated retrieval-bakeoff failures (`_route_eligibility` absent on `main`); that work remains outside this lane.
 
 ## Repository family
 

--- a/docs/operations/GITHUB-TAILSCALE-CONTROL-PLANE.md
+++ b/docs/operations/GITHUB-TAILSCALE-CONTROL-PLANE.md
@@ -1,0 +1,119 @@
+# GitHub-hosted Tailscale control plane
+
+This is the implementation contract for `Pukujan/fossil-core#79`. GitHub-hosted
+Actions is the normal orchestrator. Each integration job joins the tailnet as a
+short-lived `tag:ci` node, performs a bounded operation, uploads sanitized
+evidence, and exits. Fossil remains the durable semantic store; Gravebuster is
+only the remote persistent host for services that genuinely need to survive a
+workflow run.
+
+## Observed local inventory
+
+The local Codex host can reach the remote Gravebuster machine over Tailscale
+SSH. The remote machine is an Ubuntu Linux host and is online on the tailnet.
+The Fossil source checkout exists on that machine under its V4 lab workspace.
+
+The inventory also found persistent Langfuse and OpenTelemetry services on
+Gravebuster. The database listeners observed during discovery were loopback
+bound. No running Fossil health/API service or durable Fossil database endpoint
+was found, so the Fossil endpoint variables below remain an explicit bootstrap
+blocker. No separate Gravebuster GitHub repository was identified; the source
+visibility step is therefore unresolved until the actual Gravebuster project
+source is named.
+
+This document intentionally does not record Tailscale IPs, SSH credentials,
+tokens, raw traces, or private service URLs.
+
+## GitHub configuration
+
+Create these GitHub Actions variables after the corresponding private service
+exists:
+
+| Variable | Meaning |
+| --- | --- |
+| `FOSSIL_TAILSCALE_HOST` | Fossil MagicDNS name or tailnet address used by the Tailscale action ping |
+| `FOSSIL_HEALTH_URL` | Non-mutating Fossil HTTP health endpoint, reachable only over Tailscale |
+| `FOSSIL_HEALTH_JSON_KEY` | Required JSON key, normally `status` |
+| `GRAVEBUSTER_TAILSCALE_HOST` | Gravebuster MagicDNS name or tailnet address used by the action ping |
+| `GRAVEBUSTER_HEALTH_URL` | Health endpoint for the one required Gravebuster service |
+| `GRAVEBUSTER_OTEL_HEALTH_URL` | Optional OTel health endpoint, only if the collector is retained |
+| `GRAVEBUSTER_LANGFUSE_HEALTH_URL` | Optional Langfuse health endpoint, only if self-hosted Langfuse is retained |
+| `LITELLM_BASE_URL` | Private LiteLLM base URL for the manual live probe |
+| `LITELLM_MODEL` | Explicit requested model identifier; never inferred from a default |
+| `OPENCODE_BASE_URL` | Optional private OpenCode gateway base URL |
+| `OPENCODE_MODEL` | Explicit requested OpenCode model identifier |
+
+Configure these encrypted secrets. They are consumed by actions/scripts but are
+never written to probe reports:
+
+- `TS_OAUTH_CLIENT_ID`
+- `TS_AUDIENCE`
+- optional endpoint bearer/API keys as referenced by the workflow
+
+The preferred Tailscale authentication is workload identity federation with
+`tailscale/github-action@v4`. The workflow grants only `contents: read` and
+`id-token: write`; the latter permits fetching the GitHub OIDC token and does
+not grant repository write access. The Tailscale trust policy must restrict
+`tag:ci` to the exact Fossil/Gravebuster destinations and ports required by the
+probes.
+
+## Workflow behavior
+
+- `fossil-private-health.yml` joins the tailnet and performs a GET-only Fossil
+  health check. It rejects HTTP success with an empty body, malformed JSON, or
+  a missing required key.
+- `gravebuster-private-health.yml` checks the required persistent Gravebuster
+  service and optionally checks retained OTel/Langfuse endpoints.
+- `cross-repo-contracts.yml` runs the normal FOSSIL suite plus the control-plane
+  contract tests on a GitHub-hosted runner.
+- `langfuse-synthetic-trace.yml` sends one non-sensitive OTel span over the
+  private path and queries it back by trace ID. The observations path is
+  configurable so the current self-hosted Langfuse major can be used while the
+  deployment remains on its supported API version.
+- `live-inference-probe.yml` sends an explicit bounded request to LiteLLM and,
+  when configured, OpenCode. It fails on empty bodies, malformed JSON, zero
+  usable output, or an unknown transport status. It records requested/actual
+  model identity without recording the response body.
+
+Routine Fossil health probes never write the knowledge graph. Temporary
+databases and service containers belong in test workflows only; they are not
+production truth.
+
+## Local service boundary
+
+Do not expose a Fossil database to the public network. When the durable Fossil
+service is selected, bind its database to loopback or the tailnet interface as
+appropriate, bind its API only to the intended tailnet path, and add the
+smallest firewall rule for that named service. Re-check with a tailnet probe
+and a non-tailnet probe before claiming the acceptance gate.
+
+No firewall mutation was made during discovery because no Fossil service/API
+target was running and several broadly bound services on Gravebuster are
+unrelated to this contract. Rebinding those services would exceed #79.
+
+For every service retained on Gravebuster, record `start`, `stop`, `restart`,
+`status`, `health`, and `logs` commands in the service's own runbook. Use one
+service manager per process. Do not add Kubernetes, a cluster, a second
+semantic database, or a mandatory self-hosted runner.
+
+## Acceptance evidence
+
+The issue is complete only after a manual GitHub-hosted run produces artifacts
+showing:
+
+1. the ephemeral Tailscale node joined and was removed after the job;
+2. Fossil was reached privately and returned valid non-empty JSON;
+3. the required Gravebuster service was reached privately;
+4. durable Fossil state remained outside GitHub Actions;
+5. the chosen minimal OTel/Langfuse path received one synthetic non-sensitive
+   trace and the trace was queried back by ID;
+6. live inference probes rejected deliberately empty/malformed responses;
+7. cross-repository contract tests passed;
+8. no public database/API/admin path was needed;
+9. no secret appeared in Git history, workflow logs, or artifacts; and
+10. a draft PR links the sanitized run IDs and remaining blockers to #79.
+
+Current blockers are the missing running Fossil endpoint, the unresolved
+Gravebuster source repository identity, and the unexecuted GitHub-hosted run
+because the Tailscale trust variables/secrets are not yet configured in the
+repository.

--- a/scripts/emit_langfuse_trace.py
+++ b/scripts/emit_langfuse_trace.py
@@ -1,0 +1,115 @@
+"""Send and verify one non-sensitive OpenTelemetry span in Langfuse."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+from urllib.parse import urlencode, urljoin, urlsplit, urlunsplit
+from urllib.request import Request, urlopen
+
+
+def _safe_url(value: str) -> str:
+    parts = urlsplit(value)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+
+
+def _basic_auth(public_key: str, secret_key: str) -> str:
+    raw = f"{public_key}:{secret_key}".encode("utf-8")
+    return "Basic " + base64.b64encode(raw).decode("ascii")
+
+
+def _verify(url: str, auth: str, trace_id: str) -> bool:
+    query = urlencode({"traceId": trace_id})
+    request = Request(
+        f"{url}?{query}",
+        headers={"Accept": "application/json", "Authorization": auth},
+        method="GET",
+    )
+    with urlopen(request, timeout=20) as response:
+        if not 200 <= int(response.status) < 300:
+            return False
+        payload = json.loads(response.read())
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        if isinstance(data, list):
+            return any(
+                isinstance(item, dict)
+                and (item.get("traceId") == trace_id or item.get("trace_id") == trace_id)
+                for item in data
+            )
+        return bool(payload.get("traceId") == trace_id or payload.get("trace_id") == trace_id)
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--otel-path", default="/api/public/otel")
+    parser.add_argument("--observations-path", default="/api/public/observations")
+    parser.add_argument("--public-key-env", default="LANGFUSE_PUBLIC_KEY")
+    parser.add_argument("--secret-key-env", default="LANGFUSE_SECRET_KEY")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    public_key = os.environ.get(args.public_key_env, "")
+    secret_key = os.environ.get(args.secret_key_env, "")
+    if not public_key or not secret_key:
+        raise SystemExit("Langfuse public/secret credentials are required")
+
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    base_url = args.base_url.rstrip("/") + "/"
+    otel_url = urljoin(base_url, args.otel_path.lstrip("/"))
+    auth = _basic_auth(public_key, secret_key)
+    exporter = OTLPSpanExporter(
+        endpoint=otel_url,
+        headers={"Authorization": auth, "x-langfuse-ingestion-version": "4"},
+    )
+    provider = TracerProvider(
+        resource=Resource.create({"service.name": "fossil-github-control-plane"})
+    )
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    tracer = trace.get_tracer("fossil.github.control_plane", "1")
+    with tracer.start_as_current_span("fossil-control-plane.synthetic") as span:
+        span.set_attribute("fossil.synthetic", True)
+        span.set_attribute("fossil.source", "github-actions")
+        span.set_attribute("fossil.payload", "non-sensitive-health-check")
+        trace_id = f"{span.get_span_context().trace_id:032x}"
+    provider.force_flush()
+    provider.shutdown()
+
+    verify_url = urljoin(base_url, args.observations_path.lstrip("/"))
+    verified = False
+    for _ in range(12):
+        try:
+            if _verify(verify_url, auth, trace_id):
+                verified = True
+                break
+        except Exception:
+            pass
+        time.sleep(5)
+    report = {
+        "ok": verified,
+        "trace_id": trace_id,
+        "ingest_endpoint": _safe_url(otel_url),
+        "verification_endpoint": _safe_url(verify_url),
+        "synthetic_payload": "non-sensitive-health-check",
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if verified else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/private_probe.py
+++ b/scripts/private_probe.py
@@ -1,0 +1,124 @@
+"""Fail-closed, non-destructive HTTP probe for private services.
+
+The probe deliberately records only response metadata. It never prints response
+bodies or credentials, and treats an empty or malformed successful response as
+a failure rather than a healthy service.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit, urlunsplit
+from urllib.request import Request, urlopen
+
+
+class ProbeError(RuntimeError):
+    pass
+
+
+def safe_url(value: str) -> str:
+    """Return a display-safe URL with query and fragment removed."""
+    parts = urlsplit(value)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+
+
+def _validate_url(value: str) -> None:
+    parts = urlsplit(value)
+    if parts.scheme not in {"http", "https"} or not parts.netloc:
+        raise ProbeError("URL must include an http(s) scheme and host")
+    if parts.username or parts.password:
+        raise ProbeError("credentials in URLs are not allowed")
+
+
+def probe_url(
+    *,
+    name: str,
+    url: str,
+    timeout: float = 15.0,
+    required_keys: tuple[str, ...] = (),
+    bearer_env: str | None = None,
+) -> dict:
+    _validate_url(url)
+    headers = {"Accept": "application/json", "User-Agent": "fossil-private-probe/1"}
+    if bearer_env:
+        token = os.environ.get(bearer_env)
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+    request = Request(url, headers=headers, method="GET")
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            status = int(response.status)
+            raw = response.read()
+    except HTTPError as exc:
+        raise ProbeError(f"{name}: HTTP {exc.code}") from exc
+    except URLError as exc:
+        raise ProbeError(f"{name}: network failure ({exc.reason})") from exc
+    except TimeoutError as exc:
+        raise ProbeError(f"{name}: timeout") from exc
+
+    if not 200 <= status < 300:
+        raise ProbeError(f"{name}: HTTP {status}")
+    if not raw.strip():
+        raise ProbeError(f"{name}: 2xx response had an empty body")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ProbeError(f"{name}: 2xx response was not valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise ProbeError(f"{name}: JSON response was not an object")
+    missing = [key for key in required_keys if key not in payload]
+    if missing:
+        raise ProbeError(f"{name}: JSON response missing required keys: {', '.join(missing)}")
+
+    return {
+        "name": name,
+        "url": safe_url(url),
+        "status_code": status,
+        "json_object": True,
+        "json_keys": sorted(str(key) for key in payload),
+        "ok": True,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--timeout", type=float, default=15.0)
+    parser.add_argument("--require-json-key", action="append", default=[])
+    parser.add_argument("--bearer-env")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        report = probe_url(
+            name=args.name,
+            url=args.url,
+            timeout=args.timeout,
+            required_keys=tuple(args.require_json_key),
+            bearer_env=args.bearer_env,
+        )
+    except ProbeError as exc:
+        report = {
+            "name": args.name,
+            "url": safe_url(args.url),
+            "ok": False,
+            "failure": str(exc),
+        }
+
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="", file=sys.stdout if report["ok"] else sys.stderr)
+    return 0 if report["ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/probe-fossil.sh
+++ b/scripts/probe-fossil.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${FOSSIL_HEALTH_URL:?Set FOSSIL_HEALTH_URL to the private, non-mutating Fossil health endpoint}"
+
+output_path="${FOSSIL_PROBE_OUTPUT:-${RUNNER_TEMP:-.}/fossil-private-health.json}"
+mkdir -p "$(dirname "$output_path")"
+
+python scripts/private_probe.py \
+  --name fossil \
+  --url "$FOSSIL_HEALTH_URL" \
+  --require-json-key "${FOSSIL_HEALTH_JSON_KEY:-status}" \
+  --bearer-env FOSSIL_HEALTH_TOKEN \
+  --output "$output_path"

--- a/scripts/probe-gravebuster.sh
+++ b/scripts/probe-gravebuster.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GRAVEBUSTER_HEALTH_URL:?Set GRAVEBUSTER_HEALTH_URL to a required private Gravebuster service health endpoint}"
+
+output_dir="${GRAVEBUSTER_PROBE_OUTPUT_DIR:-${RUNNER_TEMP:-.}}"
+mkdir -p "$output_dir"
+
+python scripts/private_probe.py \
+  --name gravebuster \
+  --url "$GRAVEBUSTER_HEALTH_URL" \
+  --require-json-key "${GRAVEBUSTER_HEALTH_JSON_KEY:-status}" \
+  --bearer-env GRAVEBUSTER_HEALTH_TOKEN \
+  --output "$output_dir/gravebuster-private-health.json"
+
+probe_optional() {
+  local name="$1"
+  local url="$2"
+  local key="$3"
+  local token_env="$4"
+  [[ -n "$url" ]] || return 0
+  python scripts/private_probe.py \
+    --name "$name" \
+    --url "$url" \
+    --require-json-key "$key" \
+    --bearer-env "$token_env" \
+    --output "$output_dir/${name}-private-health.json"
+}
+
+probe_optional "gravebuster-otel" "${GRAVEBUSTER_OTEL_HEALTH_URL:-}" \
+  "${GRAVEBUSTER_OTEL_HEALTH_JSON_KEY:-status}" GRAVEBUSTER_OTEL_HEALTH_TOKEN
+probe_optional "gravebuster-langfuse" "${GRAVEBUSTER_LANGFUSE_HEALTH_URL:-}" \
+  "${GRAVEBUSTER_LANGFUSE_HEALTH_JSON_KEY:-status}" GRAVEBUSTER_LANGFUSE_HEALTH_TOKEN

--- a/scripts/probe_inference.py
+++ b/scripts/probe_inference.py
@@ -1,0 +1,142 @@
+"""Probe a model gateway and reject transport-level false successes."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlsplit, urlunsplit
+from urllib.request import Request, urlopen
+
+
+class InferenceProbeError(RuntimeError):
+    pass
+
+
+def safe_url(value: str) -> str:
+    parts = urlsplit(value)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+
+
+def _extract_text(payload: object) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    choices = payload.get("choices")
+    if isinstance(choices, list) and choices:
+        first = choices[0]
+        if isinstance(first, dict):
+            message = first.get("message")
+            if isinstance(message, dict) and isinstance(message.get("content"), str):
+                return message["content"].strip()
+            if isinstance(first.get("text"), str):
+                return first["text"].strip()
+            if first.get("tool_calls"):
+                return "[tool_call]"
+    output = payload.get("output")
+    if isinstance(output, str):
+        return output.strip()
+    if isinstance(output, list):
+        for item in output:
+            if isinstance(item, dict):
+                for content in item.get("content", []):
+                    if isinstance(content, dict) and isinstance(content.get("text"), str):
+                        return content["text"].strip()
+    return ""
+
+
+def probe(
+    *,
+    name: str,
+    base_url: str,
+    path: str,
+    model: str,
+    api_key_env: str | None,
+    timeout: float,
+) -> dict:
+    if not model.strip():
+        raise InferenceProbeError(f"{name}: requested model is empty")
+    endpoint = urljoin(base_url.rstrip("/") + "/", path.lstrip("/"))
+    parts = urlsplit(endpoint)
+    if parts.scheme not in {"http", "https"} or not parts.netloc:
+        raise InferenceProbeError(f"{name}: invalid gateway URL")
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+    if api_key_env and os.environ.get(api_key_env):
+        headers["Authorization"] = f"Bearer {os.environ[api_key_env]}"
+    body = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": "Reply with the word ok."}],
+            "max_tokens": 16,
+            "stream": False,
+        }
+    ).encode("utf-8")
+    request = Request(endpoint, data=body, headers=headers, method="POST")
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            status = int(response.status)
+            raw = response.read()
+    except HTTPError as exc:
+        raise InferenceProbeError(f"{name}: HTTP {exc.code}") from exc
+    except URLError as exc:
+        raise InferenceProbeError(f"{name}: network failure ({exc.reason})") from exc
+    except TimeoutError as exc:
+        raise InferenceProbeError(f"{name}: timeout") from exc
+    if not 200 <= status < 300:
+        raise InferenceProbeError(f"{name}: HTTP {status}")
+    if not raw.strip():
+        raise InferenceProbeError(f"{name}: 2xx response had an empty body")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise InferenceProbeError(f"{name}: 2xx response was not valid JSON") from exc
+    text = _extract_text(payload)
+    if not text:
+        raise InferenceProbeError(f"{name}: 2xx response had zero usable output")
+    actual_model = payload.get("model") if isinstance(payload, dict) else None
+    return {
+        "name": name,
+        "endpoint": safe_url(endpoint),
+        "requested_model": model,
+        "actual_model": actual_model if isinstance(actual_model, str) else None,
+        "status_code": status,
+        "usable_output": True,
+        "output_length": len(text),
+        "ok": True,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--path", default="/v1/chat/completions")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--api-key-env")
+    parser.add_argument("--timeout", type=float, default=45.0)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        report = probe(
+            name=args.name,
+            base_url=args.base_url,
+            path=args.path,
+            model=args.model,
+            api_key_env=args.api_key_env,
+            timeout=args.timeout,
+        )
+    except InferenceProbeError as exc:
+        report = {"name": args.name, "ok": False, "failure": str(exc)}
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="", file=sys.stdout if report["ok"] else sys.stderr)
+    return 0 if report["ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_github_control_plane_contract.py
+++ b/tests/test_github_control_plane_contract.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from private_probe import ProbeError, probe_url, safe_url  # noqa: E402
+from probe_inference import _extract_text  # noqa: E402
+
+
+def test_control_plane_contract_is_github_hosted_and_scoped():
+    contract = json.loads(
+        (ROOT / "config/integrations/github-control-plane.json").read_text(encoding="utf-8")
+    )
+    assert contract["control_plane"] == "github-hosted-actions"
+    assert contract["runner"] == "github-hosted-ubuntu-latest"
+    assert contract["private_network"] == "tailscale"
+    assert contract["runner_identity"]["mode"] == "ephemeral-workload-identity"
+    assert contract["routine_health_checks_mutate_knowledge_graph"] is False
+    assert "ssc-runtime" in contract["forbidden_dependencies"]
+    assert "kubernetes" in contract["forbidden_dependencies"]
+
+
+@pytest.mark.parametrize(
+    "workflow",
+    [
+        "fossil-private-health.yml",
+        "gravebuster-private-health.yml",
+    ],
+)
+def test_private_health_workflows_use_ephemeral_oidc_tailnet_access(workflow: str):
+    text = (ROOT / ".github/workflows" / workflow).read_text(encoding="utf-8")
+    assert "runs-on: ubuntu-latest" in text
+    assert "tailscale/github-action@v4" in text
+    assert "oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}" in text
+    assert "audience: ${{ secrets.TS_AUDIENCE }}" in text
+    assert "tags: tag:ci" in text
+    assert "id-token: write" in text
+    assert "self-hosted" not in text
+    assert "tailscale up" not in text
+    assert "authkey:" not in text
+
+
+def test_probe_scripts_fail_closed_and_never_echo_response_body():
+    fossil = (ROOT / "scripts/probe-fossil.sh").read_text(encoding="utf-8")
+    gravebuster = (ROOT / "scripts/probe-gravebuster.sh").read_text(encoding="utf-8")
+    for script in (fossil, gravebuster):
+        assert "set -euo pipefail" in script
+        assert "private_probe.py" in script
+        assert "--require-json-key" in script
+    probe = (ROOT / "scripts/private_probe.py").read_text(encoding="utf-8")
+    assert "response.read()" in probe
+    assert "print(rendered" in probe
+    assert "raw" not in probe.split("print(rendered", 1)[1]
+
+
+class _Handler(BaseHTTPRequestHandler):
+    body = b"{}"
+    status = 200
+
+    def do_GET(self):  # noqa: N802
+        self.send_response(self.status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(self.body)
+
+    def log_message(self, *_args):
+        return
+
+
+def _server(body: bytes, status: int = 200):
+    handler = type("Handler", (_Handler,), {"body": body, "status": status})
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def test_private_probe_accepts_required_json_and_redacts_url():
+    server, thread = _server(b'{"status":"ok"}')
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/health?token=secret#fragment"
+        result = probe_url(name="fixture", url=url, required_keys=("status",))
+        assert result["ok"] is True
+        assert result["url"].endswith("/health")
+        assert "secret" not in result["url"]
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+@pytest.mark.parametrize("body", [b"", b"not-json", b"[]"])
+def test_private_probe_rejects_empty_malformed_or_non_object_success(body: bytes):
+    server, thread = _server(body)
+    try:
+        with pytest.raises(ProbeError):
+            probe_url(name="fixture", url=f"http://127.0.0.1:{server.server_port}/health")
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_inference_probe_rejects_zero_payload_shapes():
+    assert _extract_text({"choices": [{"message": {"content": "ok"}}]}) == "ok"
+    assert _extract_text({"choices": [{"message": {"content": ""}}]}) == ""
+    assert _extract_text({"choices": [{"text": "ok"}]}) == "ok"
+    assert _extract_text({"choices": [{"tool_calls": [{"id": "tool"}]}]}) == "[tool_call]"
+    assert _extract_text({"choices": []}) == ""
+    assert _extract_text({}) == ""
+
+
+def test_workflows_do_not_put_private_credentials_in_urls_or_logs():
+    for path in (ROOT / ".github/workflows").glob("*.yml"):
+        text = path.read_text(encoding="utf-8")
+        assert "?token=" not in text
+        assert "Authorization: Bearer" not in text
+
+
+def test_synthetic_trace_workflow_uses_tailnet_and_sanitized_evidence():
+    text = (ROOT / ".github/workflows/langfuse-synthetic-trace.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "tailscale/github-action@v4" in text
+    assert "opentelemetry-exporter-otlp-proto-http" in text
+    assert "emit_langfuse_trace.py" in text
+    assert "id-token: write" in text
+    assert "self-hosted" not in text
+
+
+def test_langfuse_trace_report_contains_no_payload_or_credentials():
+    text = (ROOT / "scripts/emit_langfuse_trace.py").read_text(encoding="utf-8")
+    assert "non-sensitive-health-check" in text
+    assert "response.read()" in text
+    assert "secret_key" not in text.split("print(json.dumps(report", 1)[-1]


### PR DESCRIPTION
## Summary

Implements the narrow GitHub-hosted control-plane lane for #79:

- GitHub-hosted Ubuntu workflows join Tailscale ephemerally with `tailscale/github-action@v4`, OIDC workload identity, and `tag:ci`.
- Adds private Fossil and Gravebuster health workflows with non-mutating, fail-closed JSON probes.
- Adds a manual Langfuse OTel synthetic-trace workflow that verifies the trace by ID.
- Adds a manual live inference probe that rejects empty bodies, malformed JSON, and zero-usable-output false successes.
- Adds cross-repo contract checks and a durable ownership/dependency contract.
- Documents the real Gravebuster inventory, required GitHub variables/secrets, ACL/firewall boundaries, evidence requirements, and current blockers.

## Validation

- Focused control-plane tests: `12 passed`.
- Full suite excluding the unrelated Windows-only `tests/test_retrieval_bakeoff.py`: `120 passed`.
- Full Windows collection is blocked by that existing test importing Unix-only Python `resource`.
- Workflow YAML parsing, shell syntax, and `git diff --check` pass.

## Current infrastructure blockers

Discovery confirmed that this local Codex can SSH to the remote Gravebuster host over Tailscale and found the Fossil source checkout there. No running Fossil health/API service or durable Fossil database endpoint was present, and no separate Gravebuster GitHub repository was identified. The GitHub-hosted acceptance workflows therefore remain intentionally fail-closed until the service endpoints, Tailscale trust variables/secrets, and source-repository identity are configured.

Closes the implementation portion of #79; the live acceptance evidence must be attached after configuration.