### PR TITLE
Add status-aware build-context packet v1

### DIFF
--- a/contracts/engineering/README.md
+++ b/contracts/engineering/README.md
@@ -1,0 +1,20 @@
+# Engineering preflight v1
+
+This is a deliberately small, Git-versioned contract for bounded implementation
+work. It validates offline and never requires a live FOSSIL service, a model, or
+a secret. FOSSIL retrieval and the live GitHub read are supplied as evidence to
+`dkg.engineering_preflight.build_context_packet`.
+
+`CURRENT_AUTHORITY` establishes the current authority set only when supplied by
+an explicit lifecycle/authority source or the bounded live GitHub read. Retrieval
+rank is not an authority field. `SUPERSEDED_OR_HISTORICAL` material stays visible
+for lineage but cannot silently dispatch work. `CURRENT_STATE_UNRESOLVED`, an
+unknown source status, a material conflict, or a material unresolved assumption
+returns `dispatch_status: BLOCKED`.
+
+The default GitHub reader is intentionally unauthenticated and reads no
+environment credentials. A trusted caller may inject an authenticated transport;
+ordinary pull-request CI should use fixtures or an injected secretless transport.
+
+The JSON schemas validate `preflight-v1` and `closeout-v1`. The Python module
+adds the fail-closed semantic checks required before a bounded WorkOrder is made.

--- a/contracts/engineering/closeout-v1.schema.json
+++ b/contracts/engineering/closeout-v1.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fossil.local/contracts/engineering/closeout-v1.schema.json",
+  "type": "object",
+  "required": ["version", "outcome", "changed_files", "tests", "terminal_status", "evidence"],
+  "properties": {
+    "version": {"const": "closeout-v1"},
+    "outcome": {"type": "string"},
+    "changed_files": {"type": "array", "items": {"type": "string"}},
+    "tests": {"type": "array", "items": {"type": "object"}},
+    "terminal_status": {"enum": ["PASS", "FAILED", "BLOCKED"]},
+    "evidence": {"type": "array", "minItems": 1, "items": {"type": "object"}}
+  },
+  "additionalProperties": true
+}

--- a/contracts/engineering/engineering-constitution-v1.yaml
+++ b/contracts/engineering/engineering-constitution-v1.yaml
@@ -1,0 +1,17 @@
+version: engineering-constitution-v1
+authority: versioned-git-contract
+universal_kernel:
+  - outcome
+  - behavior_owner
+  - state_classification
+  - public_contract_impact
+  - semantic_success
+  - mechanical_success_and_failure
+  - evidence_and_tests
+  - recovery_and_rollback
+  - unresolved_assumptions
+rules:
+  - Retrieval rank never establishes current authority.
+  - Historical material is useful lineage but cannot silently drive implementation.
+  - A material unresolved current-state conflict blocks an implementation WorkOrder.
+  - Operational telemetry is evidence, not canonical FOSSIL truth.

--- a/contracts/engineering/examples/trivial-edit.json
+++ b/contracts/engineering/examples/trivial-edit.json
@@ -1,0 +1,18 @@
+{
+  "version": "preflight-v1",
+  "task": {
+    "outcome": "Correct one documentation typo.",
+    "behavior_owner": "repository documentation",
+    "state_classification": "source text only",
+    "public_contract_impact": "none",
+    "semantic_success": "the intended text is present",
+    "mechanical_success_and_failure": "targeted check passes; unrelated files are unchanged",
+    "evidence_and_tests": ["targeted text assertion"],
+    "recovery_and_rollback": "revert the one-file commit"
+  },
+  "risk_facets": [],
+  "kernel": {"scope": "trivial"},
+  "sources": [{"stable_id": "github:issue:84", "status": "CURRENT_AUTHORITY", "provenance": "live GitHub issue"}],
+  "unresolved_assumptions": [],
+  "required_closeout_evidence": ["targeted assertion"]
+}

--- a/contracts/engineering/preflight-v1.schema.json
+++ b/contracts/engineering/preflight-v1.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fossil.local/contracts/engineering/preflight-v1.schema.json",
+  "type": "object",
+  "required": ["version", "task", "risk_facets", "kernel", "sources", "unresolved_assumptions", "required_closeout_evidence"],
+  "properties": {
+    "version": {"const": "preflight-v1"},
+    "task": {"type": "object", "required": ["outcome", "behavior_owner", "state_classification", "public_contract_impact", "semantic_success", "mechanical_success_and_failure", "evidence_and_tests", "recovery_and_rollback"], "additionalProperties": true},
+    "risk_facets": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+    "kernel": {"type": "object"},
+    "sources": {"type": "array", "items": {"type": "object", "required": ["stable_id", "status", "provenance"]}},
+    "unresolved_assumptions": {"type": "array", "items": {"type": "object", "required": ["id", "material", "status"]}},
+    "required_closeout_evidence": {"type": "array", "items": {"type": "string"}}
+  },
+  "additionalProperties": true
+}

--- a/contracts/engineering/task-trigger-matrix-v1.yaml
+++ b/contracts/engineering/task-trigger-matrix-v1.yaml
@@ -1,0 +1,16 @@
+version: task-trigger-matrix-v1
+risk_facets:
+  new-service: [api-service, deployment-release, observability]
+  cross-service-call: [api-service, timeout-retry, observability]
+  durable-write: [durability, timeout-retry, recovery]
+  database-or-schema-change: [durability, migration, recovery]
+  async-or-background-work: [async-delivery, timeout-retry, recovery]
+  queue-or-event-stream: [async-delivery, timeout-retry, recovery]
+  external-dependency: [dependency-provider, timeout-retry]
+  auth-security-sensitive: [security]
+  ai-agent-or-model-call: [ai-semantic-success, timeout-retry, observability]
+  deployment-or-infrastructure: [deployment-release, security, observability]
+  migration-or-backfill: [migration, durability, recovery]
+  performance-or-capacity: [performance-capacity]
+  observability-change: [observability]
+  cross-repo-contract-change: [cross-repo-contract]

--- a/src/dkg/engineering_preflight.py
+++ b/src/dkg/engineering_preflight.py
@@ -1,0 +1,219 @@
+"""Offline-validatable engineering preflight and build-context packet v1.
+
+This module deliberately treats GitHub and FOSSIL retrieval as evidence inputs.  A
+retrieval score, a GitHub HTTP response, or a model-written summary does not by
+itself establish current authority.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from jsonschema import Draft202012Validator
+
+
+PREFLIGHT_VERSION = "preflight-v1"
+BUILD_CONTEXT_VERSION = "build-context-packet-v1"
+CURRENT_STATUSES = frozenset({"CURRENT_AUTHORITY", "ACCEPTED"})
+NONCURRENT_STATUSES = frozenset(
+    {"CANDIDATE_UNDER_TEST", "UNDECIDED", "SUPERSEDED_OR_HISTORICAL", "STALE"}
+)
+KNOWN_STATUSES = CURRENT_STATUSES | NONCURRENT_STATUSES | {"CURRENT_STATE_UNRESOLVED"}
+
+RISK_PACKS = {
+    "new-service": ("api-service", "deployment-release", "observability"),
+    "cross-service-call": ("api-service", "timeout-retry", "observability"),
+    "durable-write": ("durability", "timeout-retry", "recovery"),
+    "database-or-schema-change": ("durability", "migration", "recovery"),
+    "async-or-background-work": ("async-delivery", "timeout-retry", "recovery"),
+    "queue-or-event-stream": ("async-delivery", "timeout-retry", "recovery"),
+    "external-dependency": ("dependency-provider", "timeout-retry"),
+    "auth-security-sensitive": ("security",),
+    "ai-agent-or-model-call": ("ai-semantic-success", "timeout-retry", "observability"),
+    "deployment-or-infrastructure": ("deployment-release", "security", "observability"),
+    "migration-or-backfill": ("migration", "durability", "recovery"),
+    "performance-or-capacity": ("performance-capacity",),
+    "observability-change": ("observability",),
+    "cross-repo-contract-change": ("cross-repo-contract",),
+}
+
+
+def selected_risk_packs(risk_facets: Iterable[str]) -> list[str]:
+    """Return ordered, de-duplicated packs; a trivial task remains empty."""
+    return list(dict.fromkeys(pack for facet in risk_facets for pack in RISK_PACKS.get(facet, ())))
+
+
+def _contract_schema(name: str) -> Mapping[str, Any]:
+    root = Path(__file__).resolve().parents[2]
+    return json.loads((root / "contracts" / "engineering" / name).read_text(encoding="utf-8"))
+
+
+def validate_preflight(receipt: Mapping[str, Any]) -> list[str]:
+    """Validate the small offline preflight contract and return deterministic errors."""
+    errors = sorted(Draft202012Validator(_contract_schema("preflight-v1.schema.json")).iter_errors(receipt), key=str)
+    return [error.message for error in errors]
+
+
+def validate_closeout(receipt: Mapping[str, Any]) -> list[str]:
+    errors = sorted(Draft202012Validator(_contract_schema("closeout-v1.schema.json")).iter_errors(receipt), key=str)
+    return [error.message for error in errors]
+
+
+def _default_fetch_json(path: str) -> Mapping[str, Any]:
+    """Read public GitHub metadata without reading or requiring any secret."""
+    request = Request(
+        f"https://api.github.com/{path.lstrip('/')}",
+        headers={"Accept": "application/vnd.github+json", "User-Agent": "fossil-build-context-v1"},
+    )
+    with urlopen(request, timeout=10) as response:  # noqa: S310 - fixed GitHub API origin
+        return json.loads(response.read().decode("utf-8"))
+
+
+def resolve_live_github_state(
+    repository: str,
+    refs: Iterable[Mapping[str, Any]],
+    *,
+    fetch_json: Callable[[str], Mapping[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Resolve issue/PR/branch state into bounded evidence records.
+
+    Callers can inject an authenticated transport from a trusted path.  This
+    secretless default deliberately never reads environment credentials.
+    """
+    fetch = fetch_json or _default_fetch_json
+    resolved: list[dict[str, Any]] = []
+    for ref in refs:
+        kind, number, name = str(ref.get("kind", "")), ref.get("number"), ref.get("name")
+        if kind not in {"issue", "pull", "branch"}:
+            raise ValueError(f"unsupported GitHub ref kind: {kind}")
+        if kind in {"issue", "pull"} and not isinstance(number, int):
+            raise ValueError(f"{kind} ref requires integer number")
+        if kind == "branch" and not isinstance(name, str):
+            raise ValueError("branch ref requires name")
+        value = number if kind != "branch" else quote(name, safe="")
+        path = f"repos/{repository}/{'issues' if kind == 'issue' else 'pulls' if kind == 'pull' else 'branches'}/{value}"
+        stable_id = f"github:{repository}:{kind}:{number if kind != 'branch' else name}"
+        try:
+            payload = fetch(path)
+        except Exception as exc:  # network/permission failures are blockable evidence, never silently ignored
+            resolved.append(
+                {
+                    "stable_id": stable_id,
+                    "provenance": "live-github-read",
+                    "status": "CURRENT_STATE_UNRESOLVED",
+                    "error_class": type(exc).__name__,
+                    "material": True,
+                }
+            )
+            continue
+        resolved.append(
+            {
+                "stable_id": stable_id,
+                "provenance": "live-github-read",
+                "status": "CURRENT_AUTHORITY",
+                "url": payload.get("html_url"),
+                "updated_at": payload.get("updated_at"),
+                "state": payload.get("state"),
+                "head_sha": payload.get("head", {}).get("sha") if isinstance(payload.get("head"), Mapping) else payload.get("commit", {}).get("sha"),
+                "freshness": "live-read",
+                "material": True,
+            }
+        )
+    return resolved
+
+
+def build_context_packet(
+    *,
+    task: Mapping[str, Any],
+    fossil_material: Iterable[Mapping[str, Any]],
+    github_state: Iterable[Mapping[str, Any]],
+    risk_facets: Iterable[str] = (),
+    unresolved_assumptions: Iterable[Mapping[str, Any]] = (),
+    required_closeout_evidence: Iterable[str] = (),
+) -> dict[str, Any]:
+    """Build a task-scoped packet and fail closed on unresolved material state."""
+    fossil = [dict(item) for item in fossil_material]
+    github = [dict(item) for item in github_state]
+    material = fossil + github
+    unknown_statuses = [item for item in material if item.get("status") not in KNOWN_STATUSES]
+    unresolved = [dict(item) for item in unresolved_assumptions]
+    conflicts = [
+        item
+        for item in material
+        if item.get("status") == "CURRENT_STATE_UNRESOLVED" or (item.get("material") and item.get("conflict"))
+    ]
+    if unknown_statuses:
+        conflicts.extend({"stable_id": item.get("stable_id"), "reason": "unknown source status", "material": True} for item in unknown_statuses)
+    conflicts.extend(item for item in unresolved if item.get("material") and item.get("status") != "resolved")
+    current = [item for item in material if item.get("status") in CURRENT_STATUSES]
+    packet = {
+        "version": BUILD_CONTEXT_VERSION,
+        "task": dict(task),
+        "current_authority": current,
+        "current_implementation_state": github,
+        "candidates_under_test": [item for item in material if item.get("status") == "CANDIDATE_UNDER_TEST"],
+        "undecided": [item for item in material if item.get("status") == "UNDECIDED"],
+        "superseded_or_historical": [item for item in material if item.get("status") in {"SUPERSEDED_OR_HISTORICAL", "STALE"}],
+        "contradictions": conflicts,
+        "current_state_unresolved": bool(conflicts),
+        "risk_facets": list(dict.fromkeys(risk_facets)),
+        "selected_risk_packs": selected_risk_packs(risk_facets),
+        "sources": material,
+        "freshness": {"github": "live-read" if github_state else "not-requested", "fossil": "caller-supplied"},
+        "unresolved_assumptions": unresolved,
+        "required_tests_fault_probes_closeout": list(required_closeout_evidence),
+        "dispatch_status": "BLOCKED" if conflicts else "READY_FOR_BOUNDED_WORKORDER",
+    }
+    return packet
+
+
+def preflight_from_packet(packet: Mapping[str, Any]) -> dict[str, Any]:
+    """Create a v1 receipt whose validator remains offline and network-free."""
+    task = dict(packet["task"])
+    receipt = {
+        "version": PREFLIGHT_VERSION,
+        "task": task,
+        "risk_facets": list(packet.get("risk_facets", [])),
+        "kernel": {
+            key: task.get(key)
+            for key in (
+                "outcome", "behavior_owner", "state_classification", "public_contract_impact",
+                "semantic_success", "mechanical_success_and_failure", "evidence_and_tests", "recovery_and_rollback",
+            )
+        },
+        "sources": list(packet.get("sources", [])),
+        "unresolved_assumptions": list(packet.get("unresolved_assumptions", [])),
+        "required_closeout_evidence": list(packet.get("required_tests_fault_probes_closeout", [])),
+        "build_context_version": packet.get("version"),
+        "dispatch_status": packet.get("dispatch_status"),
+    }
+    return receipt
+
+
+def validate_build_context_packet(packet: Mapping[str, Any]) -> list[str]:
+    """Enforce the additional safety semantics not expressed by generic JSON Schema."""
+    errors: list[str] = []
+    if packet.get("version") != BUILD_CONTEXT_VERSION:
+        errors.append("unsupported build-context packet version")
+    required_task_keys = {
+        "outcome", "behavior_owner", "state_classification", "public_contract_impact", "semantic_success",
+        "mechanical_success_and_failure", "evidence_and_tests", "recovery_and_rollback",
+    }
+    missing = required_task_keys - set(packet.get("task", {}))
+    if missing:
+        errors.append(f"task is missing universal-kernel fields: {', '.join(sorted(missing))}")
+    if not packet.get("current_authority"):
+        errors.append("no CURRENT_AUTHORITY source is present")
+    if not packet.get("current_implementation_state"):
+        errors.append("live GitHub implementation state is required")
+    blocked = bool(packet.get("current_state_unresolved"))
+    if blocked and packet.get("dispatch_status") != "BLOCKED":
+        errors.append("unresolved material state must block dispatch")
+    if not blocked and packet.get("dispatch_status") != "READY_FOR_BOUNDED_WORKORDER":
+        errors.append("resolved packet must have bounded-workorder dispatch status")
+    errors.extend(f"preflight: {error}" for error in validate_preflight(preflight_from_packet(packet)))
+    return errors

--- a/tests/test_engineering_preflight.py
+++ b/tests/test_engineering_preflight.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dkg.engineering_preflight import (
+    build_context_packet,
+    preflight_from_packet,
+    resolve_live_github_state,
+    selected_risk_packs,
+    validate_build_context_packet,
+    validate_closeout,
+    validate_preflight,
+)
+
+
+def task():
+    return {
+        "outcome": "Add a bounded context packet.",
+        "behavior_owner": "FOSSIL engineering preflight",
+        "state_classification": "versioned source contract",
+        "public_contract_impact": "new opt-in contract",
+        "semantic_success": "stale material cannot silently select current authority",
+        "mechanical_success_and_failure": "validator passes or blocks dispatch",
+        "evidence_and_tests": ["unit tests"],
+        "recovery_and_rollback": "revert the isolated commit",
+    }
+
+
+def current_source(stable_id="fossil:issue:84"):
+    return {"stable_id": stable_id, "status": "CURRENT_AUTHORITY", "provenance": "fixture", "material": True}
+
+
+def github_source():
+    return {"stable_id": "github:Pukujan/fossil-core:issue:84", "status": "CURRENT_AUTHORITY", "provenance": "live-github-read", "material": True}
+
+
+def test_trivial_task_selects_no_distributed_systems_pack():
+    assert selected_risk_packs([]) == []
+
+
+def test_packet_keeps_history_but_allows_bounded_work_when_current_authority_is_known():
+    packet = build_context_packet(
+        task=task(),
+        fossil_material=[current_source(), {"stable_id": "fossil:old", "status": "SUPERSEDED_OR_HISTORICAL", "provenance": "fixture"}],
+        github_state=[github_source()],
+        required_closeout_evidence=["targeted tests"],
+    )
+    assert packet["dispatch_status"] == "READY_FOR_BOUNDED_WORKORDER"
+    assert packet["superseded_or_historical"][0]["stable_id"] == "fossil:old"
+    assert validate_build_context_packet(packet) == []
+    assert validate_preflight(preflight_from_packet(packet)) == []
+
+
+def test_material_unresolved_state_fails_closed():
+    packet = build_context_packet(
+        task=task(),
+        fossil_material=[current_source(), {"stable_id": "fossil:conflict", "status": "CURRENT_STATE_UNRESOLVED", "provenance": "fixture", "material": True}],
+        github_state=[github_source()],
+    )
+    assert packet["current_state_unresolved"] is True
+    assert packet["dispatch_status"] == "BLOCKED"
+    assert validate_build_context_packet(packet) == []
+
+
+def test_live_github_read_is_injectable_and_secretless():
+    paths = []
+
+    def fetch(path):
+        paths.append(path)
+        return {"html_url": "https://example.invalid/84", "updated_at": "2026-08-12T00:00:00Z", "state": "open"}
+
+    state = resolve_live_github_state("Pukujan/fossil-core", [{"kind": "issue", "number": 84}], fetch_json=fetch)
+    assert paths == ["repos/Pukujan/fossil-core/issues/84"]
+    assert state[0]["status"] == "CURRENT_AUTHORITY"
+    assert state[0]["provenance"] == "live-github-read"
+
+
+def test_branch_names_are_url_encoded_and_generators_are_not_lost():
+    paths = []
+
+    def fetch(path):
+        paths.append(path)
+        return {"commit": {"sha": "abc"}, "state": "active"}
+
+    state = resolve_live_github_state("Pukujan/fossil-core", [{"kind": "branch", "name": "agent/context packet"}], fetch_json=fetch)
+    packet = build_context_packet(task=task(), fossil_material=(item for item in [current_source()]), github_state=(item for item in state))
+    assert paths == ["repos/Pukujan/fossil-core/branches/agent%2Fcontext%20packet"]
+    assert packet["current_implementation_state"][0]["head_sha"] == "abc"
+
+
+def test_live_github_failure_is_packet_blocking_evidence():
+    def unavailable(_):
+        raise TimeoutError("fixture timeout")
+
+    state = resolve_live_github_state("Pukujan/fossil-core", [{"kind": "pull", "number": 90}], fetch_json=unavailable)
+    packet = build_context_packet(task=task(), fossil_material=[current_source()], github_state=state)
+    assert packet["dispatch_status"] == "BLOCKED"
+    assert packet["contradictions"][0]["error_class"] == "TimeoutError"
+
+
+def test_closeout_requires_mechanical_evidence_and_terminal_status():
+    assert validate_closeout({"version": "closeout-v1", "outcome": "done", "changed_files": [], "tests": [], "terminal_status": "PASS", "evidence": [{"kind": "test"}]}) == []
+    assert validate_closeout({"version": "closeout-v1", "outcome": "done", "changed_files": [], "tests": [], "terminal_status": "PASS", "evidence": []})


### PR DESCRIPTION
## What changed

- adds a small offline-validatable `preflight-v1` / `closeout-v1` contract plus universal-kernel and risk-trigger definitions;
- adds a status-aware build-context packet builder that combines caller-supplied FOSSIL lifecycle evidence with a bounded live GitHub state resolver;
- fails closed on material unresolved authority, conflicts, unknown source status, GitHub-read failure, or material unresolved assumptions;
- keeps historical/superseded material visible for lineage without allowing retrieval rank to establish current authority;
- adds deterministic fixture tests including no-risk trivial work, history handling, GitHub failure blocking, and branch escaping.

## Boundaries

The default GitHub reader is public/unauthenticated and reads no environment credentials. Trusted callers may inject a transport; ordinary PR CI can use fixtures. This does not dispatch real-model work, select an executor, or change durable architecture.

## Checks

- `python -m pytest tests/test_engineering_preflight.py -q` (7 passed)
- `python -m pytest -q --ignore=tests/test_retrieval_bakeoff.py` (115 passed)
- `python -m compileall -q src`

The full local suite cannot collect `tests/test_retrieval_bakeoff.py` on Windows because Python's POSIX-only `resource` module is imported. Independent GitHub PR #90 CI also has a separate pre-existing defect: `_route_eligibility` is absent while four tests expect it.