### PR TITLE
Add secretless engineering assurance checks

### DIFF
--- a/.github/workflows/engineering-assurance.yml
+++ b/.github/workflows/engineering-assurance.yml
@@ -1,0 +1,64 @@
+name: Engineering assurance
+
+on:
+  pull_request:
+    paths:
+      - "contracts/engineering/**"
+      - "src/dkg/engineering_preflight.py"
+      - "src/dkg/engineering_assurance.py"
+      - "scripts/validate_engineering_assurance.py"
+      - "tests/test_engineering_preflight.py"
+      - "tests/test_engineering_assurance.py"
+      - ".github/workflows/engineering-assurance.yml"
+      - "pyproject.toml"
+  push:
+    branches: [main]
+    paths:
+      - "contracts/engineering/**"
+      - "src/dkg/engineering_preflight.py"
+      - "src/dkg/engineering_assurance.py"
+      - "scripts/validate_engineering_assurance.py"
+      - "tests/test_engineering_preflight.py"
+      - "tests/test_engineering_assurance.py"
+      - ".github/workflows/engineering-assurance.yml"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  engineering-contracts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Clean reproducible install and dependency integrity
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[test]'
+          python -m pip check
+      - name: Validate preflight, closeout, and cross-repository contracts
+        run: python scripts/validate_engineering_assurance.py
+      - name: Run risk-triggered semantic and security fixtures
+        run: python -m pytest -q tests/test_engineering_preflight.py tests/test_engineering_assurance.py
+      - name: Emit compact secretless receipt
+        shell: bash
+        run: |
+          {
+            echo "## Engineering assurance receipt"
+            echo "- project_issue_id: #88"
+            echo "- work_order_id: not_applicable"
+            echo "- task_id: FOSSIL-04"
+            echo "- attempt_id: ${{ github.run_id }}.${{ github.run_attempt }}"
+            echo "- generation: not_applicable"
+            echo "- request_id: not_applicable"
+            echo "- trace_id: not_applicable"
+            echo "- checkpoint_id: ${{ github.sha }}"
+            echo "- commit_sha: ${{ github.sha }}"
+            echo "- deployment_id: not_applicable"
+            echo "- security: secretless; contents:read; privileged PR trigger absent"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/contracts/engineering/control-plane-contract-v1.json
+++ b/contracts/engineering/control-plane-contract-v1.json
@@ -1,0 +1,27 @@
+{
+  "version": "control-plane-contract-v1",
+  "authority": "fossil-core#86 current architecture boundary",
+  "owners": {
+    "fossil": "durable semantic evidence, lifecycle, lineage, and provenance",
+    "cortex": "execution policy, attempts, recovery, and evidence",
+    "litellm_ckff_ops": "provider/model/route/capability/timeout/observed-health factual transport"
+  },
+  "routing_policy_owner": "caller",
+  "shared_contracts": {
+    "build_context": "build-context-packet-v1",
+    "preflight": "preflight-v1",
+    "closeout": "closeout-v1"
+  },
+  "correlation_fields": [
+    "project_issue_id",
+    "work_order_id",
+    "task_id",
+    "attempt_id",
+    "generation",
+    "request_id",
+    "trace_id",
+    "checkpoint_id",
+    "commit_sha",
+    "deployment_id"
+  ]
+}

--- a/contracts/engineering/examples/trivial-edit-closeout.json
+++ b/contracts/engineering/examples/trivial-edit-closeout.json
@@ -1,0 +1,8 @@
+{
+  "version": "closeout-v1",
+  "outcome": "Corrected one documentation typo.",
+  "changed_files": ["docs/example.md"],
+  "tests": [{"name": "targeted text assertion", "result": "PASS"}],
+  "terminal_status": "PASS",
+  "evidence": [{"kind": "test", "ref": "fixture:targeted-text-assertion"}]
+}

--- a/scripts/validate_engineering_assurance.py
+++ b/scripts/validate_engineering_assurance.py
@@ -1,0 +1,37 @@
+"""Run deterministic engineering-assurance checks without network or secrets."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from dkg.engineering_assurance import load_control_plane_contract, validate_control_plane_contract
+from dkg.engineering_preflight import validate_closeout, validate_preflight
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    example = json.loads(
+        (ROOT / "contracts" / "engineering" / "examples" / "trivial-edit.json").read_text(encoding="utf-8")
+    )
+    closeout = json.loads(
+        (ROOT / "contracts" / "engineering" / "examples" / "trivial-edit-closeout.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    errors = validate_preflight(example)
+    errors.extend(validate_closeout(closeout))
+    errors.extend(validate_control_plane_contract(load_control_plane_contract(ROOT)))
+    if errors:
+        print("engineering assurance validation failed:", file=sys.stderr)
+        print("\n".join(f"- {error}" for error in errors), file=sys.stderr)
+        return 1
+    print("engineering assurance validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dkg/engineering_assurance.py
+++ b/src/dkg/engineering_assurance.py
@@ -1,0 +1,80 @@
+"""Small deterministic assurance checks for engineering contracts.
+
+These helpers intentionally validate a bounded semantic surface. They do not
+turn a 2xx response, a process exit, or a workflow success into product truth.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+
+CONTROL_PLANE_VERSION = "control-plane-contract-v1"
+REQUIRED_CORRELATION_FIELDS = (
+    "project_issue_id",
+    "work_order_id",
+    "task_id",
+    "attempt_id",
+    "generation",
+    "request_id",
+    "trace_id",
+    "checkpoint_id",
+    "commit_sha",
+    "deployment_id",
+)
+
+
+def semantic_http_errors(*, status_code: int, body: bytes, expected: str = "json") -> list[str]:
+    """Reject transport-only success when the requested semantic payload is absent."""
+    errors: list[str] = []
+    if not 200 <= status_code < 300:
+        errors.append("non-success HTTP status")
+        return errors
+    if not body:
+        return ["2xx response has an empty body"]
+    if expected == "json":
+        try:
+            parsed = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return ["2xx response has malformed JSON"]
+        if not isinstance(parsed, Mapping) or not parsed:
+            return ["2xx response has no usable JSON object"]
+    elif expected == "stream" and not body.strip():
+        return ["completed stream has zero usable payload"]
+    elif expected not in {"json", "stream", "bytes"}:
+        return [f"unsupported semantic expectation: {expected}"]
+    return errors
+
+
+def validate_control_plane_contract(contract: Mapping[str, Any]) -> list[str]:
+    """Validate the small, versioned FOSSIL/Cortex/LiteLLM compatibility seam."""
+    errors: list[str] = []
+    if contract.get("version") != CONTROL_PLANE_VERSION:
+        errors.append("unsupported control-plane contract version")
+    owners = contract.get("owners")
+    if not isinstance(owners, Mapping) or set(owners) != {"fossil", "cortex", "litellm_ckff_ops"}:
+        errors.append("control-plane owners must name fossil, cortex, and litellm_ckff_ops")
+    if contract.get("routing_policy_owner") != "caller":
+        errors.append("routing policy owner must remain caller")
+    shared = contract.get("shared_contracts")
+    required_shared = {
+        "build_context": "build-context-packet-v1",
+        "preflight": "preflight-v1",
+        "closeout": "closeout-v1",
+    }
+    if shared != required_shared:
+        errors.append("shared contract versions do not match v1 control-plane boundary")
+    if tuple(contract.get("correlation_fields", ())) != REQUIRED_CORRELATION_FIELDS:
+        errors.append("correlation fields do not match the shared receipt spine")
+    return errors
+
+
+def load_control_plane_contract(root: Path) -> dict[str, Any]:
+    path = root / "contracts" / "engineering" / "control-plane-contract-v1.json"
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("control-plane contract must be a JSON object")
+    return value

--- a/tests/test_engineering_assurance.py
+++ b/tests/test_engineering_assurance.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from dkg.engineering_assurance import (
+    load_control_plane_contract,
+    semantic_http_errors,
+    validate_control_plane_contract,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_semantic_false_success_fixtures_are_rejected():
+    assert semantic_http_errors(status_code=200, body=b"") == ["2xx response has an empty body"]
+    assert semantic_http_errors(status_code=200, body=b"{") == ["2xx response has malformed JSON"]
+    assert semantic_http_errors(status_code=200, body=b"{}") == ["2xx response has no usable JSON object"]
+    assert semantic_http_errors(status_code=200, body=b"   ", expected="stream") == [
+        "completed stream has zero usable payload"
+    ]
+
+
+def test_usable_json_and_non_success_have_explicit_outcomes():
+    assert semantic_http_errors(status_code=200, body=b'{"id":"fixture"}') == []
+    assert semantic_http_errors(status_code=503, body=b"unavailable") == ["non-success HTTP status"]
+
+
+def test_shared_control_plane_contract_preserves_owner_and_correlation_boundary():
+    assert validate_control_plane_contract(load_control_plane_contract(ROOT)) == []
+
+
+def test_assurance_workflow_is_path_scoped_and_secretless():
+    workflow = (ROOT / ".github" / "workflows" / "engineering-assurance.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "pull_request_target" not in workflow
+    assert "secrets." not in workflow
+    assert "contents: read" in workflow
+    assert "paths:" in workflow


### PR DESCRIPTION
## What changed

- adds a path-scoped, `contents: read` engineering-assurance workflow; trivial edits outside the engineering contract paths do not trigger it;
- validates the versioned preflight/closeout examples and a small FOSSIL/Cortex/LiteLLM control-plane compatibility contract;
- adds deterministic semantic false-success fixtures: empty 2xx body, malformed/empty JSON, and zero-payload stream are failures;
- performs a clean Python install plus `pip check`, emits a compact GitHub summary using the shared correlation names, and uses no secrets or privileged PR trigger.

## Boundaries

This is a reusable secretless mechanical gate. It does not claim OWASP/NIST compliance, call a live service, select a provider/executor, or alter production/deployment state.

## Checks

- `python scripts/validate_engineering_assurance.py`
- `python -m pytest -q tests/test_engineering_preflight.py tests/test_engineering_assurance.py` (11 passed)
- `python -m pytest -q` (126 passed)
- `python -m compileall -q src scripts`