### PR TITLE
Harden trusted-local broker container boundary

### DIFF
--- a/docker/trusted-local-broker/Dockerfile
+++ b/docker/trusted-local-broker/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:22-bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates gh git python3 python3-venv util-linux \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 10001 codexworker \
+    && useradd --uid 10001 --gid 10001 --create-home --shell /usr/sbin/nologin codexworker \
+    && install --directory --owner=codexworker --group=codexworker --mode=0700 /worker/home /worker/codex-home \
+    && npm install --global @openai/codex@latest
+
+WORKDIR /opt/fossil-core
+COPY pyproject.toml ./
+COPY src ./src
+COPY scripts ./scripts
+RUN python3 -m venv /opt/fossil-venv \
+    && /opt/fossil-venv/bin/pip install --no-cache-dir '.[test]'
+
+COPY docker/trusted-local-broker/worker-codex /usr/local/bin/worker-codex
+RUN chmod 0755 /usr/local/bin/worker-codex
+
+ENV PATH=/opt/fossil-venv/bin:${PATH}
+ENTRYPOINT ["python3", "scripts/run_trusted_local_broker.py"]

--- a/docker/trusted-local-broker/worker-codex
+++ b/docker/trusted-local-broker/worker-codex
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Parent broker runs as root inside its narrow container. The model process is
+# deliberately demoted to the separate unprivileged worker identity.
+exec setpriv --reuid=codexworker --regid=codexworker --init-groups "$@"

--- a/docker/trusted-local-broker/worker-codex
+++ b/docker/trusted-local-broker/worker-codex
@@ -1,4 +1,5 @@
 #!/bin/sh
 # Parent broker runs as root inside its narrow container. The model process is
 # deliberately demoted to the separate unprivileged worker identity.
+find . -path './.git' -prune -o -exec chown --no-dereference codexworker:codexworker {} \;
 exec setpriv --reuid=codexworker --regid=codexworker --init-groups "$@"

--- a/docs/operations/TRUSTED_LOCAL_RUNNER.md
+++ b/docs/operations/TRUSTED_LOCAL_RUNNER.md
@@ -99,9 +99,9 @@ Build it from the repository root:
 docker build --tag fossil-trusted-local-broker:local --file docker/trusted-local-broker/Dockerfile .
 ```
 
-Keep all mounted runtime state under a dedicated `D:` directory (for example `D:\FossilBrokerWorker`): a Codex-auth directory, a root-only GitHub CLI directory for the parent, allowlisted disposable repository clones, worktree directory, and the local configuration JSON. Mount **only** those directories. Do not mount `C:\Users\<owner>`, the Docker socket, provider credentials, browser data, or an inbound port. Configure `codex_executable` as `/usr/local/bin/worker-codex`, and use container paths in the config.
+Keep broker credentials, clones, and worktrees in named Docker volumes. Docker Desktop stores those volumes in its managed WSL data location; on this PC that location is `D:\DockerDesktopWSL`. Use a separate volume for the unprivileged Codex authentication, a root-only volume for the parent GitHub CLI authentication, and volumes for allowlisted clones and disposable worktrees. A single read-only local config-file mount may provide non-secret paths/policy. Do not mount `C:\Users\<owner>`, a broad `D:` directory, the Docker socket, provider credentials, browser data, or an inbound port. Configure `codex_executable` as `/usr/local/bin/worker-codex`, and use container paths in the config.
 
-The GitHub CLI parent login is performed as container root and stored only in its dedicated GitHub mount. The Codex device login is performed as `codexworker` and stored only in the dedicated Codex mount. Never copy either auth material between the two directories.
+The GitHub CLI parent login is performed as container root and stored only in its dedicated GitHub volume. The Codex device login is performed as `codexworker` and stored only in the dedicated Codex volume. Never copy either auth material between the two volumes. The worker wrapper gives `codexworker` ownership of the new disposable worktree while deliberately leaving its `.git` pointer and the parent clone metadata root-owned.
 
 ## Start and stop
 

--- a/docs/operations/TRUSTED_LOCAL_RUNNER.md
+++ b/docs/operations/TRUSTED_LOCAL_RUNNER.md
@@ -35,7 +35,7 @@ Old task prose that lacks the exact SHA or `local_role` is inert to the broker.
 - `gpt-5.6-terra` for role `terra`;
 - `gpt-5.6-luna` for role `luna`.
 
-The generated prompt forbids credential discovery, `.env` access, deploy/promotion, push/PR creation, and external mutation. The Codex child's exit code is not final acceptance: the parent broker runs the configured independent check command afterwards.
+The generated prompt forbids credential discovery, `.env` access, deploy/promotion, push/PR creation, and external mutation. The Codex child's exit code is not final acceptance: the parent broker runs the configured independent check command afterwards, inside the same dedicated worker boundary.
 
 ## Credential split
 
@@ -51,7 +51,7 @@ The parent publication step uses a reviewed repo allowlist, forces the expected 
 
 ### 2. Secretless Codex worker
 
-Use a dedicated local OS account/profile where practical. At minimum configure separate `worker_home` and `codex_home` paths that contain only the Codex authentication/config needed to run the CLI.
+Use a dedicated local OS account/profile or container boundary. Separate `worker_home` and `codex_home` paths contain only the Codex authentication/config needed to run the CLI. The broker parent and its independent checks must execute in that same boundary: do not run changed-code checks under the owner's normal host identity.
 
 The child environment is reconstructed from a small OS allowlist. It does not inherit the interactive user's `HOME`, `GITHUB_TOKEN`, Railway/provider keys, `OPENAI_API_KEY`, or other credential-like environment variables.
 
@@ -65,8 +65,8 @@ The existing `dispatch_privileged_verifier` path may load the minimum local cred
 
 ## One-time local setup
 
-1. Install/update Codex CLI on the PC.
-2. Create a dedicated broker/worker local account or isolated worker home.
+1. Install/update Codex CLI on the PC, or build the checked-in `docker/trusted-local-broker/Dockerfile` image.
+2. Create a dedicated broker/worker local account or isolated container boundary.
 3. Sign Codex in inside that dedicated worker profile only.
 4. Keep the normal interactive user's `.env`, GitHub credential files, Railway/provider keys, browser profiles, and other secrets outside that worker profile.
 5. Authenticate the **broker parent** to GitHub separately. Do not make the GitHub token part of the worker environment.
@@ -88,6 +88,20 @@ The existing `dispatch_privileged_verifier` path may load the minimum local cred
 ```
 
 Do not commit this config if it contains personal paths or local policy details.
+
+### Container boundary (recommended when the PC owner is the normal login)
+
+The checked-in Dockerfile runs the broker parent, its Git publication, and its independent checks inside one narrow container. It demotes only `codex exec` to an unprivileged `codexworker` user. This keeps both model execution and changed-code tests away from the Windows owner profile.
+
+Build it from the repository root:
+
+```text
+docker build --tag fossil-trusted-local-broker:local --file docker/trusted-local-broker/Dockerfile .
+```
+
+Keep all mounted runtime state under a dedicated `D:` directory (for example `D:\FossilBrokerWorker`): a Codex-auth directory, a root-only GitHub CLI directory for the parent, allowlisted disposable repository clones, worktree directory, and the local configuration JSON. Mount **only** those directories. Do not mount `C:\Users\<owner>`, the Docker socket, provider credentials, browser data, or an inbound port. Configure `codex_executable` as `/usr/local/bin/worker-codex`, and use container paths in the config.
+
+The GitHub CLI parent login is performed as container root and stored only in its dedicated GitHub mount. The Codex device login is performed as `codexworker` and stored only in the dedicated Codex mount. Never copy either auth material between the two directories.
 
 ## Start and stop
 

--- a/scripts/run_trusted_local_broker.py
+++ b/scripts/run_trusted_local_broker.py
@@ -11,10 +11,16 @@ import argparse
 import json
 import os
 import subprocess
+import sys
 import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Mapping
+
+# Keep the documented direct invocation usable from a clean source checkout.
+_SOURCE_ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(_SOURCE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SOURCE_ROOT))
 
 from dkg.trusted_local_broker import (
     GitHubQueueClient,


### PR DESCRIPTION
## Summary

- add a checked-in Docker broker image so the broker parent, model child, and independent checks stay outside the Windows owner profile;
- run only `codex exec` as the unprivileged `codexworker` identity;
- document the D:-backed mount and separate Codex/GitHub authentication split;
- make the documented direct broker script invocation work from a clean checkout.

## Why

The initial broker implementation ran configured independent checks directly under its parent process. If that parent were the Windows owner context, worker-modified code could execute outside the required low-privilege boundary. The container topology keeps checks inside the constrained runtime and keeps the parent's GitHub credential mount unavailable to the worker identity.

## Validation

- `python scripts/run_trusted_local_broker.py --help`
- `python -m compileall -q src scripts`
- `python -m pytest -q` (159 passed)
- `mypy --ignore-missing-imports src/dkg/trusted_local_broker.py src/dkg/trusted_local_queue.py src/dkg/trusted_local_runner.py scripts/run_trusted_local_broker.py`
- `docker build --tag fossil-trusted-local-broker:local --file docker/trusted-local-broker/Dockerfile .`

The remaining physical proof still requires a dedicated container-only Codex device login and a benign exact-SHA Luna queue task; neither uses provider or production credentials.
