### PR TITLE
Package trusted broker runtime contracts

### DIFF
--- a/docker/trusted-local-broker/Dockerfile
+++ b/docker/trusted-local-broker/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
 
 WORKDIR /opt/fossil-core
 COPY pyproject.toml ./
+COPY contracts ./contracts
 COPY src ./src
 COPY scripts ./scripts
 RUN python3 -m venv /opt/fossil-venv \
@@ -19,4 +20,4 @@ COPY docker/trusted-local-broker/worker-codex /usr/local/bin/worker-codex
 RUN chmod 0755 /usr/local/bin/worker-codex
 
 ENV PATH=/opt/fossil-venv/bin:${PATH}
-ENTRYPOINT ["python3", "scripts/run_trusted_local_broker.py"]
+ENTRYPOINT ["/opt/fossil-venv/bin/python", "scripts/run_trusted_local_broker.py"]


### PR DESCRIPTION
## Summary

- package the trusted-local WorkOrder contract schema in the broker Docker image;
- invoke the broker with its installed virtual-environment Python rather than the dependency-free system Python.

## Root cause

The first physical `INFRA-05-PROOF` cycle failed closed during WorkOrder authorization: the image contained the broker code but omitted `contracts/trusted-local-workorder-v1.schema.json`. Validation also revealed that the image entrypoint selected system Python, which lacks the broker dependencies. No Codex process, worktree, test, commit, or PR was created by that failed cycle.

## Validation

- `python -m pytest -q` (159 passed)
- `git diff --check`
- Docker image build
- image starts `run_trusted_local_broker.py --help` through the virtual environment
- image contract-path assertion passes

This is a packaging-only correction required before retrying the benign, exact-SHA Luna broker proof.
