### PR TITLE
Fix unprivileged Codex worker launcher

### DIFF
--- a/docker/trusted-local-broker/worker-codex
+++ b/docker/trusted-local-broker/worker-codex
@@ -2,4 +2,4 @@
 # Parent broker runs as root inside its narrow container. The model process is
 # deliberately demoted to the separate unprivileged worker identity.
 find . -path './.git' -prune -o -exec chown --no-dereference codexworker:codexworker {} \;
-exec setpriv --reuid=codexworker --regid=codexworker --init-groups "$@"
+exec setpriv --reuid=codexworker --regid=codexworker --init-groups codex "$@"


### PR DESCRIPTION
## Summary

Fix the container's unprivileged worker launcher to execute the `codex` binary after dropping privileges.

## Root cause

The initial physical proof reached the wrapper but passed Codex's `exec` subcommand to `setpriv` as though it were an executable. `setpriv` failed closed before starting a model process. The broker then posted its terminal and release records and removed the disposable worktree.

## Validation

- `python -m pytest -q` (159 passed)
- `git diff --check`
- Docker image build
- `/usr/local/bin/worker-codex --version` inside the built image (Codex CLI 0.147.0)

This is the final launcher correction before retrying the benign Luna WorkOrder with a fresh queue generation.
