### PR TITLE
Allow parent Git on isolated worker worktrees

### DIFF
--- a/src/dkg/trusted_local_broker.py
+++ b/src/dkg/trusted_local_broker.py
@@ -389,6 +389,11 @@ def _safe_branch(task_id: str, attempt_id: str) -> str:
     return f"agent/{task_id.lower()}-{tail}"[:120]
 
 
+def _git_in_worktree(worktree: Path, *arguments: str) -> list[str]:
+    """Build a parent Git command for this exact unprivileged worktree only."""
+    return ["git", "-c", f"safe.directory={worktree}", "-C", str(worktree), *arguments]
+
+
 def publish_checked_changes(
     repo_policy: RepoPolicy,
     *,
@@ -398,7 +403,7 @@ def publish_checked_changes(
     github: GitHubQueueClient,
 ) -> str:
     status = subprocess.run(
-        ["git", "-C", str(worktree), "status", "--porcelain"],
+        _git_in_worktree(worktree, "status", "--porcelain"),
         check=False,
         capture_output=True,
         text=True,
@@ -412,19 +417,21 @@ def publish_checked_changes(
     empty_hooks = worktree / ".broker-empty-hooks"
     empty_hooks.mkdir(exist_ok=True)
     commands = [
-        ["git", "-C", str(worktree), "switch", "-c", branch],
-        ["git", "-C", str(worktree), "add", "-A"],
-        [
-            "git", "-C", str(worktree), "-c", f"core.hooksPath={empty_hooks}",
+        _git_in_worktree(worktree, "switch", "-c", branch),
+        _git_in_worktree(worktree, "add", "-A"),
+        _git_in_worktree(
+            worktree,
+            "-c", f"core.hooksPath={empty_hooks}",
             "-c", "user.name=trusted-local-broker",
             "-c", "user.email=trusted-local-broker@users.noreply.github.com",
             "commit", "-m", f"{task.task_id}: autonomous local WorkOrder",
-        ],
-        [
-            "git", "-C", str(worktree), "-c", f"core.hooksPath={empty_hooks}",
+        ),
+        _git_in_worktree(
+            worktree,
+            "-c", f"core.hooksPath={empty_hooks}",
             "-c", f"remote.origin.url=https://github.com/{task.repo}.git",
             "push", "origin", f"HEAD:refs/heads/{branch}",
-        ],
+        ),
     ]
     for command in commands:
         completed = subprocess.run(command, check=False, capture_output=True, text=True)

--- a/tests/test_trusted_local_broker.py
+++ b/tests/test_trusted_local_broker.py
@@ -8,6 +8,7 @@ from dkg.trusted_local_broker import (
     build_codex_prompt,
     choose_unclaimed_task,
     codex_worker_environment,
+    _git_in_worktree,
     make_work_order,
     parse_broker_ledger,
     parse_ready_local_tasks,
@@ -92,6 +93,19 @@ def test_codex_command_is_fresh_ephemeral_workspace_write_and_role_mapped():
     assert MODEL_BY_ROLE["terra"] in terra
     assert MODEL_BY_ROLE["luna"] in luna
     assert terra[-1] == "-"
+
+
+def test_parent_git_command_trusts_only_the_exact_disposable_worktree(tmp_path):
+    worktree = tmp_path / "worktree"
+    assert _git_in_worktree(worktree, "status", "--porcelain") == [
+        "git",
+        "-c",
+        f"safe.directory={worktree}",
+        "-C",
+        str(worktree),
+        "status",
+        "--porcelain",
+    ]
 
 
 def test_codex_worker_environment_drops_infra_secrets_and_interactive_home(tmp_path):


### PR DESCRIPTION
## Summary

Allow the root parent broker to run only its Git publication commands against the exact disposable worktree owned by the unprivileged worker.

## Root cause

The real Luna process and its low-privilege environment completed, but the root parent then failed closed on Git's ownership safety guard while inspecting the worker-owned worktree. The task was not published and the worktree was cleaned up.

The parent now passes one command-scoped `safe.directory=<exact worktree>` setting to its status, switch, add, commit, and push invocations. It does not relax global Git ownership policy or trust any other path.

## Validation

- `python -m pytest -q` (160 passed)
- `python -m compileall -q src scripts`
- `mypy --ignore-missing-imports` for broker modules/script
- `git diff --check`
- Docker image build

The regression test asserts that parent Git trusts only the exact disposable worktree path.
