### PR TITLE
Support outer sandbox broker configuration

### DIFF
--- a/docs/decisions/2026-08-12-D025-container-outer-sandbox-for-broker.md
+++ b/docs/decisions/2026-08-12-D025-container-outer-sandbox-for-broker.md
@@ -1,0 +1,19 @@
+# D025 — Docker outer sandbox for trusted local broker
+
+**State:** accepted / implementation refinement  
+**Date:** 2026-08-12  
+**Refines:** D024; INFRA-05 physical proof.
+
+## Decision
+
+When Docker Desktop prevents nested unprivileged Linux namespaces, run Codex with `danger-full-access` **only inside** the dedicated broker Docker container. The container remains the OS-enforced boundary: the child is `codexworker`; it receives only its Codex-auth volume and the disposable repository/worktree volumes; the root-only GitHub-parent volume, owner profile, provider credentials, Docker socket, and inbound ports are absent.
+
+Non-container broker deployments retain Codex `workspace-write` as their default. This is not permission to run Codex with unrestricted host access.
+
+## Evidence
+
+The physical proof showed `workspace-write` failing before file operations because Docker Desktop denied nested user namespaces, including with the distribution `bubblewrap` package. Under the restricted container mount set, a Luna `danger-full-access` diagnostic successfully created a requested disposable-worktree file while still running as `codexworker`.
+
+## Reconsider when
+
+Docker Desktop enables nested unprivileged namespaces reliably, or a stronger nested sandbox works under the same corpus-specific isolation proof.

--- a/docs/operations/TRUSTED_LOCAL_RUNNER.md
+++ b/docs/operations/TRUSTED_LOCAL_RUNNER.md
@@ -103,6 +103,9 @@ Keep broker credentials, clones, and worktrees in named Docker volumes. Docker D
 
 The GitHub CLI parent login is performed as container root and stored only in its dedicated GitHub volume. The Codex device login is performed as `codexworker` and stored only in the dedicated Codex volume. Never copy either auth material between the two volumes. The worker wrapper gives `codexworker` ownership of the new disposable worktree while deliberately leaving its `.git` pointer and the parent clone metadata root-owned.
 
+Docker Desktop may prohibit Codex's nested Linux `workspace-write` namespace. Only in the checked-in Docker topology, set `codex_sandbox` to `danger-full-access`: Docker's named-volume mount set and `codexworker` identity are then the enforcement boundary. The worker has no owner profile, parent GitHub volume, provider credentials, Docker socket, or inbound port. Keep the default `workspace-write` sandbox for non-container deployments.
+
+
 ## Start and stop
 
 One cycle:

--- a/scripts/run_trusted_local_broker.py
+++ b/scripts/run_trusted_local_broker.py
@@ -53,7 +53,7 @@ def load_token() -> str:
     return completed.stdout.strip()
 
 
-def load_config(path: Path) -> tuple[str, Path, Path, dict[str, RepoPolicy], str]:
+def load_config(path: Path) -> tuple[str, Path, Path, dict[str, RepoPolicy], str, str]:
     raw = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(raw, Mapping):
         raise WorkOrderError("MALFORMED_CONFIG", "broker config must be a JSON object")
@@ -61,6 +61,9 @@ def load_config(path: Path) -> tuple[str, Path, Path, dict[str, RepoPolicy], str
     worker_home = Path(str(raw.get("worker_home", ""))).expanduser().resolve()
     codex_home = Path(str(raw.get("codex_home", ""))).expanduser().resolve()
     codex_executable = str(raw.get("codex_executable", "codex")).strip() or "codex"
+    codex_sandbox = str(raw.get("codex_sandbox", "workspace-write")).strip()
+    if codex_sandbox not in {"workspace-write", "danger-full-access"}:
+        raise WorkOrderError("MALFORMED_CONFIG", "codex_sandbox must be workspace-write or danger-full-access")
     repos_raw = raw.get("repos")
     if not agent or not isinstance(repos_raw, Mapping):
         raise WorkOrderError("MALFORMED_CONFIG", "agent and repos mapping are required")
@@ -80,7 +83,7 @@ def load_config(path: Path) -> tuple[str, Path, Path, dict[str, RepoPolicy], str
             Path(str(value.get("path", ""))).expanduser().resolve(),
             tuple(check),
         )
-    return agent, worker_home, codex_home, repos, codex_executable
+    return agent, worker_home, codex_home, repos, codex_executable, codex_sandbox
 
 
 def closeout(
@@ -119,6 +122,7 @@ def run_once(
     codex_home: Path,
     repos: Mapping[str, RepoPolicy],
     codex_executable: str,
+    codex_sandbox: str,
     worktree_root: Path,
 ) -> bool:
     comments = client.comments()
@@ -157,6 +161,7 @@ def run_once(
             codex_home=codex_home,
             github=client,
             codex_executable=codex_executable,
+            codex_sandbox=codex_sandbox,
         )
     except WorkOrderError as exc:
         receipt = sanitize_receipt(
@@ -192,7 +197,7 @@ def main() -> int:
     if args.poll_seconds < 15:
         raise SystemExit("--poll-seconds must be >= 15")
 
-    agent, worker_home, codex_home, repos, codex_executable = load_config(args.config)
+    agent, worker_home, codex_home, repos, codex_executable, codex_sandbox = load_config(args.config)
     client = GitHubQueueClient(load_token())
     worktree_root = args.worktree_root.expanduser().resolve()
 
@@ -205,6 +210,7 @@ def main() -> int:
                 codex_home=codex_home,
                 repos=repos,
                 codex_executable=codex_executable,
+                codex_sandbox=codex_sandbox,
                 worktree_root=worktree_root,
             )
         except WorkOrderError as exc:

--- a/src/dkg/trusted_local_broker.py
+++ b/src/dkg/trusted_local_broker.py
@@ -40,6 +40,7 @@ DEFAULT_REPOS = frozenset(
     }
 )
 MODEL_BY_ROLE = {"terra": "gpt-5.6-terra", "luna": "gpt-5.6-luna"}
+CODEX_SANDBOXES = frozenset({"workspace-write", "danger-full-access"})
 _TASK_START = re.compile(r"^TASK\s+task=(?P<task>[^\s]+)$", re.MULTILINE)
 _FIELD = re.compile(r"^(?P<key>[A-Za-z_][A-Za-z0-9_-]*)=(?P<value>.*)$", re.MULTILINE)
 _WORKORDER = re.compile(
@@ -213,15 +214,19 @@ def build_codex_prompt(task: QueueTask, work_order: Mapping[str, Any]) -> str:
     )
 
 
-def build_codex_command(role: str, *, executable: str = "codex") -> list[str]:
+def build_codex_command(
+    role: str, *, executable: str = "codex", sandbox: str = "workspace-write"
+) -> list[str]:
     if role not in MODEL_BY_ROLE:
         raise WorkOrderError("BLOCKED_POLICY", f"unsupported local role: {role}")
+    if sandbox not in CODEX_SANDBOXES:
+        raise WorkOrderError("BLOCKED_POLICY", f"unsupported Codex sandbox: {sandbox}")
     return [
         executable,
         "exec",
         "--ephemeral",
         "--sandbox",
-        "workspace-write",
+        sandbox,
         "--json",
         "--ignore-user-config",
         "-m",
@@ -490,6 +495,7 @@ def run_local_codex_task(
     codex_home: Path,
     github: GitHubQueueClient,
     codex_executable: str = "codex",
+    codex_sandbox: str = "workspace-write",
 ) -> tuple[dict[str, Any], str | None]:
     """Run fresh Codex, independent checks, reconcile live state, then publish."""
     policy = DispatchPolicy(
@@ -506,7 +512,9 @@ def run_local_codex_task(
     environment = codex_worker_environment(worker_home=worker_home, codex_home=codex_home)
     try:
         codex_receipt = run_bounded_process(
-            build_codex_command(task.role, executable=codex_executable),
+            build_codex_command(
+                task.role, executable=codex_executable, sandbox=codex_sandbox
+            ),
             worktree=worktree,
             work_order=work_order,
             environment=environment,

--- a/tests/test_trusted_local_broker.py
+++ b/tests/test_trusted_local_broker.py
@@ -93,6 +93,8 @@ def test_codex_command_is_fresh_ephemeral_workspace_write_and_role_mapped():
     assert MODEL_BY_ROLE["terra"] in terra
     assert MODEL_BY_ROLE["luna"] in luna
     assert terra[-1] == "-"
+    outer = build_codex_command("luna", sandbox="danger-full-access")
+    assert outer[outer.index("--sandbox") + 1] == "danger-full-access"
 
 
 def test_parent_git_command_trusts_only_the_exact_disposable_worktree(tmp_path):


### PR DESCRIPTION
## Summary

Add an explicitly configured Docker-only Codex outer-sandbox mode for the trusted-local broker.

## Root cause and decision

Docker Desktop on this PC denies nested unprivileged Linux namespaces. Both Codex's bundled helper and the distribution `bubblewrap` package therefore failed before any worker filesystem operation. The Docker container itself already provides the required OS-enforced boundary: the model runs as `codexworker` and has only its Codex-auth, clone, and disposable-worktree volumes; it cannot read the root-only parent GitHub volume, the owner profile, provider credentials, browser data, or Docker socket.

The new `codex_sandbox` config defaults to `workspace-write`. Only the reviewed Docker topology may set `danger-full-access`, which means full access to that restricted container—not the host. D025 records the refinement.

## Validation

- `python -m pytest -q` (160 passed)
- `python -m compileall -q src scripts`
- `mypy --ignore-missing-imports` for broker modules/script
- `git diff --check`
- Docker image build and broker CLI startup
- physical Luna diagnostic wrote the requested file under the restricted container mount set
