### PR TITLE
Add isolated privileged verifier lane

### DIFF
--- a/docker/privileged-local-verifier/Dockerfile
+++ b/docker/privileged-local-verifier/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates gh git \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 10002 verifier \
+    && useradd --uid 10002 --gid 10002 --create-home --shell /usr/sbin/nologin verifier
+
+WORKDIR /opt/fossil-core
+COPY pyproject.toml ./
+COPY contracts ./contracts
+COPY src ./src
+COPY scripts ./scripts
+RUN python3 -m venv /opt/fossil-venv \
+    && /opt/fossil-venv/bin/pip install --no-cache-dir . \
+    && install --directory --owner=verifier --group=verifier --mode=0700 /verifier/home
+
+ENV PATH=/opt/fossil-venv/bin:${PATH}
+ENTRYPOINT ["/opt/fossil-venv/bin/python", "scripts/run_privileged_local_verifier.py"]

--- a/docs/DECISION_LOG.md
+++ b/docs/DECISION_LOG.md
@@ -192,6 +192,19 @@ Potentially useful old eval/checker assets may survive only through a **standalo
 
 **Reconsider only if:** a specific historical asset is independently validated under the extraction policy. This does not authorize reviving SSC itself.
 
+## D026 â€” Local application credentials use a model-free, action-allowlisted verifier
+
+**State:** accepted / provisional execution topology
+**Decision:** credentials that must remain only on the owner's PC are stored in a root-only Docker named volume separate from the Codex-worker volume and broker GitHub-auth volume. They are never copied into GitHub, repository worktrees, a Codex prompt/environment, or an issue receipt. A separate privileged verifier container may load only a locally configured named allowlist after it has accepted a trusted queue task for an exact reviewed SHA and reviewed verifier-dispatch revision.
+
+The queue may select a local `verifier_action`, but cannot provide an executable command, secret-file path, or credential variable name. Each action fixes its literal non-shell argv, minimum environment-variable allowlist, and non-production access class in a local owner-controlled configuration. Reviewed-code subprocesses run as the dedicated unprivileged verifier identity; output is discarded rather than made receipt material. Production actions are rejected; any promotion needs a separate explicit authorization design.
+
+**Why:** the normal local Codex broker must remain secretless. A broad mounted `.env`, even in a Docker volume, would make model-driven process compromise a credential disclosure risk. A capability map separates “run code” from “perform this narrowly approved staging verification with exactly these inputs.”
+
+**Evidence/contract:** Issue #94 `INFRA-05`; `docs/operations/TRUSTED_LOCAL_RUNNER.md`; `src/dkg/privileged_local_verifier.py`; `docker/privileged-local-verifier/Dockerfile`; the local volume access proof records that `codexworker` cannot read `fossil-privileged-secrets`.
+
+**Reconsider when:** a protected managed secret runner provides equal/stronger exact-SHA, action allowlisting, independent runtime identity, non-disclosure receipts, and operational recovery with lower owner burden.
+
 ## How to add a decision
 
 When implementation or evidence changes an architectural conclusion:

--- a/docs/HANDOFF_CURRENT.md
+++ b/docs/HANDOFF_CURRENT.md
@@ -115,6 +115,8 @@ Therefore:
 - sanitized receipts only;
 - no implicit production promotion.
 
+The verifier is deliberately a separate model-free Docker service. `fossil-privileged-secrets` is a root-only Docker volume in the local Docker Desktop WSL data store (`D:\DockerDesktopWSL`) containing the owner-provided SSC `.env` copy; `codexworker` access was mechanically denied. Queue records select only a locally owned `verifier_action`; they cannot supply commands, secret names, or values. See D026 and `docs/operations/TRUSTED_LOCAL_RUNNER.md` before configuring a staging action.
+
 ### Agent roles
 
 - **Terra:** complex/root-cause, architecture-sensitive, and explicitly trusted local/infra tasks.

--- a/docs/operations/TRUSTED_LOCAL_RUNNER.md
+++ b/docs/operations/TRUSTED_LOCAL_RUNNER.md
@@ -61,7 +61,9 @@ Treat Codex's local auth file as a password. Do not copy it into Git, #94, logs,
 
 Railway/provider/telemetry/object-store credentials remain a **separate deterministic verifier lane**. A model/Codex process does not receive those credentials.
 
-The existing `dispatch_privileged_verifier` path may load the minimum local credential environment only after exact-reviewed-SHA authorization. Production promotion remains separately forbidden unless explicitly authorized.
+`scripts/run_privileged_local_verifier.py` is the executable implementation. It has no Codex installation, no model authentication/profile, and never accepts a command or credential variable name from #94. A queue task can select only a locally configured `verifier_action`; that action fixes the literal argv, access class, root-only secret file, and exact environment-variable allowlist. The verifier coordinator loads only that allowlist after exact-reviewed-SHA authorization, demotes the reviewed-code process to its dedicated `verifier` identity, discards its stdout/stderr, and posts only a fixed sanitized receipt.
+
+Production is intentionally unsupported by this service. A `production: true` action is rejected. A future promotion path requires a separately reviewed authorization design.
 
 ## One-time local setup
 
@@ -105,6 +107,54 @@ The GitHub CLI parent login is performed as container root and stored only in it
 
 Docker Desktop may prohibit Codex's nested Linux `workspace-write` namespace. Only in the checked-in Docker topology, set `codex_sandbox` to `danger-full-access`: Docker's named-volume mount set and `codexworker` identity are then the enforcement boundary. The worker has no owner profile, parent GitHub volume, provider credentials, Docker socket, or inbound port. Keep the default `workspace-write` sandbox for non-container deployments.
 
+### Privileged verifier setup (separate container)
+
+The secret file belongs in a **third**, root-only named volume. On this PC the volume data is held by Docker Desktop's WSL store on `D:\DockerDesktopWSL`; it is not in GitHub, the repository, the Codex volume, or the broker container. The original source file remains yours to rotate/delete after verifying the copy. The unprivileged Codex worker must be unable to read this volume.
+
+Build the separate image:
+
+```text
+docker build --tag fossil-privileged-local-verifier:local --file docker/privileged-local-verifier/Dockerfile .
+```
+
+Keep this local-only JSON at `D:\FossilBrokerWorker\config\privileged-verifier.json` (do not commit it). Start with an empty action map; that is safe and means the service cannot inject any application credential until you deliberately add one narrow action.
+
+```json
+{
+  "agent": "trusted-local-verifier-my-pc",
+  "repos": {"Pukujan/fossil-core": "/data/repos/fossil-core"},
+  "trusted_dispatch_refs": ["<exact verifier-image source commit SHA>"],
+  "actions": {}
+}
+```
+
+An approved staging-only action is an owner-administered mapping such as:
+
+```json
+"railway-staging-smoke": {
+  "access_class": "LIVE_STAGING",
+  "secret_file": "/secrets/ssc.env",
+  "required_env": ["ONE_EXACT_KEY_THE_CHECK_NEEDS"],
+  "command": ["/opt/fossil-venv/bin/python", "scripts/staging_smoke.py", "--worktree", "{worktree}"]
+}
+```
+
+Use literal argv, never a shell. The queue cannot override any field in that mapping. The task must include the exact reviewed SHA, an allowlisted verifier image source SHA, a matching privileged access class, and the action name:
+
+```text
+TASK task=INFRA-EXAMPLE
+state=READY
+repo=Pukujan/fossil-core
+access=LIVE_STAGING
+starting_ref=<exact-40-char-reviewed-sha>
+reviewed_sha=<same-exact-sha>
+trusted_dispatch_ref=<allowlisted-verifier-image-source-sha>
+local_role=luna
+verifier_action=railway-staging-smoke
+```
+
+`local_role=luna` is retained only because the frozen WorkOrder v1 schema requires a role; it never invokes Luna/Codex in this lane and conveys no authority.
+
 
 ## Start and stop
 
@@ -121,6 +171,12 @@ python scripts/run_trusted_local_broker.py --config <local-config.json> --poll-s
 ```
 
 The broker opens no inbound port and requires no webhook or self-hosted Actions runner registration.
+
+The privileged verifier is a separate process/container and uses the same polling cadence:
+
+```text
+python scripts/run_privileged_local_verifier.py --config <local-verifier-config.json> --poll-seconds 60
+```
 
 Stop the process/service to stop local automation immediately.
 

--- a/scripts/run_privileged_local_verifier.py
+++ b/scripts/run_privileged_local_verifier.py
@@ -1,0 +1,106 @@
+"""Outbound, model-free privileged verifier service for exact reviewed SHAs."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+_SOURCE_ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(_SOURCE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SOURCE_ROOT))
+
+from dkg.privileged_local_verifier import (active_ready_privileged_tasks, make_privileged_work_order, parse_actions, run_verified_action)
+from dkg.trusted_local_broker import GitHubQueueClient, claim_text, terminal_text
+from dkg.trusted_local_runner import DispatchPolicy, WorkOrderError, sanitize_receipt
+
+
+def load_token() -> str:
+    token = os.environ.get("FOSSIL_BROKER_GITHUB_TOKEN", "").strip()
+    if token:
+        return token
+    completed = subprocess.run(["gh", "auth", "token"], check=False, capture_output=True, text=True)
+    if completed.returncode != 0 or not completed.stdout.strip():
+        raise WorkOrderError("GITHUB_AUTH_REQUIRED", "authenticate GitHub CLI for the verifier coordinator")
+    return completed.stdout.strip()
+
+
+def load_config(path: Path) -> tuple[str, dict[str, Path], frozenset[str], dict[str, Any]]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise WorkOrderError("MALFORMED_CONFIG", "verifier config must be a JSON object")
+    agent = str(raw.get("agent", "")).strip()
+    repos_raw = raw.get("repos")
+    refs = raw.get("trusted_dispatch_refs")
+    if not agent or not isinstance(repos_raw, Mapping) or not isinstance(refs, list):
+        raise WorkOrderError("MALFORMED_CONFIG", "agent, repos, and trusted_dispatch_refs are required")
+    repos = {str(repo): Path(str(value)).expanduser().resolve() for repo, value in repos_raw.items()}
+    trusted = frozenset(str(ref) for ref in refs)
+    if not repos or not trusted:
+        raise WorkOrderError("MALFORMED_CONFIG", "repos and trusted_dispatch_refs cannot be empty")
+    return agent, repos, trusted, parse_actions(raw)
+
+
+def closeout(client: GitHubQueueClient, *, task: Any, order: Mapping[str, Any], receipt: Mapping[str, Any], agent: str) -> None:
+    client.comment(terminal_text(order, receipt))
+    status = str(receipt["terminal_status"])
+    if status == "PASS":
+        client.comment(f"DONE task={task.task_id}\nagent={agent}\nresult=PRIVILEGED_VERIFIER_PASS\nrefs=reviewed_sha:{task.reviewed_sha}\ntests={receipt['detail']}")
+    else:
+        client.comment(f"BLOCKED task={task.task_id}\nagent={agent}\nclass=PRIVILEGED_VERIFIER_{status}\nevidence={receipt['detail']}")
+    client.comment(f"RELEASE task={task.task_id} agent={agent} reason=privileged-verifier-terminal-{status.lower()}")
+
+
+def run_once(*, client: GitHubQueueClient, agent: str, repos: Mapping[str, Path], trusted_refs: frozenset[str], actions: Mapping[str, Any], worktree_root: Path) -> bool:
+    comments = client.comments()
+    from dkg.trusted_local_broker import parse_broker_ledger
+    ledger = parse_broker_ledger(comments, now=datetime.now(UTC))
+    candidates = [task for task in active_ready_privileged_tasks(comments) if task.repo in repos and task.action in actions and actions[task.action].access_class == task.access]
+    task = next((item for item in candidates if item.task_id not in ledger.claims), None)
+    if task is None:
+        return False
+    client.comment(claim_text(task.queue_task(), agent=agent, now=datetime.now(UTC)))
+    ledger = parse_broker_ledger(client.comments(), now=datetime.now(UTC))
+    if ledger.claims.get(task.task_id) is None or ledger.claims[task.task_id].agent != agent:
+        return False
+    order = make_privileged_work_order(task, ledger=ledger, now=datetime.now(UTC))
+    client.comment(f"WORKORDER task={order['task_id']} attempt_id={order['attempt_id']} generation={order['generation']}\nrepo={order['repo']}\nstarting_ref={order['starting_ref']}\nrole=luna access={order['access_class']}\nreviewed_sha={task.reviewed_sha}\ntrusted_dispatch_ref={task.trusted_dispatch_ref}\nverifier_action={task.action}")
+    ledger = parse_broker_ledger(client.comments(), now=datetime.now(UTC))
+    policy = DispatchPolicy(repo_allowlist=frozenset(repos), task_allowlist=frozenset({task.task_id}), local_agent=agent, trusted_dispatch_refs=trusted_refs, now=lambda: datetime.now(UTC))
+    try:
+        receipt = run_verified_action(order, ledger=ledger, policy=policy, repo_root=repos[task.repo], worktree_root=worktree_root, action=actions[task.action])
+    except WorkOrderError as exc:
+        receipt = sanitize_receipt({"version": "trusted-local-receipt-v1", "terminal_status": "BLOCKED", "work_order_id": order["work_order_id"], "attempt_id": order["attempt_id"], "generation": order["generation"], "starting_ref": order["starting_ref"], "detail": f"{exc.code}: privileged verifier blocked"})
+    closeout(client, task=task, order=order, receipt=receipt, agent=agent)
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--poll-seconds", type=int, default=60)
+    parser.add_argument("--worktree-root", type=Path, default=Path(".privileged-verifier-worktrees"))
+    args = parser.parse_args()
+    if args.poll_seconds < 15:
+        raise SystemExit("--poll-seconds must be >= 15")
+    agent, repos, refs, actions = load_config(args.config)
+    client = GitHubQueueClient(load_token())
+    while True:
+        try:
+            did_work = run_once(client=client, agent=agent, repos=repos, trusted_refs=refs, actions=actions, worktree_root=args.worktree_root.resolve())
+        except WorkOrderError as exc:
+            print(json.dumps({"terminal_status": "BLOCKED", "code": exc.code, "detail": "privileged verifier blocked"}))
+            did_work = False
+        if args.once:
+            return 0 if did_work else 2
+        time.sleep(args.poll_seconds)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dkg/privileged_local_verifier.py
+++ b/src/dkg/privileged_local_verifier.py
@@ -1,0 +1,244 @@
+"""Exact-SHA, model-free local verifier helpers.
+
+This is deliberately not an extension of the Codex broker.  The only executable
+input is a locally administered argv allowlist; queue text selects an action name
+but never supplies a command or an environment-variable name.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+from uuid import uuid4
+
+from dkg.trusted_local_broker import QueueTask, choose_unclaimed_task, claim_text, make_work_order, parse_broker_ledger, terminal_text
+from dkg.trusted_local_runner import (
+    PRIVILEGED_ACCESS_CLASSES,
+    DispatchLedger,
+    DispatchPolicy,
+    WorkOrderError,
+    authorize_work_order,
+    destroy_worktree,
+    isolated_worktree,
+    sanitize_receipt,
+)
+
+_TASK = re.compile(r"^TASK\s+task=(?P<task>[^\s]+)$", re.MULTILINE)
+_FIELD = re.compile(r"^(?P<key>[A-Za-z_][A-Za-z0-9_-]*)=(?P<value>.*)$", re.MULTILINE)
+_TERMINAL = re.compile(r"^(?:DONE|BLOCKED)\s+task=(?P<task>[^\s]+)", re.MULTILINE)
+_SHA = re.compile(r"^[0-9a-f]{40}$")
+_ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_TRUSTED_AUTHORS = frozenset({"Pukujan"})
+
+
+@dataclass(frozen=True)
+class VerifierTask:
+    task_id: str
+    repo: str
+    access: str
+    starting_ref: str
+    reviewed_sha: str
+    trusted_dispatch_ref: str
+    action: str
+    spec: str
+    comment_id: int | None = None
+
+    def queue_task(self) -> QueueTask:
+        # WorkOrder v1 has a role field.  This schema compatibility value never
+        # launches a model; the verifier has no Codex executable or model auth.
+        return QueueTask(self.task_id, self.repo, self.access, self.starting_ref, "luna", self.spec, self.comment_id)
+
+
+@dataclass(frozen=True)
+class VerifierAction:
+    name: str
+    access_class: str
+    secret_file: Path
+    required_env: tuple[str, ...]
+    command: tuple[str, ...]
+
+
+def _trusted(comment: Mapping[str, Any], trusted_authors: frozenset[str]) -> bool:
+    user = comment.get("user")
+    return isinstance(user, Mapping) and user.get("login") in trusted_authors
+
+
+def _parse_task(comment: Mapping[str, Any]) -> VerifierTask | None:
+    body = str(comment.get("body", ""))
+    start = _TASK.search(body)
+    if start is None:
+        return None
+    fields = {item["key"]: item["value"].strip() for item in _FIELD.finditer(body)}
+    access = fields.get("access", "")
+    starting_ref = fields.get("starting_ref", "")
+    reviewed_sha = fields.get("reviewed_sha", "")
+    dispatch_ref = fields.get("trusted_dispatch_ref", "")
+    action = fields.get("verifier_action", "")
+    if (
+        fields.get("state") != "READY"
+        or access not in PRIVILEGED_ACCESS_CLASSES
+        or not all(_SHA.fullmatch(value) for value in (starting_ref, reviewed_sha, dispatch_ref))
+        or reviewed_sha != starting_ref
+        or fields.get("local_role") != "luna"
+        or not action
+        or not fields.get("repo")
+    ):
+        return None
+    return VerifierTask(
+        task_id=start["task"], repo=fields["repo"], access=access,
+        starting_ref=starting_ref, reviewed_sha=reviewed_sha,
+        trusted_dispatch_ref=dispatch_ref, action=action, spec=body,
+        comment_id=comment.get("id") if isinstance(comment.get("id"), int) else None,
+    )
+
+
+def active_ready_privileged_tasks(
+    comments: Iterable[Mapping[str, Any]], *, trusted_authors: frozenset[str] = _TRUSTED_AUTHORS
+) -> list[VerifierTask]:
+    """Return current trusted privileged tasks, never resurrecting terminal work."""
+    active: dict[str, VerifierTask] = {}
+    order: list[str] = []
+    for comment in comments:
+        if not _trusted(comment, trusted_authors):
+            continue
+        body = str(comment.get("body", ""))
+        directive = _TASK.search(body)
+        if directive:
+            task_id = directive["task"]
+            task = _parse_task(comment)
+            if task is None:
+                active.pop(task_id, None)
+                if task_id in order:
+                    order.remove(task_id)
+            else:
+                active[task_id] = task
+                if task_id in order:
+                    order.remove(task_id)
+                order.append(task_id)
+            continue
+        terminal = _TERMINAL.search(body)
+        if terminal:
+            active.pop(terminal["task"], None)
+            if terminal["task"] in order:
+                order.remove(terminal["task"])
+    return [active[task_id] for task_id in order if task_id in active]
+
+
+def parse_actions(raw: Mapping[str, Any]) -> dict[str, VerifierAction]:
+    """Validate a local-only action allowlist without reading any secret values."""
+    actions_raw = raw.get("actions")
+    if not isinstance(actions_raw, Mapping):
+        raise WorkOrderError("MALFORMED_CONFIG", "local actions must be a mapping")
+    actions: dict[str, VerifierAction] = {}
+    for name, value in actions_raw.items():
+        if not isinstance(name, str) or not name or not isinstance(value, Mapping):
+            raise WorkOrderError("MALFORMED_CONFIG", "each verifier action must have a name and object")
+        access = str(value.get("access_class", ""))
+        secret_file = Path(str(value.get("secret_file", "")))
+        required = value.get("required_env", [])
+        command = value.get("command")
+        if access not in PRIVILEGED_ACCESS_CLASSES or value.get("production") is True:
+            raise WorkOrderError("MALFORMED_CONFIG", f"action {name} has an unauthorized access class or production flag")
+        if not secret_file.is_absolute() or not isinstance(required, list) or not all(isinstance(key, str) and _ENV_NAME.fullmatch(key) for key in required):
+            raise WorkOrderError("MALFORMED_CONFIG", f"action {name} has invalid secret_file or required_env")
+        if not isinstance(command, list) or not command or not all(isinstance(part, str) and part for part in command):
+            raise WorkOrderError("MALFORMED_CONFIG", f"action {name} command must be a non-empty argv list")
+        if any(part in {"sh", "bash", "cmd", "powershell", "pwsh"} for part in command):
+            raise WorkOrderError("MALFORMED_CONFIG", f"action {name} cannot use a shell")
+        actions[name] = VerifierAction(name, access, secret_file, tuple(required), tuple(command))
+    return actions
+
+
+def read_selected_dotenv(path: Path, required_env: Sequence[str]) -> dict[str, str]:
+    """Read only a named allowlist from an owner-controlled, root-only dotenv file."""
+    if not path.is_file():
+        raise WorkOrderError("SECRET_SOURCE_UNAVAILABLE", "configured local secret file is unavailable")
+    values: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" not in line:
+            raise WorkOrderError("SECRET_SOURCE_MALFORMED", "secret file has an unsupported dotenv line")
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key in required_env:
+            values[key] = value
+    missing = [key for key in required_env if not values.get(key)]
+    if missing:
+        raise WorkOrderError("REQUIRED_SECRET_MISSING", "configured required secret is absent or empty")
+    return values
+
+
+def verifier_environment(selected: Mapping[str, str], *, home: Path = Path("/verifier/home")) -> dict[str, str]:
+    """No inherited GitHub/user profile; only a minimal OS env plus selected keys."""
+    result = {key: os.environ[key] for key in ("PATH", "LANG", "LC_ALL", "TZ") if key in os.environ}
+    result.update({"HOME": str(home), "USERPROFILE": str(home), "GIT_CONFIG_NOSYSTEM": "1"})
+    result.update(selected)
+    return result
+
+
+def _drop_to_verifier_user() -> None:
+    """Demote reviewed-code execution away from the coordinator/root credentials."""
+    geteuid = getattr(os, "geteuid", None)
+    if os.name != "posix" or geteuid is None or geteuid() != 0:
+        return
+    try:
+        import pwd
+
+        account = getattr(pwd, "getpwnam")("verifier")
+    except KeyError as exc:
+        raise WorkOrderError("VERIFIER_IDENTITY_UNAVAILABLE", "dedicated verifier account is required") from exc
+    setgroups = getattr(os, "setgroups")
+    setgid = getattr(os, "setgid")
+    setuid = getattr(os, "setuid")
+    setgroups([])
+    setgid(account.pw_gid)
+    setuid(account.pw_uid)
+
+
+def make_privileged_work_order(task: VerifierTask, *, ledger: DispatchLedger, now: datetime) -> dict[str, Any]:
+    order = make_work_order(task.queue_task(), ledger=ledger, now=now, duration=timedelta(minutes=30))
+    order.update({"reviewed_sha": task.reviewed_sha, "trusted_dispatch_ref": task.trusted_dispatch_ref, "selected_checks": [task.action]})
+    return order
+
+
+def run_verified_action(
+    work_order: Mapping[str, Any], *, ledger: DispatchLedger, policy: DispatchPolicy,
+    repo_root: Path, worktree_root: Path, action: VerifierAction,
+) -> dict[str, Any]:
+    """Run reviewed code with allowlisted credentials and deliberately discard output."""
+    if authorize_work_order(work_order, ledger=ledger, policy=policy) != "privileged":
+        raise WorkOrderError("ACCESS_CLASS_MISMATCH", "verifier requires a privileged WorkOrder")
+    selected = read_selected_dotenv(action.secret_file, action.required_env)
+    worktree = isolated_worktree(repo_root, work_order=work_order, base_dir=worktree_root)
+    try:
+        remaining = (datetime.fromisoformat(str(work_order["deadline"]).replace("Z", "+00:00")) - datetime.now(UTC)).total_seconds()
+        if remaining <= 0:
+            raise WorkOrderError("DEADLINE_EXPIRED", "WorkOrder deadline passed before verifier launch")
+        command = [part.replace("{worktree}", str(worktree)) for part in action.command]
+        completed = subprocess.run(
+            command, cwd=worktree, env=verifier_environment(selected),
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=remaining,
+            check=False, preexec_fn=_drop_to_verifier_user if os.name == "posix" else None,
+        )
+        return sanitize_receipt({
+            "version": "trusted-local-receipt-v1", "terminal_status": "PASS" if completed.returncode == 0 else "FAILED",
+            "work_order_id": work_order["work_order_id"], "attempt_id": work_order["attempt_id"],
+            "generation": work_order["generation"], "starting_ref": work_order["starting_ref"],
+            "detail": f"privileged verifier action {action.name} completed; process output was discarded",
+        })
+    except subprocess.TimeoutExpired:
+        return sanitize_receipt({
+            "version": "trusted-local-receipt-v1", "terminal_status": "FAILED",
+            "work_order_id": work_order["work_order_id"], "attempt_id": work_order["attempt_id"],
+            "generation": work_order["generation"], "starting_ref": work_order["starting_ref"],
+            "detail": "privileged verifier timed out; process output was discarded",
+        })
+    finally:
+        destroy_worktree(repo_root, worktree)

--- a/tests/test_privileged_local_verifier.py
+++ b/tests/test_privileged_local_verifier.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from dkg.privileged_local_verifier import (
+    active_ready_privileged_tasks,
+    parse_actions,
+    read_selected_dotenv,
+    verifier_environment,
+)
+from dkg.trusted_local_runner import WorkOrderError
+
+SHA = "a" * 40
+
+
+def comment(body: str, *, login: str = "Pukujan") -> dict:
+    return {"id": 1, "user": {"login": login}, "body": body}
+
+
+def ready(*, task: str = "INFRA-06", sha: str = SHA) -> dict:
+    return comment(
+        f"TASK task={task}\nstate=READY\nrepo=Pukujan/fossil-core\naccess=LIVE_STAGING\n"
+        f"starting_ref={sha}\nreviewed_sha={sha}\ntrusted_dispatch_ref={SHA}\n"
+        "local_role=luna\nverifier_action=staging-smoke\npurpose=reviewed staging check"
+    )
+
+
+def test_privileged_task_requires_exact_reviewed_sha_action_and_trusted_author():
+    tasks = active_ready_privileged_tasks([ready()])
+    assert len(tasks) == 1
+    assert tasks[0].action == "staging-smoke"
+    assert active_ready_privileged_tasks([comment(ready()["body"], login="attacker")]) == []
+    invalid = ready()
+    invalid["body"] = invalid["body"].replace(f"reviewed_sha={SHA}", "reviewed_sha=" + "b" * 40)
+    assert active_ready_privileged_tasks([invalid]) == []
+
+
+def test_terminal_record_prevents_reexecution_until_new_ready_directive():
+    assert active_ready_privileged_tasks([ready(), comment("DONE task=INFRA-06\nresult=PASS")]) == []
+
+
+def test_action_config_is_local_allowlist_and_rejects_production_or_shell(tmp_path):
+    raw = {"actions": {"staging-smoke": {"access_class": "LIVE_STAGING", "secret_file": str(tmp_path / "ssc.env"), "required_env": ["STAGING_TOKEN"], "command": ["python", "-m", "pytest"]}}}
+    parsed = parse_actions(raw)
+    assert parsed["staging-smoke"].required_env == ("STAGING_TOKEN",)
+    raw["actions"]["staging-smoke"]["production"] = True
+    with pytest.raises(WorkOrderError, match="unauthorized"):
+        parse_actions(raw)
+    raw["actions"]["staging-smoke"].pop("production")
+    raw["actions"]["staging-smoke"]["command"] = ["sh", "-c", "echo unsafe"]
+    with pytest.raises(WorkOrderError, match="cannot use a shell"):
+        parse_actions(raw)
+
+
+def test_dotenv_loader_only_returns_approved_names_and_child_env_has_no_parent_secrets(tmp_path):
+    env_file = tmp_path / "ssc.env"
+    env_file.write_text("ALLOWED=ok\nUNRELATED=must-not-pass\n", encoding="utf-8")
+    selected = read_selected_dotenv(env_file, ["ALLOWED"])
+    assert selected == {"ALLOWED": "ok"}
+    env = verifier_environment(selected)
+    assert env["ALLOWED"] == "ok"
+    assert "UNRELATED" not in env
+    assert "GITHUB_TOKEN" not in env
+    with pytest.raises(WorkOrderError, match="absent"):
+        read_selected_dotenv(env_file, ["MISSING"])


### PR DESCRIPTION
## What changed\n- adds a model-free, exact-reviewed-SHA privileged verifier service\n- keeps local credentials in a root-only Docker volume and injects only a local action allowlist\n- adds a separate verifier image with no Codex CLI/profile\n- documents the local configuration and decision D026\n\n## Why\nThe ordinary local Codex broker must remain secretless while reviewed staging checks can use minimum necessary local credentials.\n\n## Validation\n- python -m compileall -q src scripts\n- python -m pytest -q (164 passed)\n- mypy --ignore-missing-imports on broker/verifier modules\n- Docker verifier image build and no-Codex isolation check