### PR TITLE
Add real S3-compatible service fixture proof

### DIFF
--- a/.github/workflows/s3-service-fixture.yml
+++ b/.github/workflows/s3-service-fixture.yml
@@ -28,8 +28,6 @@ jobs:
     env:
       FOSSIL_TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       FOSSIL_S3_TEST_ENDPOINT: http://127.0.0.1:9000
-      AWS_ACCESS_KEY_ID: fossilfixture
-      AWS_SECRET_ACCESS_KEY: fossil-fixture-password-123
       AWS_DEFAULT_REGION: us-east-1
       AWS_EC2_METADATA_DISABLED: "true"
 
@@ -44,6 +42,19 @@ jobs:
           set -euo pipefail
           actual="$(git rev-parse HEAD)"
           test "$actual" = "$FOSSIL_TARGET_SHA"
+
+      - name: Configure disposable fixture credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          access_key="fossil$(openssl rand -hex 6)"
+          secret_key="$(openssl rand -hex 16)"
+          echo "::add-mask::$access_key"
+          echo "::add-mask::$secret_key"
+          {
+            echo "AWS_ACCESS_KEY_ID=$access_key"
+            echo "AWS_SECRET_ACCESS_KEY=$secret_key"
+          } >> "$GITHUB_ENV"
 
       - uses: actions/setup-python@v5
         with:
@@ -60,7 +71,8 @@ jobs:
             -p 9001:9001 \
             -e "MINIO_ROOT_USER=$AWS_ACCESS_KEY_ID" \
             -e "MINIO_ROOT_PASSWORD=$AWS_SECRET_ACCESS_KEY" \
-            quay.io/minio/minio server /data --console-address ":9001"
+            quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e \
+            server /data --console-address ":9001"
 
           for attempt in $(seq 1 60); do
             if curl --fail --silent http://127.0.0.1:9000/minio/health/ready >/dev/null; then

--- a/.github/workflows/s3-service-fixture.yml
+++ b/.github/workflows/s3-service-fixture.yml
@@ -1,0 +1,86 @@
+name: S3-compatible service fixture
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/s3-service-fixture.yml"
+      - "src/fossil_core/s3_storage.py"
+      - "src/fossil_core/storage_ports.py"
+      - "tests/test_s3_service_fixture.py"
+      - "pyproject.toml"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/s3-service-fixture.yml"
+      - "src/fossil_core/s3_storage.py"
+      - "src/fossil_core/storage_ports.py"
+      - "tests/test_s3_service_fixture.py"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  minio-fixture:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      FOSSIL_TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      FOSSIL_S3_TEST_ENDPOINT: http://127.0.0.1:9000
+      AWS_ACCESS_KEY_ID: fossilfixture
+      AWS_SECRET_ACCESS_KEY: fossil-fixture-password-123
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_EC2_METADATA_DISABLED: "true"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Verify exact target checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(git rev-parse HEAD)"
+          test "$actual" = "$FOSSIL_TARGET_SHA"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Start disposable MinIO service
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run -d \
+            --name fossil-minio \
+            -p 9000:9000 \
+            -p 9001:9001 \
+            -e "MINIO_ROOT_USER=$AWS_ACCESS_KEY_ID" \
+            -e "MINIO_ROOT_PASSWORD=$AWS_SECRET_ACCESS_KEY" \
+            quay.io/minio/minio server /data --console-address ":9001"
+
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent http://127.0.0.1:9000/minio/health/ready >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          docker logs fossil-minio
+          exit 1
+
+      - name: Install FOSSIL with S3 runtime
+        run: python -m pip install -e '.[test,s3]'
+
+      - name: Run real S3-compatible service proof
+        run: python -m pytest -q tests/test_s3_service_fixture.py
+
+      - name: Show MinIO log on failure
+        if: failure()
+        run: docker logs fossil-minio || true
+
+      - name: Stop disposable MinIO service
+        if: always()
+        run: docker rm -f fossil-minio || true

--- a/tests/test_s3_service_fixture.py
+++ b/tests/test_s3_service_fixture.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from fossil_core.artifact_store import ArtifactIntegrityError, ArtifactRedactedError
+from fossil_core.event_store import DurableEventStore, IdempotencyConflict
+from fossil_core.projection.migration import SemanticSnapshot
+from fossil_core.s3_storage import RemoteStoreUnavailable, S3ArtifactStore, S3DurableEventStore
+
+
+ROOT = Path(__file__).parents[1]
+SCHEMA = ROOT / "schemas/events/v1.schema.json"
+WORKFLOW = ROOT / ".github/workflows/s3-service-fixture.yml"
+PACK = "pack_269099f7b2ba43b7a99b9427d64092de"
+
+
+def _event(number: int) -> dict:
+    return {
+        "schema_version": "dkg.event.v1",
+        "event_type": "claim.proposed",
+        "occurred_at": f"2026-08-15T11:0{number}:00Z",
+        "recorded_at": f"2026-08-15T11:1{number}:00Z",
+        "pack_id": PACK,
+        "actor": {"actor_type": "system", "actor_id": "s3-service-fixture"},
+        "subject_refs": [f"clm_s3_service_{number}"],
+        "idempotency_key": f"s3-service-fixture-{number}",
+        "payload": {"claim_text": f"real S3-compatible fixture {number}"},
+    }
+
+
+def test_real_s3_service_fixture_workflow_is_fail_closed_and_exact_head() -> None:
+    assert WORKFLOW.exists(), "real S3-compatible service fixture workflow is required"
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    required = [
+        "quay.io/minio/minio",
+        "server /data --console-address \"\\:9001\"",
+        "/minio/health/ready",
+        "python -m pip install -e '.[test,s3]'",
+        "python -m pytest -q tests/test_s3_service_fixture.py",
+        "FOSSIL_S3_TEST_ENDPOINT: http://127.0.0.1:9000",
+        "ref: ${{ github.event.pull_request.head.sha || github.sha }}",
+        "git rev-parse HEAD",
+    ]
+    for needle in required:
+        assert needle in workflow, f"missing hosted service-fixture contract: {needle}"
+
+
+def test_real_s3_service_preserves_canonical_semantics(tmp_path: Path) -> None:
+    endpoint = os.environ.get("FOSSIL_S3_TEST_ENDPOINT")
+    if not endpoint:
+        pytest.skip("requires explicit local S3-compatible service endpoint")
+
+    import boto3
+    from botocore.config import Config
+    from botocore.exceptions import ClientError
+
+    region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    access_key = os.environ["AWS_ACCESS_KEY_ID"]
+    secret_key = os.environ["AWS_SECRET_ACCESS_KEY"]
+    config = Config(
+        s3={"addressing_style": "path"},
+        connect_timeout=2,
+        read_timeout=2,
+        retries={"max_attempts": 0},
+    )
+    raw = boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        region_name=region,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        config=config,
+    )
+
+    bucket = f"fossil-fixture-{uuid4().hex[:12]}"
+    prefix = f"proof/{uuid4().hex}"
+    raw.create_bucket(Bucket=bucket)
+    raw.head_bucket(Bucket=bucket)
+
+    # Use the adapter's real default boto3 path for the positive compatibility proof.
+    artifacts = S3ArtifactStore(
+        bucket=bucket,
+        prefix=prefix,
+        endpoint_url=endpoint,
+        region_name=region,
+    )
+    events = S3DurableEventStore(
+        bucket=bucket,
+        schema_path=SCHEMA,
+        prefix=prefix,
+        endpoint_url=endpoint,
+        region_name=region,
+    )
+
+    manifest = artifacts.put_bytes(b"canonical service bytes", media_type="text/plain")
+    assert artifacts.put_bytes(b"canonical service bytes", media_type="text/plain") == manifest
+    assert artifacts.read_bytes(manifest["artifact_id"]) == b"canonical service bytes"
+    assert artifacts.verify(manifest["artifact_id"]) is True
+
+    # Deliberate remote corruption must be detected rather than normalized away.
+    digest = manifest["content_hash"]["digest"]
+    raw.put_object(
+        Bucket=bucket,
+        Key=artifacts.backend.key(artifacts._blob_key(digest)),
+        Body=b"corrupted remote bytes",
+    )
+    with pytest.raises(ArtifactIntegrityError, match="verification failed"):
+        artifacts.verify(manifest["artifact_id"])
+
+    # A separate artifact proves the tombstone exists in the real service before deletion.
+    redact_manifest = artifacts.put_bytes(b"redact me", media_type="text/plain")
+    observed = {"tombstone_before_delete": False}
+    original_delete = artifacts.backend.delete
+
+    def checked_delete(relative: str) -> None:
+        raw.head_object(
+            Bucket=bucket,
+            Key=artifacts.backend.key(
+                artifacts._redaction_key(redact_manifest["artifact_id"])
+            ),
+        )
+        observed["tombstone_before_delete"] = True
+        original_delete(relative)
+
+    artifacts.backend.delete = checked_delete  # type: ignore[method-assign]
+    artifacts.redact(
+        redact_manifest["artifact_id"],
+        reason="privacy fixture",
+        authority="test",
+        redacted_at="2026-08-15T11:30:00Z",
+        request_ref="service-fixture-redaction",
+    )
+    assert observed["tombstone_before_delete"] is True
+    assert artifacts.is_redacted(redact_manifest["artifact_id"])
+    with pytest.raises(ArtifactRedactedError):
+        artifacts.put_bytes(b"redact me", media_type="text/plain")
+
+    first = events.commit(_event(1))
+    second = events.commit(_event(2))
+    assert events.commit(_event(1)) == first
+
+    conflicting = deepcopy(_event(1))
+    conflicting["payload"]["claim_text"] = "different bytes under stable identity"
+    with pytest.raises(IdempotencyConflict, match="different content"):
+        events.commit(conflicting)
+
+    expected = SemanticSnapshot.from_events([first, second])
+
+    # Fresh adapter/client instance: no warm Python object or connection state.
+    restarted = S3DurableEventStore(
+        bucket=bucket,
+        schema_path=SCHEMA,
+        prefix=prefix,
+        endpoint_url=endpoint,
+        region_name=region,
+    )
+    restarted_events = list(restarted.iter_events())
+    assert {item["event_id"] for item in restarted_events} == {
+        first["event_id"],
+        second["event_id"],
+    }
+
+    # Fresh local state rebuilds only from canonical remote enumeration.
+    restored = DurableEventStore(tmp_path / "restored-events", SCHEMA)
+    assert list(restored.iter_events()) == []
+    for remote_event in restarted_events:
+        restored.commit(remote_event)
+    assert SemanticSnapshot.from_events(list(restored.iter_events())) == expected
+
+    # A real HTTP client aimed at a dead local endpoint must fail closed quickly.
+    dead_client = boto3.client(
+        "s3",
+        endpoint_url="http://127.0.0.1:1",
+        region_name=region,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        config=config,
+    )
+    unavailable = S3DurableEventStore(
+        bucket=bucket,
+        schema_path=SCHEMA,
+        prefix=f"{prefix}/outage",
+        client=dead_client,
+    )
+    with pytest.raises(RemoteStoreUnavailable, match="durable object"):
+        unavailable.commit(_event(3))
+
+    # Sanity check that the fixture was the real S3 API surface, not an injected fake.
+    try:
+        raw.head_object(Bucket=bucket, Key="definitely-missing")
+    except ClientError as exc:
+        assert str(exc.response.get("Error", {}).get("Code")) in {"404", "NoSuchKey", "NotFound"}
+    else:  # pragma: no cover - a compliant service must report missing objects
+        raise AssertionError("missing object unexpectedly resolved")

--- a/tests/test_s3_service_fixture.py
+++ b/tests/test_s3_service_fixture.py
@@ -38,7 +38,7 @@ def test_real_s3_service_fixture_workflow_is_fail_closed_and_exact_head() -> Non
     workflow = WORKFLOW.read_text(encoding="utf-8")
     required = [
         "quay.io/minio/minio",
-        "server /data --console-address \"\\:9001\"",
+        'server /data --console-address ":9001"',
         "/minio/health/ready",
         "python -m pip install -e '.[test,s3]'",
         "python -m pytest -q tests/test_s3_service_fixture.py",
@@ -82,7 +82,6 @@ def test_real_s3_service_preserves_canonical_semantics(tmp_path: Path) -> None:
     raw.create_bucket(Bucket=bucket)
     raw.head_bucket(Bucket=bucket)
 
-    # Use the adapter's real default boto3 path for the positive compatibility proof.
     artifacts = S3ArtifactStore(
         bucket=bucket,
         prefix=prefix,
@@ -102,7 +101,6 @@ def test_real_s3_service_preserves_canonical_semantics(tmp_path: Path) -> None:
     assert artifacts.read_bytes(manifest["artifact_id"]) == b"canonical service bytes"
     assert artifacts.verify(manifest["artifact_id"]) is True
 
-    # Deliberate remote corruption must be detected rather than normalized away.
     digest = manifest["content_hash"]["digest"]
     raw.put_object(
         Bucket=bucket,
@@ -112,7 +110,6 @@ def test_real_s3_service_preserves_canonical_semantics(tmp_path: Path) -> None:
     with pytest.raises(ArtifactIntegrityError, match="verification failed"):
         artifacts.verify(manifest["artifact_id"])
 
-    # A separate artifact proves the tombstone exists in the real service before deletion.
     redact_manifest = artifacts.put_bytes(b"redact me", media_type="text/plain")
     observed = {"tombstone_before_delete": False}
     original_delete = artifacts.backend.delete
@@ -151,7 +148,6 @@ def test_real_s3_service_preserves_canonical_semantics(tmp_path: Path) -> None:
 
     expected = SemanticSnapshot.from_events([first, second])
 
-    # Fresh adapter/client instance: no warm Python object or connection state.
     restarted = S3DurableEventStore(
         bucket=bucket,
         schema_path=SCHEMA,
@@ -165,14 +161,12 @@ def test_real_s3_service_preserves_canonical_semantics(tmp_path: Path) -> None:
         second["event_id"],
     }
 
-    # Fresh local state rebuilds only from canonical remote enumeration.
     restored = DurableEventStore(tmp_path / "restored-events", SCHEMA)
     assert list(restored.iter_events()) == []
     for remote_event in restarted_events:
         restored.commit(remote_event)
     assert SemanticSnapshot.from_events(list(restored.iter_events())) == expected
 
-    # A real HTTP client aimed at a dead local endpoint must fail closed quickly.
     dead_client = boto3.client(
         "s3",
         endpoint_url="http://127.0.0.1:1",
@@ -190,10 +184,9 @@ def test_real_s3_service_preserves_canonical_semantics(tmp_path: Path) -> None:
     with pytest.raises(RemoteStoreUnavailable, match="durable object"):
         unavailable.commit(_event(3))
 
-    # Sanity check that the fixture was the real S3 API surface, not an injected fake.
     try:
         raw.head_object(Bucket=bucket, Key="definitely-missing")
     except ClientError as exc:
         assert str(exc.response.get("Error", {}).get("Code")) in {"404", "NoSuchKey", "NotFound"}
-    else:  # pragma: no cover - a compliant service must report missing objects
+    else:  # pragma: no cover
         raise AssertionError("missing object unexpectedly resolved")


### PR DESCRIPTION
Implements #122 under #87.

Phase S1 begins with a failed-first acceptance test requiring a dedicated exact-head MinIO service-fixture workflow. The integration proof is secretless and skipped outside that explicit fixture environment. No cloud credentials or provider selection.

Do not merge until the real local S3-compatible service workflow passes on the exact head and existing DKG/assurance/dependency/Graphiti gates remain green.