### PR TITLE
Add OBJECT_STORE_LIVE manual proof harness

### DIFF
--- a/.github/workflows/object-store-live.yml
+++ b/.github/workflows/object-store-live.yml
@@ -1,0 +1,160 @@
+name: OBJECT_STORE_LIVE
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Exact 40-character commit SHA to prove"
+        required: true
+        type: string
+      confirmation:
+        description: "Type OBJECT_STORE_LIVE to authorize the live proof"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fossil-object-store-live
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate explicit live dispatch
+        shell: bash
+        env:
+          FOSSIL_TARGET_SHA: ${{ inputs.ref }}
+          FOSSIL_LIVE_CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+          if [[ "$FOSSIL_LIVE_CONFIRMATION" != "OBJECT_STORE_LIVE" ]]; then
+            echo "::error::Live object-store proof requires explicit OBJECT_STORE_LIVE confirmation"
+            exit 2
+          fi
+          if [[ ! "$FOSSIL_TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Live object-store proof requires an exact 40-character lowercase commit SHA"
+            exit 2
+          fi
+
+  writer:
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: object-store-live
+    env:
+      FOSSIL_TARGET_SHA: ${{ inputs.ref }}
+      FOSSIL_SOFTWARE_COMMIT: ${{ inputs.ref }}
+      FOSSIL_PROOF_PREFIX: fossil-live-proof/${{ github.run_id }}/${{ github.run_attempt }}
+      FOSSIL_PROOF_RECEIPT_PATH: ${{ runner.temp }}/writer-receipt.json
+      OBJECT_STORE_ENDPOINT: ${{ vars.R2_ENDPOINT }}
+      OBJECT_STORE_BUCKET: ${{ vars.R2_BUCKET }}
+      OBJECT_STORE_REGION: auto
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: auto
+      AWS_EC2_METADATA_DISABLED: "true"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Verify exact target checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(git rev-parse HEAD)"
+          test "$actual" = "$FOSSIL_TARGET_SHA"
+
+      - name: Validate encrypted live configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in OBJECT_STORE_ENDPOINT OBJECT_STORE_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error::BLOCKED_CREDENTIAL: required configuration $name is empty"
+              missing=1
+            fi
+          done
+          test "$missing" -eq 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install FOSSIL S3 runtime
+        run: python -m pip install -e '.[s3]'
+
+      - name: Run live durability writer
+        run: python scripts/live_object_store_proof.py write
+
+      - name: Upload sanitized writer receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: object-store-live-writer-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/writer-receipt.json
+          if-no-files-found: error
+
+  rebuild:
+    needs: writer
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: object-store-live
+    env:
+      FOSSIL_TARGET_SHA: ${{ inputs.ref }}
+      FOSSIL_SOFTWARE_COMMIT: ${{ inputs.ref }}
+      FOSSIL_PROOF_PREFIX: fossil-live-proof/${{ github.run_id }}/${{ github.run_attempt }}
+      FOSSIL_PROOF_RECEIPT_PATH: ${{ runner.temp }}/rebuild-receipt.json
+      OBJECT_STORE_ENDPOINT: ${{ vars.R2_ENDPOINT }}
+      OBJECT_STORE_BUCKET: ${{ vars.R2_BUCKET }}
+      OBJECT_STORE_REGION: auto
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: auto
+      AWS_EC2_METADATA_DISABLED: "true"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Verify exact target checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(git rev-parse HEAD)"
+          test "$actual" = "$FOSSIL_TARGET_SHA"
+
+      - name: Validate encrypted live configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in OBJECT_STORE_ENDPOINT OBJECT_STORE_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error::BLOCKED_CREDENTIAL: required configuration $name is empty"
+              missing=1
+            fi
+          done
+          test "$missing" -eq 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install FOSSIL S3 runtime
+        run: python -m pip install -e '.[s3]'
+
+      - name: Run fresh empty-runner rebuild twice
+        run: python scripts/live_object_store_proof.py rebuild
+
+      - name: Upload sanitized rebuild receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: object-store-live-rebuild-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/rebuild-receipt.json
+          if-no-files-found: error

--- a/.github/workflows/object-store-live.yml
+++ b/.github/workflows/object-store-live.yml
@@ -44,6 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: object-store-live
+    outputs:
+      proof_prefix: ${{ steps.proof_outputs.outputs.proof_prefix }}
+      fixture_identity: ${{ steps.proof_outputs.outputs.fixture_identity }}
     env:
       FOSSIL_TARGET_SHA: ${{ inputs.ref }}
       FOSSIL_SOFTWARE_COMMIT: ${{ inputs.ref }}
@@ -92,6 +95,19 @@ jobs:
       - name: Run live durability writer
         run: python scripts/live_object_store_proof.py write
 
+      - name: Publish non-secret handoff outputs
+        id: proof_outputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          fixture_identity="$(python -c 'import json, os; print(json.load(open(os.environ["FOSSIL_PROOF_RECEIPT_PATH"], encoding="utf-8"))["artifact_id"])')"
+          if [[ ! "$fixture_identity" =~ ^art_[0-9a-f]{32}$ ]]; then
+            echo "::error::writer receipt did not contain a deterministic artifact identity"
+            exit 2
+          fi
+          printf 'proof_prefix=%s\n' "$FOSSIL_PROOF_PREFIX" >> "$GITHUB_OUTPUT"
+          printf 'fixture_identity=%s\n' "$fixture_identity" >> "$GITHUB_OUTPUT"
+
       - name: Upload sanitized writer receipt
         uses: actions/upload-artifact@v4
         with:
@@ -107,7 +123,8 @@ jobs:
     env:
       FOSSIL_TARGET_SHA: ${{ inputs.ref }}
       FOSSIL_SOFTWARE_COMMIT: ${{ inputs.ref }}
-      FOSSIL_PROOF_PREFIX: fossil-live-proof/${{ github.run_id }}/${{ github.run_attempt }}
+      FOSSIL_PROOF_PREFIX: ${{ needs.writer.outputs.proof_prefix }}
+      FOSSIL_FIXTURE_IDENTITY: ${{ needs.writer.outputs.fixture_identity }}
       FOSSIL_PROOF_RECEIPT_PATH: ${{ runner.temp }}/rebuild-receipt.json
       OBJECT_STORE_ENDPOINT: ${{ vars.R2_ENDPOINT }}
       OBJECT_STORE_BUCKET: ${{ vars.R2_BUCKET }}
@@ -150,7 +167,7 @@ jobs:
         run: python -m pip install -e '.[s3]'
 
       - name: Run fresh empty-runner rebuild twice
-        run: python scripts/live_object_store_proof.py rebuild
+        run: python scripts/live_object_store_rebuild_proof.py
 
       - name: Upload sanitized rebuild receipt
         uses: actions/upload-artifact@v4

--- a/scripts/live_object_store_proof.py
+++ b/scripts/live_object_store_proof.py
@@ -1,0 +1,430 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+import time
+from collections import Counter
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from fossil_core.artifact_store import ArtifactRedactedError
+from fossil_core.event_store import (
+    DurableEventStore,
+    EventRedactedError,
+    IdempotencyConflict,
+)
+from fossil_core.projection.migration import SemanticSnapshot
+from fossil_core.s3_storage import (
+    RemoteObjectConflict,
+    RemoteStoreUnavailable,
+    S3ArtifactStore,
+    S3DurableEventStore,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas/events/v1.schema.json"
+PACK_ID = "pack_269099f7b2ba43b7a99b9427d64092de"
+WRITER_RECEIPT = "proof-receipts/writer-receipt.json"
+REBUILD_RECEIPT = "proof-receipts/rebuild-receipt.json"
+
+
+class _CountingBody:
+    def __init__(self, body: Any, owner: "CountingClient") -> None:
+        self._body = body
+        self._owner = owner
+
+    def read(self, *args: Any, **kwargs: Any) -> bytes:
+        data = self._body.read(*args, **kwargs)
+        self._owner.bytes_read += len(data)
+        return data
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._body, name)
+
+
+class CountingClient:
+    """Small metrics proxy around a real boto3 S3 client.
+
+    It records only operation names and byte counts. Request parameters,
+    authorization headers, endpoints, and credentials are never serialized.
+    """
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+        self.requests: Counter[str] = Counter()
+        self.bytes_written = 0
+        self.bytes_read = 0
+
+    def __getattr__(self, name: str) -> Any:
+        target = getattr(self._client, name)
+        if not callable(target):
+            return target
+
+        def call(*args: Any, **kwargs: Any) -> Any:
+            self.requests[name] += 1
+            if name == "put_object":
+                body = kwargs.get("Body", b"")
+                if isinstance(body, str):
+                    self.bytes_written += len(body.encode("utf-8"))
+                elif isinstance(body, (bytes, bytearray, memoryview)):
+                    self.bytes_written += len(body)
+            result = target(*args, **kwargs)
+            if name == "get_object" and isinstance(result, dict):
+                body = result.get("Body")
+                if hasattr(body, "read"):
+                    result = dict(result)
+                    result["Body"] = _CountingBody(body, self)
+            return result
+
+        return call
+
+    def metrics(self) -> dict[str, Any]:
+        return {
+            "request_count": sum(self.requests.values()),
+            "requests_by_operation": dict(sorted(self.requests.items())),
+            "bytes_written": self.bytes_written,
+            "bytes_read": self.bytes_read,
+        }
+
+
+def _required(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"BLOCKED_CREDENTIAL: required configuration {name} is empty")
+    return value
+
+
+def _prefix() -> str:
+    value = _required("FOSSIL_PROOF_PREFIX").strip("/")
+    if not value.startswith("fossil-live-proof/") or ".." in value:
+        raise RuntimeError("proof prefix must stay under fossil-live-proof/")
+    return value
+
+
+def _event(number: int) -> dict[str, Any]:
+    return {
+        "schema_version": "dkg.event.v1",
+        "event_type": "claim.proposed",
+        "occurred_at": f"2026-08-15T17:0{number}:00Z",
+        "recorded_at": f"2026-08-15T17:1{number}:00Z",
+        "pack_id": PACK_ID,
+        "actor": {"actor_type": "system", "actor_id": "object-store-live"},
+        "subject_refs": [f"clm_object_store_live_{number}"],
+        "idempotency_key": f"object-store-live-{number}",
+        "payload": {"claim_text": f"OBJECT_STORE_LIVE canonical fixture {number}"},
+    }
+
+
+def _new_raw_client(*, endpoint: str, region: str, dead: bool = False) -> Any:
+    import boto3
+    from botocore.config import Config
+
+    return boto3.client(
+        "s3",
+        endpoint_url="http://127.0.0.1:1" if dead else endpoint,
+        region_name=region,
+        config=Config(
+            connect_timeout=1 if dead else 10,
+            read_timeout=1 if dead else 30,
+            retries={"max_attempts": 0},
+        ),
+    )
+
+
+def _stores() -> tuple[CountingClient, S3ArtifactStore, S3DurableEventStore]:
+    endpoint = _required("OBJECT_STORE_ENDPOINT")
+    bucket = _required("OBJECT_STORE_BUCKET")
+    region = os.environ.get("OBJECT_STORE_REGION", "auto") or "auto"
+    client = CountingClient(_new_raw_client(endpoint=endpoint, region=region))
+    artifacts = S3ArtifactStore(bucket=bucket, prefix=_prefix(), client=client)
+    events = S3DurableEventStore(
+        bucket=bucket,
+        schema_path=SCHEMA,
+        prefix=_prefix(),
+        client=client,
+    )
+    return client, artifacts, events
+
+
+def _canonical(value: dict[str, Any]) -> bytes:
+    return (
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        + "\n"
+    ).encode("utf-8")
+
+
+def _assert_receipt_safe(encoded: bytes) -> None:
+    text = encoded.decode("utf-8")
+    for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"):
+        value = os.environ.get(name, "")
+        if value and value in text:
+            raise RuntimeError(f"credential material leaked into proof receipt via {name}")
+
+
+def _publish_receipt(events: S3DurableEventStore, relative: str, receipt: dict[str, Any]) -> None:
+    encoded = _canonical(receipt)
+    _assert_receipt_safe(encoded)
+    events.backend.put_immutable(relative, encoded)
+
+
+def _write_local_receipt(receipt: dict[str, Any]) -> None:
+    path = Path(_required("FOSSIL_PROOF_RECEIPT_PATH"))
+    encoded = _canonical(receipt)
+    _assert_receipt_safe(encoded)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(encoded)
+
+
+def _assert_raises(exc_type: type[BaseException], func: Any, message: str) -> None:
+    try:
+        func()
+    except exc_type:
+        return
+    raise RuntimeError(message)
+
+
+def write_phase() -> None:
+    started = time.monotonic()
+    bucket = _required("OBJECT_STORE_BUCKET")
+    software_commit = _required("FOSSIL_SOFTWARE_COMMIT")
+    client, artifacts, events = _stores()
+
+    client.head_bucket(Bucket=bucket)
+
+    artifact_payload = b"FOSSIL OBJECT_STORE_LIVE canonical artifact v1\n"
+    artifact = artifacts.put_bytes(artifact_payload, media_type="text/plain")
+    if artifacts.put_bytes(artifact_payload, media_type="text/plain") != artifact:
+        raise RuntimeError("byte-identical artifact replay changed the canonical manifest")
+    if artifacts.read_bytes(artifact["artifact_id"]) != artifact_payload:
+        raise RuntimeError("canonical artifact bytes did not round-trip")
+    if artifacts.verify(artifact["artifact_id"]) is not True:
+        raise RuntimeError("canonical artifact verification did not pass")
+
+    conflict_key = "proof-controls/immutable-conflict.bin"
+    artifacts.backend.put_immutable(conflict_key, b"stable-v1")
+    _assert_raises(
+        RemoteObjectConflict,
+        lambda: artifacts.backend.put_immutable(conflict_key, b"stable-v2"),
+        "stable-key conflicting bytes did not fail closed",
+    )
+
+    redacted_artifact = artifacts.put_bytes(
+        b"FOSSIL OBJECT_STORE_LIVE redactable artifact\n",
+        media_type="text/plain",
+    )
+    artifact_tombstone_before_delete = {"passed": False}
+    artifact_delete = artifacts.backend.delete
+
+    def checked_artifact_delete(relative: str) -> None:
+        tombstone_key = artifacts._redaction_key(redacted_artifact["artifact_id"])
+        if not artifacts.backend.exists(tombstone_key):
+            raise RuntimeError("artifact tombstone was not durable before sensitive delete")
+        artifact_tombstone_before_delete["passed"] = True
+        artifact_delete(relative)
+
+    artifacts.backend.delete = checked_artifact_delete  # type: ignore[method-assign]
+    artifacts.redact(
+        redacted_artifact["artifact_id"],
+        reason="OBJECT_STORE_LIVE privacy proof",
+        authority="object-store-live",
+        redacted_at="2026-08-15T17:30:00Z",
+        request_ref="OBJECT_STORE_LIVE",
+    )
+    if not artifact_tombstone_before_delete["passed"]:
+        raise RuntimeError("artifact tombstone-before-delete observation did not pass")
+    _assert_raises(
+        ArtifactRedactedError,
+        lambda: artifacts.put_bytes(
+            b"FOSSIL OBJECT_STORE_LIVE redactable artifact\n",
+            media_type="text/plain",
+        ),
+        "redacted artifact identity was republished",
+    )
+
+    first = events.commit(_event(1))
+    second = events.commit(_event(2))
+    if events.commit(_event(2)) != second:
+        raise RuntimeError("byte-identical event replay changed canonical event")
+
+    conflicting = deepcopy(_event(2))
+    conflicting["payload"]["claim_text"] = "conflicting content under stable identity"
+    _assert_raises(
+        IdempotencyConflict,
+        lambda: events.commit(conflicting),
+        "stable event identity accepted conflicting content",
+    )
+
+    event_tombstone_before_delete = {"passed": False}
+    event_delete = events.backend.delete
+
+    def checked_event_delete(relative: str) -> None:
+        if not events.backend.exists(events._redaction_key(first["event_id"])):
+            raise RuntimeError("event tombstone was not durable before event delete")
+        event_tombstone_before_delete["passed"] = True
+        event_delete(relative)
+
+    events.backend.delete = checked_event_delete  # type: ignore[method-assign]
+    events.redact(
+        first["event_id"],
+        reason="OBJECT_STORE_LIVE redaction proof",
+        authority="object-store-live",
+        redacted_at="2026-08-15T17:31:00Z",
+        request_ref="OBJECT_STORE_LIVE",
+    )
+    if not event_tombstone_before_delete["passed"]:
+        raise RuntimeError("event tombstone-before-delete observation did not pass")
+    _assert_raises(
+        EventRedactedError,
+        lambda: events.commit(_event(1)),
+        "redacted event identity was republished",
+    )
+
+    remaining = list(events.iter_events())
+    if [item["event_id"] for item in remaining] != [second["event_id"]]:
+        raise RuntimeError("canonical remote enumeration retained unexpected event identities")
+    expected_digest = SemanticSnapshot.from_events(remaining).digest()
+
+    region = os.environ.get("OBJECT_STORE_REGION", "auto") or "auto"
+    dead_client = _new_raw_client(
+        endpoint=_required("OBJECT_STORE_ENDPOINT"),
+        region=region,
+        dead=True,
+    )
+    unavailable = S3DurableEventStore(
+        bucket=bucket,
+        schema_path=SCHEMA,
+        prefix=f"{_prefix()}/negative-control",
+        client=dead_client,
+    )
+    _assert_raises(
+        RemoteStoreUnavailable,
+        lambda: unavailable.commit(_event(3)),
+        "dead endpoint was normalized into durable success",
+    )
+
+    receipt = {
+        "schema": "fossil.object-store-live.writer.v1",
+        "status": "PASS",
+        "software_commit": software_commit,
+        "bucket": bucket,
+        "proof_prefix": _prefix(),
+        "artifact_id": artifact["artifact_id"],
+        "redacted_artifact_id": redacted_artifact["artifact_id"],
+        "redacted_event_id": first["event_id"],
+        "remaining_event_ids": [second["event_id"]],
+        "expected_snapshot_digest": expected_digest,
+        "tombstone_before_delete": {
+            "artifact": True,
+            "event": True,
+        },
+        "negative_controls": {
+            "immutable_conflict": "PASS",
+            "event_conflict": "PASS",
+            "dead_endpoint_fail_closed": "PASS",
+            "redacted_republication_blocked": "PASS",
+        },
+        "metrics": {
+            **client.metrics(),
+            "elapsed_ms": round((time.monotonic() - started) * 1000),
+        },
+    }
+    _publish_receipt(events, WRITER_RECEIPT, receipt)
+    _write_local_receipt(receipt)
+    print(
+        "OBJECT_STORE_LIVE writer PASS "
+        f"sha={software_commit} prefix={_prefix()} digest={expected_digest} "
+        f"requests={receipt['metrics']['request_count']}"
+    )
+
+
+def _rebuild_once() -> tuple[str, list[str], dict[str, Any]]:
+    client, _artifacts, events = _stores()
+    remote_events = list(events.iter_events())
+    expected_second = events.prepare(_event(2))
+    expected_ids = [expected_second["event_id"]]
+    actual_ids = [item["event_id"] for item in remote_events]
+    if actual_ids != expected_ids:
+        raise RuntimeError(
+            f"empty-runner remote enumeration mismatch: expected {expected_ids}, got {actual_ids}"
+        )
+
+    redacted_id = events.prepare(_event(1))["event_id"]
+    if not events.is_redacted(redacted_id):
+        raise RuntimeError("redaction tombstone missing on empty-runner rebuild")
+    _assert_raises(
+        EventRedactedError,
+        lambda: events.get(redacted_id),
+        "redacted event resurrected during empty-runner rebuild",
+    )
+
+    with tempfile.TemporaryDirectory(prefix="fossil-object-store-live-") as temp:
+        local = DurableEventStore(Path(temp) / "events", SCHEMA)
+        if list(local.iter_events()):
+            raise RuntimeError("fresh local rebuild directory was not empty")
+        for event in remote_events:
+            local.commit(event)
+        digest = SemanticSnapshot.from_events(list(local.iter_events())).digest()
+
+    return digest, actual_ids, client.metrics()
+
+
+def rebuild_phase() -> None:
+    started = time.monotonic()
+    software_commit = _required("FOSSIL_SOFTWARE_COMMIT")
+    client, _artifacts, events = _stores()
+    writer = json.loads(events.backend.read(WRITER_RECEIPT).decode("utf-8"))
+    if writer.get("status") != "PASS" or writer.get("software_commit") != software_commit:
+        raise RuntimeError("writer receipt is absent, stale, or not PASS")
+
+    first_digest, first_ids, first_metrics = _rebuild_once()
+    second_digest, second_ids, second_metrics = _rebuild_once()
+    expected = str(writer["expected_snapshot_digest"])
+    if first_digest != expected or second_digest != expected:
+        raise RuntimeError("fresh rebuild semantic digest does not match writer durable truth")
+    if first_ids != second_ids:
+        raise RuntimeError("second fresh rebuild produced different event identities")
+
+    receipt = {
+        "schema": "fossil.object-store-live.rebuild.v1",
+        "status": "PASS",
+        "software_commit": software_commit,
+        "bucket": _required("OBJECT_STORE_BUCKET"),
+        "proof_prefix": _prefix(),
+        "writer_snapshot_digest": expected,
+        "first_rebuild_digest": first_digest,
+        "second_rebuild_digest": second_digest,
+        "event_ids": first_ids,
+        "redaction_non_resurrection": "PASS",
+        "restartability": "PASS",
+        "metrics": {
+            "receipt_read_client": client.metrics(),
+            "first_rebuild": first_metrics,
+            "second_rebuild": second_metrics,
+            "elapsed_ms": round((time.monotonic() - started) * 1000),
+        },
+    }
+    _publish_receipt(events, REBUILD_RECEIPT, receipt)
+    _write_local_receipt(receipt)
+    print(
+        "OBJECT_STORE_LIVE rebuild PASS "
+        f"sha={software_commit} prefix={_prefix()} digest={expected}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="FOSSIL live object-store durability proof")
+    parser.add_argument("phase", choices=("write", "rebuild"))
+    args = parser.parse_args()
+    if args.phase == "write":
+        write_phase()
+    else:
+        rebuild_phase()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/live_object_store_rebuild_proof.py
+++ b/scripts/live_object_store_rebuild_proof.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from typing import Any
+
+from fossil_core.artifact_store import ArtifactRedactedError
+from fossil_core.s3_storage import S3ArtifactStore
+
+import live_object_store_proof as base
+
+
+CANONICAL_ARTIFACT_PAYLOAD = b"FOSSIL OBJECT_STORE_LIVE canonical artifact v1\n"
+REDACTABLE_ARTIFACT_PAYLOAD = b"FOSSIL OBJECT_STORE_LIVE redactable artifact\n"
+MEDIA_TYPE = "text/plain"
+
+
+def _artifact_identity(data: bytes) -> tuple[str, str]:
+    digest = hashlib.sha256(data).hexdigest()
+    return S3ArtifactStore.artifact_id_for_digest(digest), digest
+
+
+def _expected_manifest(artifact_id: str, digest: str, data: bytes) -> dict[str, Any]:
+    return {
+        "artifact_id": artifact_id,
+        "content_hash": {"algorithm": "sha256", "digest": digest},
+        "byte_size": len(data),
+        "media_type": MEDIA_TYPE,
+    }
+
+
+def _verify_artifacts_once(fixture_identity: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    client, artifacts, _events = base._stores()
+
+    artifact_id, artifact_digest = _artifact_identity(CANONICAL_ARTIFACT_PAYLOAD)
+    if artifact_id != fixture_identity:
+        raise RuntimeError(
+            f"fresh-runner fixture identity mismatch: expected {artifact_id}, got {fixture_identity}"
+        )
+
+    manifest = artifacts.get_manifest(artifact_id)
+    expected_manifest = _expected_manifest(
+        artifact_id,
+        artifact_digest,
+        CANONICAL_ARTIFACT_PAYLOAD,
+    )
+    if manifest != expected_manifest:
+        raise RuntimeError("fresh-runner canonical artifact manifest does not match expected identity")
+    if artifacts.read_bytes(artifact_id) != CANONICAL_ARTIFACT_PAYLOAD:
+        raise RuntimeError("fresh-runner canonical artifact bytes do not match expected content")
+    if artifacts.verify(artifact_id) is not True:
+        raise RuntimeError("fresh-runner canonical artifact hash/size verification did not pass")
+
+    redacted_artifact_id, redacted_digest = _artifact_identity(REDACTABLE_ARTIFACT_PAYLOAD)
+    redacted_manifest = artifacts.get_manifest(redacted_artifact_id)
+    expected_redacted_manifest = _expected_manifest(
+        redacted_artifact_id,
+        redacted_digest,
+        REDACTABLE_ARTIFACT_PAYLOAD,
+    )
+    if redacted_manifest != expected_redacted_manifest:
+        raise RuntimeError("fresh-runner redacted artifact manifest identity changed")
+    if not artifacts.is_redacted(redacted_artifact_id):
+        raise RuntimeError("fresh-runner redacted artifact tombstone is missing")
+
+    tombstone = artifacts.get_redaction(redacted_artifact_id)
+    if tombstone is None:
+        raise RuntimeError("fresh-runner redacted artifact tombstone could not be reopened")
+    for key, expected in {
+        "artifact_id": redacted_artifact_id,
+        "content_hash": {"algorithm": "sha256", "digest": redacted_digest},
+        "byte_size": len(REDACTABLE_ARTIFACT_PAYLOAD),
+        "media_type": MEDIA_TYPE,
+    }.items():
+        if tombstone.get(key) != expected:
+            raise RuntimeError(f"fresh-runner redaction tombstone mismatch for {key}")
+
+    if artifacts.backend.exists(artifacts._blob_key(redacted_digest)):
+        raise RuntimeError("fresh-runner found redacted sensitive artifact bytes still present")
+    base._assert_raises(
+        ArtifactRedactedError,
+        lambda: artifacts.read_bytes(redacted_artifact_id),
+        "redacted artifact resurrected during fresh-runner read",
+    )
+    base._assert_raises(
+        ArtifactRedactedError,
+        lambda: artifacts.put_bytes(REDACTABLE_ARTIFACT_PAYLOAD, media_type=MEDIA_TYPE),
+        "fresh runner was able to republish a redacted artifact identity",
+    )
+
+    proof = {
+        "artifact_id": artifact_id,
+        "artifact_sha256": artifact_digest,
+        "artifact_byte_size": len(CANONICAL_ARTIFACT_PAYLOAD),
+        "redacted_artifact_id": redacted_artifact_id,
+        "artifact_exact_bytes_hash_identity": "PASS",
+        "artifact_redaction_non_resurrection": "PASS",
+    }
+    return proof, client.metrics()
+
+
+def rebuild_phase() -> None:
+    started = time.monotonic()
+    software_commit = base._required("FOSSIL_SOFTWARE_COMMIT")
+    fixture_identity = base._required("FOSSIL_FIXTURE_IDENTITY")
+    client, _artifacts, events = base._stores()
+
+    writer = json.loads(events.backend.read(base.WRITER_RECEIPT).decode("utf-8"))
+    if writer.get("status") != "PASS" or writer.get("software_commit") != software_commit:
+        raise RuntimeError("writer receipt is absent, stale, or not PASS")
+    if writer.get("proof_prefix") != base._prefix():
+        raise RuntimeError("runner B proof prefix does not match the durable writer receipt")
+    if writer.get("artifact_id") != fixture_identity:
+        raise RuntimeError("runner B fixture identity does not match the durable writer receipt")
+
+    expected_redacted_artifact_id, _ = _artifact_identity(REDACTABLE_ARTIFACT_PAYLOAD)
+    if writer.get("redacted_artifact_id") != expected_redacted_artifact_id:
+        raise RuntimeError("writer receipt redacted artifact identity is not the deterministic fixture")
+
+    first_artifacts, first_artifact_metrics = _verify_artifacts_once(fixture_identity)
+    first_digest, first_ids, first_event_metrics = base._rebuild_once()
+
+    second_artifacts, second_artifact_metrics = _verify_artifacts_once(fixture_identity)
+    second_digest, second_ids, second_event_metrics = base._rebuild_once()
+
+    expected_digest = str(writer["expected_snapshot_digest"])
+    if first_digest != expected_digest or second_digest != expected_digest:
+        raise RuntimeError("fresh rebuild semantic digest does not match writer durable truth")
+    if first_ids != second_ids:
+        raise RuntimeError("second fresh rebuild produced different event identities")
+    if first_ids != list(writer.get("remaining_event_ids", [])):
+        raise RuntimeError("fresh-runner event identities do not match the durable writer receipt")
+    if first_artifacts != second_artifacts:
+        raise RuntimeError("second fresh rebuild produced different artifact proof results")
+
+    receipt = {
+        "schema": "fossil.object-store-live.rebuild.v2",
+        "status": "PASS",
+        "software_commit": software_commit,
+        "bucket": base._required("OBJECT_STORE_BUCKET"),
+        "proof_prefix": base._prefix(),
+        "fixture_identity": fixture_identity,
+        "writer_snapshot_digest": expected_digest,
+        "first_rebuild_digest": first_digest,
+        "second_rebuild_digest": second_digest,
+        "event_ids": first_ids,
+        "artifact_id": first_artifacts["artifact_id"],
+        "redacted_artifact_id": first_artifacts["redacted_artifact_id"],
+        "artifact_exact_bytes_hash_identity": "PASS",
+        "artifact_rebuild_verification": "PASS",
+        "redaction_non_resurrection": "PASS",
+        "restartability": "PASS",
+        "metrics": {
+            "receipt_read_client": client.metrics(),
+            "first_rebuild": {
+                "artifact_remote": first_artifact_metrics,
+                "event_remote_and_local": first_event_metrics,
+            },
+            "second_rebuild": {
+                "artifact_remote": second_artifact_metrics,
+                "event_remote_and_local": second_event_metrics,
+            },
+            "elapsed_ms": round((time.monotonic() - started) * 1000),
+        },
+    }
+    base._publish_receipt(events, base.REBUILD_RECEIPT, receipt)
+    base._write_local_receipt(receipt)
+    print(
+        "OBJECT_STORE_LIVE rebuild PASS "
+        f"sha={software_commit} prefix={base._prefix()} "
+        f"artifact={fixture_identity} digest={expected_digest}"
+    )
+
+
+def main() -> int:
+    rebuild_phase()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_object_store_live_harness.py
+++ b/tests/test_object_store_live_harness.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+WORKFLOW = ROOT / ".github/workflows/object-store-live.yml"
+SCRIPT = ROOT / "scripts/live_object_store_proof.py"
+
+
+def test_object_store_live_workflow_is_manual_exact_head_and_credential_scoped() -> None:
+    assert WORKFLOW.exists(), "OBJECT_STORE_LIVE workflow is required"
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    required = [
+        "workflow_dispatch:",
+        "environment: object-store-live",
+        "ref: ${{ inputs.ref }}",
+        "git rev-parse HEAD",
+        "vars.R2_ENDPOINT",
+        "vars.R2_BUCKET",
+        "secrets.R2_ACCESS_KEY_ID",
+        "secrets.R2_SECRET_ACCESS_KEY",
+        "AWS_EC2_METADATA_DISABLED: \"true\"",
+        "fossil-live-proof/${{ github.run_id }}/${{ github.run_attempt }}",
+        "python scripts/live_object_store_proof.py write",
+        "python scripts/live_object_store_proof.py rebuild",
+    ]
+    for needle in required:
+        assert needle in workflow, f"missing live object-store safety contract: {needle}"
+
+    assert "pull_request:" not in workflow
+    assert "push:" not in workflow
+
+
+def test_object_store_live_script_is_provider_neutral_and_fail_closed() -> None:
+    assert SCRIPT.exists(), "OBJECT_STORE_LIVE proof script is required"
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    for needle in [
+        "S3ArtifactStore",
+        "S3DurableEventStore",
+        "SemanticSnapshot",
+        "RemoteStoreUnavailable",
+        "ArtifactRedactedError",
+        "IdempotencyConflict",
+        "OBJECT_STORE_ENDPOINT",
+        "OBJECT_STORE_BUCKET",
+        "FOSSIL_PROOF_PREFIX",
+        "writer-receipt.json",
+        "rebuild-receipt.json",
+    ]:
+        assert needle in source, f"missing live proof semantic: {needle}"
+
+    # Provider-specific secret names belong at the workflow boundary, not in the
+    # provider-neutral proof implementation or receipts.
+    assert "R2_SECRET_ACCESS_KEY" not in source
+    assert "R2_ACCESS_KEY_ID" not in source

--- a/tests/test_object_store_live_harness.py
+++ b/tests/test_object_store_live_harness.py
@@ -6,6 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).parents[1]
 WORKFLOW = ROOT / ".github/workflows/object-store-live.yml"
 SCRIPT = ROOT / "scripts/live_object_store_proof.py"
+REBUILD_SCRIPT = ROOT / "scripts/live_object_store_rebuild_proof.py"
 
 
 def test_object_store_live_workflow_is_manual_exact_head_and_credential_scoped() -> None:
@@ -24,13 +25,32 @@ def test_object_store_live_workflow_is_manual_exact_head_and_credential_scoped()
         "AWS_EC2_METADATA_DISABLED: \"true\"",
         "fossil-live-proof/${{ github.run_id }}/${{ github.run_attempt }}",
         "python scripts/live_object_store_proof.py write",
-        "python scripts/live_object_store_proof.py rebuild",
+        "python scripts/live_object_store_rebuild_proof.py",
     ]
     for needle in required:
         assert needle in workflow, f"missing live object-store safety contract: {needle}"
 
     assert "pull_request:" not in workflow
     assert "push:" not in workflow
+
+
+def test_writer_hands_runner_b_only_prefix_and_deterministic_fixture_identity() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    writer_block, rebuild_block = workflow.split("\n  rebuild:\n", 1)
+
+    for needle in [
+        "outputs:",
+        "proof_prefix: ${{ steps.proof_outputs.outputs.proof_prefix }}",
+        "fixture_identity: ${{ steps.proof_outputs.outputs.fixture_identity }}",
+        "id: proof_outputs",
+        "printf 'proof_prefix=%s\\n' \"$FOSSIL_PROOF_PREFIX\" >> \"$GITHUB_OUTPUT\"",
+        "printf 'fixture_identity=%s\\n' \"$fixture_identity\" >> \"$GITHUB_OUTPUT\"",
+    ]:
+        assert needle in writer_block, f"missing writer handoff contract: {needle}"
+
+    assert "FOSSIL_PROOF_PREFIX: ${{ needs.writer.outputs.proof_prefix }}" in rebuild_block
+    assert "FOSSIL_FIXTURE_IDENTITY: ${{ needs.writer.outputs.fixture_identity }}" in rebuild_block
+    assert "FOSSIL_PROOF_PREFIX: fossil-live-proof/${{ github.run_id }}/${{ github.run_attempt }}" not in rebuild_block
 
 
 def test_object_store_live_script_is_provider_neutral_and_fail_closed() -> None:
@@ -54,5 +74,30 @@ def test_object_store_live_script_is_provider_neutral_and_fail_closed() -> None:
 
     # Provider-specific secret names belong at the workflow boundary, not in the
     # provider-neutral proof implementation or receipts.
+    assert "R2_SECRET_ACCESS_KEY" not in source
+    assert "R2_ACCESS_KEY_ID" not in source
+
+
+def test_fresh_runner_reopens_artifact_and_proves_redaction_non_resurrection() -> None:
+    assert REBUILD_SCRIPT.exists(), "fresh-runner artifact verification wrapper is required"
+    source = REBUILD_SCRIPT.read_text(encoding="utf-8")
+
+    for needle in [
+        "S3ArtifactStore",
+        "artifacts.get_manifest(artifact_id)",
+        "artifacts.read_bytes(artifact_id)",
+        "artifacts.verify(artifact_id)",
+        "artifacts.is_redacted(redacted_artifact_id)",
+        "artifacts.get_redaction(redacted_artifact_id)",
+        "artifacts.backend.exists(artifacts._blob_key(redacted_digest))",
+        "ArtifactRedactedError",
+        "base._rebuild_once()",
+        '"artifact_exact_bytes_hash_identity": "PASS"',
+        '"artifact_rebuild_verification": "PASS"',
+        '"redaction_non_resurrection": "PASS"',
+    ]:
+        assert needle in source, f"missing fresh-runner acceptance proof: {needle}"
+
+    assert source.count("base._rebuild_once()") == 2
     assert "R2_SECRET_ACCESS_KEY" not in source
     assert "R2_ACCESS_KEY_ID" not in source


### PR DESCRIPTION
Implements the credential-free harness portion of #124 under #87.

This starts failed-first with a deterministic contract test requiring a workflow_dispatch-only exact-SHA live proof, environment-scoped R2 configuration, provider-neutral proof code, independent writer/rebuild phases, and fail-closed semantics.

No credential values are included. Do not dispatch or merge until the harness implementation is green in normal CI; actual live R2 verification remains credential-gated and separate.