### PR TITLE
docs: reconcile agent continuation after current-state merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,120 +1,133 @@
 # Agent Continuation Contract
 
-This repository is designed so another GPT/Codex/Claude session can continue the project without relying on chat memory.
+This repository is designed so another GPT/Codex/Claude session can continue without relying on chat memory.
 
 ## Start here, in this order
 
-1. `ARCHITECTURE.md` — frozen durable invariants.
-2. `docs/HANDOFF_CURRENT.md` — exact continuation point.
-3. `docs/PROJECT_STATE.md` — work/campaign state.
-4. `docs/research/2026-08-10-production-rag-hardening-research-trace.md` — current post-Gate-2 research basis.
-5. GitHub Issue #48 — active production RAG hardening campaign.
-6. GitHub Issue #47 — embedding/reranker/model-scale candidate workstream.
-7. `docs/handoffs/2026-08-10-chatgpt-session-handoff-gate2-complete.md` — completed Gate 2 transfer when history is needed.
-8. `docs/DECISION_LOG.md` — accepted decisions, alternatives, and reconsideration triggers.
-9. Gate/proof documents under `docs/implementation/`.
-10. Closed Gate 2 Issue #33 and children #34–#37 only when detailed Gate 2 history is useful.
+1. `ARCHITECTURE.md` — durable FOSSIL invariants and non-goals.
+2. GitHub Issue #86 — current cross-project architecture authority.
+3. Latest GitHub Issue #94 comments — current execution queue, claims, and closeouts.
+4. `docs/HANDOFF_CURRENT.md` — current continuation summary.
+5. `docs/PROJECT_STATE.md` — current FOSSIL state plus durable proof anchors.
+6. `docs/operations/EXTERNAL-RUNTIME-RECONCILIATION-2026-08-15.md` — read-only Cortex V5 / LiteLLM inspection snapshot.
+7. GitHub Issue #87 — provider-neutral S3-compatible durability track.
+8. GitHub Issue #124 — current `OBJECT_STORE_LIVE` candidate gate.
+9. `docs/DECISION_LOG.md` — accepted decisions and reconsideration triggers.
+10. The focused issue/PR for the task you actually claim.
 
-## Current state
+Live #86/#94 state supersedes stale operational ordering in repository prose. Re-fetch exact heads, CI, review state, environment/config state, and claims immediately before any write, rebase, merge, deployment, credentialed proof, or task claim.
 
-**Milestone 0 / Gate 1 is complete. Gate 2 is complete and formally closed. Issue #48 is the active post-Gate-2 production RAG hardening campaign.**
+## Current boundary
 
-Gate 2 decision D021 remains active: revision-pinned BGE dense retrieval is the normal primary, BM25 is an explicit degraded availability fallback, and current/history/lineage/citation safeguards remain mandatory. D021 is replaceable policy, not canonical truth.
+The project invariant is:
 
-Issue #47 records future embedding/model-scale/reranker comparison work. Treat it as a workstream feeding #48 rather than permission to replace D021 based on model novelty or public leaderboard scores.
+> **Compute may disappear; truth must not.**
 
-## Active campaign — #48
+The subsystem boundary is:
 
-The campaign is evidence-driven hardening, **not a GraphRAG rewrite and not an invented Gate 3**.
+> **Cortex V5 owns execution policy. FOSSIL owns durable knowledge/evidence. GitHub owns source/coordination/review. LiteLLM/CKFF owns provider/model/route transport facts. Infrastructure and projections are replaceable.**
 
-Current workstreams:
+The owner has explicitly requested that `Pukujan/cortex-v5` and `Pukujan/litellm-ckff-ops` remain **read-only** during the current FOSSIL continuation. Inspect them when needed to understand behavior; do not change their code, workflow, routing, deployment, or model policy unless the owner separately authorizes that work.
 
-- evolving-corpus temporal/update benchmark;
-- end-to-end answer/citation/unsupported-claim/abstention evaluation;
-- retrieval poisoning and untrusted-context adversarial tests;
-- replayable query execution receipt;
-- embedding/hybrid/reranker bakeoff (#47);
-- conservative adaptive routing if it beats simple baselines;
-- ACL/redaction propagation readiness before shared/cloud use.
+## Current FOSSIL lane
 
-The research trace under `docs/research/2026-08-10-production-rag-hardening-research-trace.md` is a local derived synthesis. External papers/vendor pages must remain separate source evidence when ingested into the corpus.
+The secretless S3-compatible storage foundation is complete. Historical runtime/storage anchor `ea1d88fc114981915603ec46a401dca45acd5a11` includes merged PR #123, which proved the provider-neutral storage contract against a real disposable S3-compatible service with no cloud credential/provider selection.
 
-## Non-negotiable rules
+The active durability gate is Issue #124 / `OBJECT_STORE_LIVE`: a separately credentialed, non-production R2 **candidate** durability + empty-runner rebuild proof. R2 is the first live candidate only; `S3ArtifactStore` / `S3DurableEventStore` remain the provider-neutral architecture boundary.
 
-- Do not treat Neo4j, Graphiti, an embedding index, MCP, a retriever, a reranker, a planner, a specific model, or a chat transcript as the durable source of truth.
-- Original evidence is preserved; summaries never replace source evidence.
-- Normal knowledge-changing history is append-only and versioned.
-- Privacy/legal erasure is an exceptional explicit tombstone-before-delete path; erased identities must not silently resurrect.
-- Stable IDs belong to the corpus, not to a storage engine.
-- Stable knowledge-pack identity is logical and independent of repository path, graph namespace, or physical database placement.
-- Graph/search/vector structures are rebuildable projections.
-- A new/rebuilt physical projection gets a fresh build-scoped applied ledger.
-- Rebuild replay order is `(recorded_at, event_id)`.
-- Migration compares stable FOSSIL semantics, not graph-native UUID equality.
-- `DISPUTED` and unresolved disagreement are valid durable states.
-- Model agreement is metadata, not external evidence.
-- Small/local model output remains candidate-only unless independent evidence/risk policy permits downstream authority.
-- Retrieval rank and reranker score are candidate ordering, not truth state.
-- Retrieved/source text is untrusted data and cannot issue executable policy/system/tool instructions merely because it was retrieved.
-- Agents normally propose; deterministic validation/policy gates commit durable changes.
-- Skills contain methodology, not canonical truth.
-- Protocol adapters remain thin and must not become the durable knowledge model.
-- Operational telemetry stays outside canonical knowledge; durable knowledge-changing provenance stays inside.
-- Reconstructed evidence can never silently become verbatim evidence.
-- Do not add infrastructure because it is fashionable. New technology must beat the existing adapter/benchmark contract on corpus-specific evidence.
-- Prefer a simpler retrieval/context pipeline when a complex one does not win under a matched quality/resource budget.
-- Do not casually rename the internal `src/fossil_core` module/API namespace. The legacy `src/dkg` namespace was deliberately and only temporarily retained as a deprecated import shim by Issue #82.
+Do not infer `OBJECT_STORE_LIVE PASS` from ordinary PR CI. Live PASS requires the exact issue acceptance, including fresh-runner reconstruction, redaction/non-resurrection, fail-closed controls, sanitized receipts, and same-head normal DKG.
+
+As of the 2026-08-15 checkpoint, draft PR #125 carried the credential-free harness and had exact-head DKG green, but independent review found acceptance/config reconciliation items. Re-read the current PR and #94 before acting; do not treat this sentence as live branch state.
+
+## Non-negotiable authority rules
+
+- Durable FOSSIL evidence/events, stable IDs, provenance, lifecycle, lineage, redaction, and accepted contracts remain semantic authority.
+- Neo4j/Graphiti, vector/lexical indexes, retrievers, rerankers, models, Cortex, LiteLLM, Skills, MCP, dashboards, and CI artifacts are replaceable services/projections, not durable truth.
+- Retrieval rank, reranker score, model confidence, model tier, and multi-model agreement do not create evidence authority.
+- A gateway fallback response is not evidence that the requested model itself succeeded.
+- `2xx` with empty, malformed, truncated, or zero-usable semantic output is failure, not success.
+- Reconstructed evidence cannot silently become verbatim evidence.
+- Privacy/legal erasure is exceptional tombstone-before-delete; erased identities must not silently resurrect.
+- Stable knowledge-pack identity is logical and independent of repository/database/graph placement.
+- Ordinary PR CI remains secretless.
+- Production promotion requires separate explicit human authorization.
+- Never weaken, skip, xfail, suppress, or narrow an acceptance path merely to obtain green.
+
+## Legacy SSC
+
+Legacy `stupidly-simple-cortex` is retired/superseded as runtime, memory, RAG, ontology/current-state, orchestration, and project authority. Cortex V5 does not depend on it.
+
+Potentially useful historical eval/checker assets may survive only after independent extraction/revalidation with exact bytes, hashes, provenance, license, checker dependencies, and leakage controls. Do not revive SSC runtime to preserve an old asset.
+
+Durable retirement decision: D023 in `docs/DECISION_LOG.md`.
 
 ## Repository family invariants
 
 - `Pukujan/fossil-common` keeps stable pack ID `pack_269099f7b2ba43b7a99b9427d64092de`.
 - `Pukujan/fossil-ai-systems` keeps stable pack ID `pack_f024177f89a5442db84171c3dd7f58e5` and its required dependency on common.
-- Do not call pack repositories database shards; physical sharding/placement is a separate concern.
+- Do not call pack repositories database shards; physical placement/sharding is a separate concern.
 
-## Frozen does not mean unchangeable
+## Claim protocol
 
-`ARCHITECTURE.md` is frozen as a contract, not dogma. A durable invariant changes only when implementation evidence or stronger research justifies it.
+Before mutating FOSSIL work, use Issue #94:
 
-When changing one:
+```text
+CLAIM task=<TASK_ID>
+agent=<unique-agent-id>
+mode=<LOCAL_CODEX|CLOUD_CODEX|CHATGPT|ACTIONS>
+lease_until=<ISO-8601 UTC>
+repo=<repo>
+starting_ref=<branch/SHA/PR>
+```
 
-1. use the relevant active issue;
-2. record the competing theory/failure;
-3. cite source or benchmark evidence;
-4. update `docs/DECISION_LOG.md`;
-5. update the architecture contract explicitly;
-6. preserve the previous decision and why it was superseded.
+Immediately re-fetch #94. Earliest valid unexpired claim wins. One active mutating owner per repo lane unless the task explicitly declares safe parallelism.
 
-Do not silently rewrite history.
+Close with `DONE`, `BLOCKED`, or `RELEASE` using exact refs, tests, hosted run IDs, and evidence required by that task.
 
-## Gate 2 completion anchors
+## Engineering policy
 
-Gate 2 control #33 and children #34–#37 are closed/completed.
+- SDD always.
+- TDD for deterministic behavior where practical.
+- Infra/config: contract first -> failing verification/probe -> smallest change -> passing verification.
+- Integration/wiring tests where there is actual wiring.
+- E2E for important real flows.
+- Fault injection for recovery/retry infrastructure.
+- Explicit security checks at credential/deployment boundaries.
+- Hidden holdouts for autonomous model evaluation where appropriate.
+- Selective mutation testing on small critical validators/gates/security/recovery logic.
+- Regression coverage for every discovered bug.
 
-- Gate 2A core commit: `a028f9e328c2cbcde0185930e90b5eeb4c4efcb8`.
-- Gate 2B core commit: `2affde923acf196319d90bfa63f206e4a5e2f25f`.
-- Gate 2C PR #44 / squash `38aac6325cdb5b738c8a6ac5e55959affb3acfb5`.
-- Gate 2C semantic proof run `31364039745`, artifact `9053475462`, digest `sha256:23c95b46f47cec5a16e0a8c0926a4f13532f283d8f4fbcc0de12ceb63db63c41`.
-- Gate 2D PR #45 / squash `2d22dee9e6b176956d30005f4d7877baf68b0a3c`.
-- Gate 2 closed-state reconciliation PR #46 / squash `a614936249ff0ab201756fa54a1e89699d7b924f`.
+For deterministic changes, prefer:
 
-BGE dense was the only compared Gate 2 strategy with zero full retrieval misses and had mean recall@5 `0.98413`; it still exhibited current-state ranking leakage and incomplete multi-target lineage recall. D021 therefore requires durable lifecycle/lineage resolution rather than trusting rank/top-k absence.
+1. **RED** — reproduce the defect/invariant first.
+2. **GREEN** — smallest correct change.
+3. **REGRESSION** — neighboring tests + full suite.
+4. **CLEAN VERIFY** — independent clean environment/worktree.
+5. **HOSTED EVIDENCE** — exact-head CI where the PR has hosted acceptance.
 
-## Work-state rule
+## Immediate fresh-agent behavior
 
-GitHub issues track implementation state. Repository docs track durable decisions/evidence/contracts.
+1. Read #86, #94, #87, and #124 live.
+2. Confirm current `main`, open PR heads, review state, environment/config state, and active claims.
+3. Treat Cortex V5 and LiteLLM/CKFF as read-only unless the owner explicitly opens separate mutation work.
+4. Take only an eligible task matching access and collision rules.
+5. Work on an isolated branch/target.
+6. Test mechanically without weakening acceptance.
+7. Post exact `DONE`, `BLOCKED`, or `RELEASE` evidence.
+8. Re-read #94 before taking another task.
 
-An issue can close, but an architectural decision must not exist only in an issue comment. Conversely, durable docs should point back to the issue/benchmark that caused the change when useful.
+If no eligible task exists, stop with explicit idle/BLOCKED evidence rather than inventing work.
 
 ## Session continuity protocol
 
 At the end of substantial work:
 
-- update `docs/HANDOFF_CURRENT.md`;
-- update `docs/PROJECT_STATE.md` if the campaign/gate state changed;
-- update the relevant active GitHub issue checklist/status;
+- update #94 with exact claim/closeout evidence;
+- update `docs/HANDOFF_CURRENT.md` when the continuation point materially changes;
+- update `docs/PROJECT_STATE.md` when the campaign/gate state changes;
+- update the relevant focused issue/PR;
 - commit benchmark/test results that materially justify a decision;
-- record architectural changes in `docs/DECISION_LOG.md`;
-- add/update a dated handoff when a long session is being retired;
+- record architectural changes in `docs/DECISION_LOG.md` and #86 when appropriate;
 - never rely on the chat UI as the only record of a decision.
 
-If chat history is missing or ambiguous, label reconstructed material as reconstructed rather than presenting it as verbatim evidence.
+If history is missing or ambiguous, label reconstructed material as reconstructed rather than presenting it as verbatim evidence.

--- a/docs/HANDOFF_CURRENT.md
+++ b/docs/HANDOFF_CURRENT.md
@@ -8,7 +8,7 @@
 
 ## Current status
 
-FOSSIL is operating under the disposable-compute invariant:
+FOSSIL operates under the invariant:
 
 > **Compute may disappear; truth must not.**
 
@@ -16,71 +16,100 @@ The current subsystem boundary is:
 
 > **Cortex V5 owns execution policy. FOSSIL owns durable knowledge/evidence. GitHub owns source/coordination/review. LiteLLM/CKFF owns provider/model/route transport facts. Infrastructure and projections are replaceable.**
 
-Current `fossil-core` main at this checkpoint:
+Do not treat an exact SHA embedded in this file as the live queue. Re-fetch #94 and current GitHub state before any write, merge, deployment, credentialed proof, or task claim.
 
-`ea1d88fc114981915603ec46a401dca45acd5a11`
+## Recent closeout anchors
 
-That main includes the merged real secretless S3-compatible service-fixture proof from PR #123.
+The earlier #112–#115 repair/fan-in campaign is complete:
 
-## Recent FOSSIL closeout
+- PR #115 merged after exact-head live Graphiti evidence plus deterministic, assurance, dependency, and security checks passed.
+- PR #112 refreshed, verified, and merged.
+- PR #113 refreshed, verified, and merged.
+- final-main Graphiti materialization plus redaction/non-resurrection remained green.
 
-The earlier #112–#115 repair/fan-in campaign is no longer pending:
+The provider-neutral storage lane then advanced:
 
-- PR #115 Graphiti compatibility/receipt lane merged after exact-head live Graphiti evidence, deterministic suite, assurance, dependency and security checks passed.
-- PR #112 was refreshed, verified and merged.
-- PR #113 was refreshed, verified and merged.
-- final-main Graphiti fan-in remained green.
-- PR #121 landed the provider-neutral S3-compatible canonical storage adapter.
-- PR #123 landed the **secretless real S3-compatible service fixture** proof using a disposable local/service-container implementation; no cloud provider was selected and no cloud credential was used.
+- PR #121 landed S3-compatible artifact/event adapters with fail-closed immutable/idempotent/conflict semantics.
+- PR #123 proved those adapters against a real disposable S3-compatible service with no cloud credentials and no provider selection.
+- Runtime/storage anchor after PR #123: `ea1d88fc114981915603ec46a401dca45acd5a11`.
 
-The next storage phase is Issue #124 / `OBJECT_STORE_LIVE`: a separately credential-gated live R2 candidate durability + empty-runner rebuild proof. R2 remains only the first candidate, not architecture truth or a permanent provider choice.
+Docs reconciliation PR #126 later merged as `771216d79bdaaf324dff30c970c11be65d47d890`. Treat these SHAs as evidence anchors, not as a substitute for checking live `main`.
+
+## Active FOSSIL lane — Issue #124 / OBJECT_STORE_LIVE
+
+The next durability gate is a separately credentialed, **non-production R2 candidate** proof. R2 is the first live candidate only; the provider-neutral `S3ArtifactStore` / `S3DurableEventStore` contract remains architecture truth.
+
+PASS requires the exact #124 acceptance, including:
+
+- exact-SHA checkout/fail-closed guard;
+- live immutable create, byte-identical replay, and stable-identity conflict behavior;
+- artifact and event durability from a genuinely fresh hosted runner;
+- repeated rebuild/restartability from zero local state;
+- redaction tombstone-before-delete and non-resurrection;
+- dead-endpoint/auth/partial-response fail-closed controls;
+- sanitized receipts with no credential material;
+- same-head normal DKG green;
+- no provider-specific weakening of FOSSIL semantics.
+
+Ordinary PR CI is **not** `OBJECT_STORE_LIVE PASS`.
+
+### Current harness checkpoint
+
+As of this handoff checkpoint, draft PR #125 carried the credential-free live harness on head `9d8ad737d0778075a98232df7ddb2c43fb4156fb`, and exact-head DKG was green (`31899262413`). Re-read the PR before acting because the branch may move.
+
+Independent review on that head identified two acceptance/configuration items before live dispatch:
+
+1. fresh-runner rebuild covered durable events but did not independently re-read/verify the surviving canonical artifact or prove redacted-artifact non-resurrection from runner B;
+2. the workflow targeted GitHub Environment `object-store-live`, while the repository environment list observed during review contained only `r2-proof`. Environment variable/secret names were not readable through the GitHub integration, so credential placement must be reconciled deliberately rather than guessed.
+
+The review also noted that #124 asks the writer to publish non-secret proof prefix/fixture identity as job outputs for runner B; the reviewed workflow instead recomputed them. Re-read the latest PR review state to see whether these points were addressed.
+
+If required configuration/credentials are absent, the result is `BLOCKED_CREDENTIAL`, not simulated PASS.
 
 ## External runtime posture — read only
 
-The owner has explicitly requested that **Cortex V5 and LiteLLM/CKFF not be modified as part of this FOSSIL continuation**. Inspect them to understand current behavior; do not change their repositories or workflows unless the owner separately authorizes that work.
+The owner explicitly requested that **Cortex V5 and LiteLLM/CKFF not be modified as part of this FOSSIL continuation**. Inspect them to understand current behavior; do not change their repositories or workflows unless the owner separately authorizes that work.
 
-Detailed exact-SHA reconciliation:
+Detailed inspection snapshot:
 
 `docs/operations/EXTERNAL-RUNTIME-RECONCILIATION-2026-08-15.md`
 
 ### Cortex V5
 
-Observed current `Pukujan/cortex-v5` main:
+Observed main at the reconciliation snapshot:
 
 `f29e7a2fa0584577765bfe3f437695a2cbaefcf2`
 
-Key current facts:
+Key facts at that snapshot:
 
-- V5 has no runtime dependency on Cortex V4 or legacy SSC.
-- Tasks enter through the V5 HTTP API.
-- V5 refreshes the live LiteLLM `/v1/models` catalog and selects a deterministic seat.
-- V5 uses strict streamed `/v1/chat/completions`; invalid/premature SSE is failure.
-- V5's LiteLLM client default timeout is 120 seconds.
-- the old undocumented `PREFERENCE_HINTS` ordering was removed;
-- current `MODEL_TIERS` is a documented research-grounded prior, with availability and task/methodology relevance ranked ahead of the tier;
-- model output never replaces the deterministic checker/verification gate;
-- retry/model switch remains a new attempt/receipt, not hidden success.
+- no runtime dependency on Cortex V4 or legacy SSC;
+- tasks enter through the V5 HTTP API;
+- live LiteLLM `/v1/models` catalog refresh plus deterministic seat selection;
+- strict streamed `/v1/chat/completions`; invalid/premature SSE is failure;
+- 120-second LiteLLM client default timeout;
+- documented research-grounded `MODEL_TIERS` replaced undocumented `PREFERENCE_HINTS`;
+- deterministic checker remains completion authority;
+- retry/model switch creates a new attempt/receipt rather than hidden success.
 
-The first real V5 HumanEval acceptance is already closed/completed. Do not reopen V5 acceptance or automatically make CORTEX-02/workflow changes merely because older FOSSIL queue text mentions them.
+V5 acceptance is already closed/completed. Do not reopen it or automatically mutate V5 because older queue text mentions CORTEX-02.
 
 ### LiteLLM / CKFF
 
-Observed current `Pukujan/litellm-ckff-ops` main:
+Observed main at the reconciliation snapshot:
 
 `9520e8dffe819d97a1557fe76022ed080f0eb8d6`
 
-Current executable/config facts include:
+Key executable/config facts at that snapshot:
 
-- configured logical models have CKFF deployments on `https://ckffai.com/v1` plus `https://ckff.dev/v1`;
-- LiteLLM `request_timeout` is 120 seconds, aligned with V5's default client deadline;
-- router retries/cooldown remain bounded and `max_parallel_requests` is 8;
-- the Responses bridge has an explicit cross-model fallback table and records requested/actual model identity; exact-model work should disable bridge fallbacks;
-- embeddings and reranking remain separate `/v1/embeddings` and `/v1/rerank` service lanes;
-- gateway privacy warnings are advisory; CKFF is not verified zero-data-retention.
+- configured logical models have `ckffai.com` primary plus `ckff.dev` secondary deployments;
+- LiteLLM `request_timeout` is 120 seconds;
+- retries/cooldown are bounded and `max_parallel_requests` is 8;
+- Responses bridge can use explicit cross-model fallback and records requested/actual identity;
+- exact-model work should disable bridge fallbacks;
+- embeddings and reranking remain separate fail-closed service lanes;
+- CKFF is not established here as universal zero-data-retention.
 
-LiteLLM's repository documentation is **not fully reconciled with current config**: the timeout contract is current, but the compatibility report still contains a 90-second LiteLLM value and the implementation-gap document still claims `ckffai.com` is absent from generated config. Treat those dated reports as historical evidence where they conflict with current exact source/config.
-
-Do **not** edit the LiteLLM repository or its workflows from this FOSSIL task.
+Some dated LiteLLM docs lag current source/config. When they conflict, use current exact source/config as operational fact and treat the dated prose as historical evidence.
 
 ## Read first
 
@@ -88,66 +117,35 @@ For a fresh session:
 
 1. `AGENTS.md`
 2. `ARCHITECTURE.md`
-3. this file
-4. `docs/PROJECT_STATE.md`
-5. `docs/operations/EXTERNAL-RUNTIME-RECONCILIATION-2026-08-15.md`
-6. Issue #86 — current architecture reconciliation
-7. Issue #94 — execution queue and append-only claim ledger
-8. Issue #87 — S3-compatible canonical storage + rebuild proof
-9. Issue #124 — current live object-store candidate proof
+3. Issue #86
+4. latest Issue #94 comments
+5. this file
+6. `docs/PROJECT_STATE.md`
+7. `docs/operations/EXTERNAL-RUNTIME-RECONCILIATION-2026-08-15.md`
+8. Issue #87
+9. Issue #124
 10. `docs/DECISION_LOG.md`
-11. `docs/operations/LITELLM-GATEWAY.md`
-
-Verify live GitHub state immediately before any write, merge, rebase, deployment, credentialed proof or task claim.
+11. the focused issue/PR for the eligible task
 
 ## Frozen authority rules
 
-- Retrieval rank is candidate ordering, not truth.
-- Reranker score is not truth.
-- Model confidence, model tier and multi-model agreement are not truth.
-- A gateway fallback response is not evidence that the requested model itself succeeded.
-- GitHub Actions artifacts/caches are not canonical FOSSIL truth.
-- FOSSIL durable evidence/events, stable IDs, provenance, lifecycle, lineage, redaction and accepted contracts remain semantic authority.
-- Cortex V5 owns execution/methodology/model seating; that policy does not become FOSSIL semantic authority.
-- LiteLLM/CKFF owns factual transport/routing/capability/timeout state; callers own task-specific acceptance.
+- FOSSIL durable evidence/events, stable IDs, provenance, lifecycle, lineage, redaction, and accepted contracts remain semantic authority.
+- Retrieval rank, reranker score, model confidence, model tier, and multi-model agreement are not truth.
+- Graphiti/Neo4j, search/vector indexes, models, Cortex, LiteLLM, Skills, MCP, dashboards, and CI artifacts remain replaceable services/projections.
+- A fallback response is not evidence that the requested model itself succeeded.
+- `2xx` with empty/malformed/truncated/zero-usable output is failure.
+- Reconstructed evidence cannot silently become verbatim evidence.
 - Ordinary PR CI remains secretless.
-- Production promotion always requires separate explicit authorization.
+- Production promotion always requires separate explicit human authorization.
+- Never weaken acceptance merely to obtain green.
 
 ## Legacy SSC
 
-Legacy `stupidly-simple-cortex` is retired/superseded as runtime, memory, RAG, ontology/current-state, orchestration and project authority. Cortex V5 does not depend on it.
+Legacy `stupidly-simple-cortex` is retired/superseded as runtime, memory, RAG, ontology/current-state, orchestration, and project authority. Cortex V5 does not depend on it.
 
-Potentially useful historical eval/checker assets may survive only after independent extraction/revalidation with exact bytes, hashes, provenance, license and leakage controls. Do not revive SSC runtime to preserve an old asset.
+Potentially useful historical eval/checker assets may survive only after independent extraction/revalidation with exact bytes, hashes, provenance, license, checker dependencies, and leakage controls. Do not revive SSC runtime to preserve an old asset.
 
 Durable retirement decision: D023 in `docs/DECISION_LOG.md`.
-
-## Current execution order
-
-### Active FOSSIL lane — Issue #124 / OBJECT_STORE_LIVE
-
-The secretless storage foundation has passed. The current live phase is narrowly scoped to a dedicated non-production R2 bucket/prefix and must remain fail-closed.
-
-PASS requires, among other issue-specific checks:
-
-- exact-SHA checkout;
-- live immutable/idempotent/conflict semantics;
-- independent fresh hosted-runner rebuild from zero local state;
-- repeated rebuild/restartability;
-- redaction tombstone-before-delete and non-resurrection;
-- negative controls for dead endpoint/auth/partial response;
-- sanitized receipts with no credential material;
-- normal DKG green on the same code head;
-- no provider-specific weakening of the core storage contract.
-
-If the required live config/credential is absent, report `BLOCKED_CREDENTIAL`; do not improvise secrets.
-
-### Parallel docs lane
-
-`DOCS-RECONCILE-20260815` is explicitly docs-only and parallel-safe. It must not modify #124 harness/workflow/runtime files or alter the active live-proof state.
-
-### After #124
-
-Reconcile the exact live evidence first, then choose the next **FOSSIL-only** gate. Do not automatically mutate Cortex V5 or LiteLLM/CKFF. Any external-runtime change is a separate owner decision.
 
 ## Claim protocol
 
@@ -162,31 +160,31 @@ repo=<repo>
 starting_ref=<branch/SHA/PR>
 ```
 
-Immediately re-fetch #94 comments. Earliest valid unexpired claim wins. One active mutating owner per repo lane unless the task explicitly declares safe parallelism.
+Immediately re-fetch #94. Earliest valid unexpired claim wins. One active mutating owner per repo lane unless the task explicitly declares safe parallelism.
 
-Close with `DONE`, `BLOCKED` or `RELEASE` using exact refs/tests/evidence.
+Close with exact `DONE`, `BLOCKED`, or `RELEASE` evidence.
 
 ## Engineering policy
 
 - SDD always.
 - TDD for deterministic behavior where practical.
-- Integration/wiring tests for real boundaries.
-- E2E for important actual flows.
-- Hidden holdouts for autonomous model evaluation.
+- Integration/wiring tests for actual boundaries.
+- E2E for important real flows.
 - Fault injection for recovery/retry infrastructure.
 - Explicit security checks at credential/deployment boundaries.
 - Regression coverage for discovered bugs.
-- Never weaken acceptance merely to obtain green.
+- Hidden holdouts for autonomous model evaluation where appropriate.
+- Never weaken, skip, or suppress acceptance merely to obtain green.
 
 ## Immediate fresh-agent behavior
 
-1. Read #86, #94, #87 and #124 live.
-2. Confirm current `main` and active claim state.
-3. Treat Cortex V5 and LiteLLM as read-only unless the owner explicitly opens a separate mutation task.
+1. Read #86, #94, #87, and #124 live.
+2. Confirm current `main`, active PR heads, review state, environment/config state, and claim ownership.
+3. Treat Cortex V5 and LiteLLM/CKFF as read-only unless the owner explicitly opens separate mutation work.
 4. Take only an eligible task matching access and collision rules.
 5. Work on an isolated branch/target.
 6. Test mechanically and record exact evidence.
-7. Post `DONE`, `BLOCKED` or `RELEASE`.
-8. Re-read the queue before taking another task.
+7. Post `DONE`, `BLOCKED`, or `RELEASE`.
+8. Re-read #94 before taking another task.
 
 If no eligible task exists, stop with explicit idle/BLOCKED evidence rather than inventing work.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -8,23 +8,21 @@
 **Current live candidate gate:** Issue #124 / `OBJECT_STORE_LIVE`  
 **Last updated:** 2026-08-15
 
-## Current checkpoint
+## Current state
 
-Current `fossil-core` main at this checkpoint:
-
-`ea1d88fc114981915603ec46a401dca45acd5a11`
-
-This includes the merged PR #123 real secretless S3-compatible service-fixture proof.
-
-The project invariant remains:
+FOSSIL operates under the invariant:
 
 > **Compute may disappear; truth must not.**
 
-FOSSIL owns durable semantic/evidence authority. Cortex V5 and LiteLLM/CKFF are external replaceable execution/transport systems. Their current behavior may be documented and consumed, but their repositories/workflows are not part of the active FOSSIL mutation scope unless the owner explicitly opens that work.
+Canonical FOSSIL knowledge remains **immutable evidence + stable corpus IDs + append-only validated knowledge events + versioned pack/ontology contracts + provenance/history**.
+
+Cortex V5, LiteLLM/CKFF, Graphiti/Neo4j, lexical/vector indexes, models, Skills, MCP, dashboards, and CI infrastructure are replaceable execution/transport/projection systems around that durable truth.
+
+Do not use an exact SHA embedded in this document as a live queue pointer. Issue #94 and current GitHub state are authoritative for active heads, claims, review state, and execution evidence.
 
 ## Repository family
 
-- `Pukujan/fossil-core` — architecture, contracts, durable core, projections, storage adapters, rebuild machinery, benchmarks and control-plane docs;
+- `Pukujan/fossil-core` — architecture, contracts, durable core, projections, storage adapters, rebuild machinery, benchmarks, and control-plane docs;
 - `Pukujan/fossil-common` — stable pack `pack_269099f7b2ba43b7a99b9427d64092de`;
 - `Pukujan/fossil-ai-systems` — stable pack `pack_f024177f89a5442db84171c3dd7f58e5`, depending on common.
 
@@ -34,173 +32,194 @@ Repository/database/graph placement is physical placement, not knowledge identit
 
 1. `AGENTS.md`
 2. `ARCHITECTURE.md`
-3. `docs/HANDOFF_CURRENT.md`
-4. this file
-5. `docs/operations/EXTERNAL-RUNTIME-RECONCILIATION-2026-08-15.md`
-6. Issue #86
-7. Issue #94
+3. Issue #86
+4. latest Issue #94 comments
+5. `docs/HANDOFF_CURRENT.md`
+6. this file
+7. `docs/operations/EXTERNAL-RUNTIME-RECONCILIATION-2026-08-15.md`
 8. Issue #87
 9. Issue #124
 10. `docs/DECISION_LOG.md`
-11. `docs/operations/LITELLM-GATEWAY.md`
+11. the focused issue/PR for the eligible task
 
 The chat UI is source material, not the control plane.
 
-## Frozen architecture
-
-Canonical FOSSIL knowledge is **immutable evidence + stable corpus IDs + append-only validated knowledge events + versioned pack/ontology contracts + provenance/history**.
-
-Graphiti/Neo4j, lexical/vector indexes, embedding models, rerankers, context construction, planners, model services, Skills, MCP, Cortex, LiteLLM and future databases remain replaceable projections/services.
-
-Retrieved/source text is untrusted data. Retrieval rank, reranker score, model confidence, model tier, multi-model agreement, route success and query-execution receipts are not truth authority.
-
 ## Completed foundation
 
-The earlier durable/evidence foundation remains complete, including:
+The durable/evidence foundation remains complete, including:
 
 - immutable validated events and content-addressed evidence;
-- stable pack identity and portable pack boundaries;
-- provenance, lifecycle, disagreement, supersession and lineage replay;
+- deterministic idempotency and stable corpus identity;
+- portable pack boundaries and provenance-preserving promotion;
+- disagreement, lifecycle, supersession, and lineage replay;
 - exact source/citation integrity;
-- exceptional redaction with tombstone-before-delete and non-resurrection;
-- replaceable Graphiti/Neo4j projection and rebuild/migration proof;
+- exceptional privacy/legal redaction with tombstone-before-delete and non-resurrection;
+- replaceable Graphiti/Neo4j projection plus destructive rebuild/migration proof;
+- conversation ingestion with explicit verbatim-vs-reconstructed provenance;
 - safe Agent Skill/API/MCP boundary;
 - cognitive-service interfaces and benchmark/receipt contracts;
-- post-Gate-2 answer, poisoning/untrusted-context and query-replay hardening evidence.
+- post-Gate-2 temporal, answer/citation, poisoning/untrusted-context, and replay hardening evidence.
 
-Historical Gate 1/Gate 2/workstream proof detail remains in the existing implementation, research, handoff and decision-log documents and in git history. This current-state file does not replace those records.
+Historical Gate 1/Gate 2/workstream proof detail remains in the implementation, research, handoff, decision-log, issue, and git records. This current-state document does not replace those records.
 
-## Recent 2026-08-15 reconciliation
+## 2026-08-15 baseline closeout anchors
 
-### #112–#115 baseline/fan-in
+### Graphiti / receipt / ingestion fan-in
 
-The previously open repair/fan-in work is now reconciled:
+The earlier #112–#115 campaign is complete:
 
-- PR #115 merged after exact-head Graphiti live proof, deterministic tests and engineering/dependency/security gates passed;
-- PR #112 refreshed, verified and merged;
-- PR #113 refreshed, verified and merged;
+- PR #115 merged after exact-head Graphiti live proof plus deterministic, assurance, dependency, and security checks passed;
+- PR #112 refreshed, verified, and merged;
+- PR #113 refreshed, verified, and merged;
 - final-main Graphiti materialization plus redaction/non-resurrection remained green.
 
-### #87 secretless storage foundation
+### Provider-neutral S3-compatible storage
 
-The provider-neutral S3-compatible storage lane advanced:
+The storage foundation advanced through:
 
-- PR #121 landed explicit provider-neutral S3-compatible artifact/event storage adapters and fail-closed durability semantics;
-- exact-head DKG/engineering/dependency/Graphiti evidence passed;
-- no live cloud credentials were used and no provider was selected.
+- PR #121 — provider-neutral `S3ArtifactStore` / `S3DurableEventStore` adapters with fail-closed immutable/idempotent/conflict/redaction semantics;
+- PR #123 — real disposable S3-compatible service-fixture proof with no cloud credential and no provider selection.
 
-### Real secretless S3-compatible service fixture
+Historical runtime/storage anchor after PR #123:
 
-PR #123 then proved the adapter against a real local/service-container S3-compatible implementation. The final-main proof covered the storage contract without cloud credentials/provider lock-in, including the required secretless service-fixture path and normal DKG.
+`ea1d88fc114981915603ec46a401dca45acd5a11`
 
-Current main after that merge is `ea1d88fc114981915603ec46a401dca45acd5a11`.
+### Current-state documentation reconciliation
 
-## Active FOSSIL work — Issue #124 / OBJECT_STORE_LIVE
+PR #126 reconciled FOSSIL continuation/operational docs against the then-current Cortex V5 and LiteLLM/CKFF implementations and merged as:
+
+`771216d79bdaaf324dff30c970c11be65d47d890`
+
+That SHA is a documentation closeout anchor, not a permanent assertion about the repository's current HEAD.
+
+## Active durability gate — Issue #124 / OBJECT_STORE_LIVE
 
 The next durability gate is a **separately credentialed, non-production R2 candidate proof**.
 
-R2 is the first live candidate only. The provider-neutral `S3ArtifactStore` / `S3DurableEventStore` contract remains architecture truth.
+R2 is the first live candidate only. The provider-neutral S3-compatible storage contract remains architecture truth and provider selection remains open.
 
 Required acceptance includes:
 
 - exact-SHA checkout/fail-closed guard;
-- live artifact/event immutable create, byte-identical replay and stable-identity conflict behavior;
-- live redaction tombstone-before-delete and non-resurrection;
+- real live artifact/event immutable creation;
+- byte-identical replay/idempotency;
+- stable-key/stable-identity conflict rejection;
+- artifact and event redaction tombstone-before-delete;
+- same-identity non-resurrection;
 - independent hosted runner rebuilding from zero local FOSSIL state;
-- a second rebuild/restartability pass from durable truth;
-- explicit dead-endpoint/partial/auth failure controls;
+- exact surviving fixture identity/content verification from durable storage;
+- a second fresh rebuild/restartability pass;
+- explicit dead-endpoint/auth/partial-response fail-closed controls;
 - sanitized receipts with no credential material;
-- normal DKG green on the same code head;
-- no provider-specific weakening of FOSSIL domain semantics.
+- same-head normal DKG green;
+- no provider-specific weakening of domain semantics.
 
-If required configuration/credentials are absent, the result is `BLOCKED_CREDENTIAL`, not simulated PASS.
+If required live configuration/credentials are absent, the result is `BLOCKED_CREDENTIAL`, not simulated PASS.
 
-## External execution/transport state — read only
+Ordinary secretless PR CI proves the harness/code contract only; it is not `OBJECT_STORE_LIVE PASS`.
 
-Detailed exact-SHA inspection is recorded in:
+## Current harness checkpoint
+
+At the 2026-08-15 review checkpoint, draft PR #125 was open on exact head:
+
+`9d8ad737d0778075a98232df7ddb2c43fb4156fb`
+
+Exact-head DKG run `31899262413` was SUCCESS.
+
+Independent review found acceptance/configuration items that must be reconciled before live dispatch; re-read the latest PR because the branch may have moved:
+
+1. the reviewed fresh-runner rebuild independently reconstructed durable events but did not independently re-read/verify the surviving canonical artifact or prove redacted-artifact non-resurrection on runner B;
+2. #124 asks writer A to publish non-secret proof prefix/fixture identity as job outputs for runner B, while the reviewed workflow recomputed those values instead;
+3. the reviewed workflow targeted GitHub Environment `object-store-live`, while the repository environment list observed during review contained only `r2-proof`.
+
+The GitHub integration could list environment names but was not allowed to inspect the environment/repository variable or secret metadata. No secret values were read or requested. Credential/config placement therefore must be reconciled deliberately rather than guessed.
+
+## External execution/transport posture — read only
+
+The owner explicitly requested that Cortex V5 and LiteLLM/CKFF remain read-only during this FOSSIL continuation.
+
+Detailed exact-SHA inspection snapshot:
 
 `docs/operations/EXTERNAL-RUNTIME-RECONCILIATION-2026-08-15.md`
 
-### Cortex V5
+### Cortex V5 snapshot
 
-Observed main:
+Observed `Pukujan/cortex-v5` main at reconciliation:
 
 `f29e7a2fa0584577765bfe3f437695a2cbaefcf2`
 
-Current posture:
+Key observed posture:
 
-- active execution runtime is Cortex V5, not V4;
-- V5 has no runtime dependency on SSC;
+- V5 is the active execution runtime; V4/SSC are not runtime dependencies;
 - strict streamed LiteLLM Chat Completions transport;
-- 120-second default client timeout;
+- default LiteLLM client timeout 120 seconds;
 - deterministic live-catalog seating;
-- research-grounded `MODEL_TIERS` prior replaces undocumented `PREFERENCE_HINTS`;
+- research-grounded `MODEL_TIERS` prior replaced undocumented `PREFERENCE_HINTS`;
 - deterministic checker remains completion authority;
-- the V5 acceptance issue is already closed/completed.
+- retry/model switching creates distinct attempts/receipts;
+- first real V5 acceptance is already closed/completed.
 
-**Policy for this FOSSIL checkpoint:** do not change Cortex V5 code or workflows. Older queue text suggesting automatic CORTEX-02 work is not authorization to mutate V5 after the owner's explicit read-only boundary.
+Do not change Cortex V5 code or workflows from the current FOSSIL lane without separate owner authorization.
 
-### LiteLLM / CKFF
+### LiteLLM / CKFF snapshot
 
-Observed main:
+Observed `Pukujan/litellm-ckff-ops` main at reconciliation:
 
 `9520e8dffe819d97a1557fe76022ed080f0eb8d6`
 
-Current executable/config posture:
+Key executable/config posture:
 
-- configured models have `ckffai.com` primary plus `ckff.dev` secondary deployments;
+- `ckffai.com` primary plus `ckff.dev` secondary deployments;
 - LiteLLM `request_timeout: 120`;
 - bounded retries/cooldown and `max_parallel_requests: 8`;
-- Responses bridge may use explicit cross-model fallback and exposes requested/actual/attempt metadata;
+- Responses bridge may use explicit cross-model fallback and records requested/actual identity;
 - exact-model evaluation should disable bridge fallbacks;
-- embeddings and reranking are separate fail-closed service lanes;
-- upstream privacy remains model/provider-dependent and CKFF is not verified zero-data-retention.
+- embeddings and reranking remain separate fail-closed service lanes;
+- CKFF is not established here as universal zero-data-retention.
 
-The LiteLLM repo's documentation is only partially reconciled with source/config. In particular, a dated compatibility report still mentions a 90-second LiteLLM timeout and the implementation-gap document still says `ckffai.com` is absent from generated config. FOSSIL therefore treats current exact source/config as the operational fact source when those dated docs conflict.
+Some dated LiteLLM documentation lags current source/config. When they conflict, current exact source/config is the operational fact source and the dated prose remains historical evidence.
 
-**Policy for this FOSSIL checkpoint:** do not change LiteLLM code, workflows, routing or deployment.
+Do not change LiteLLM code, workflows, routing, deployment, or model policy from the current FOSSIL lane without separate owner authorization.
 
-## Cognitive-service posture
-
-FOSSIL service contracts remain replaceable:
-
-- `Retriever`;
-- `EmbeddingProvider`;
-- `Reranker`;
-- `ContextProvider`;
-- `ModelService`;
-- `VerificationService`.
-
-Current external service availability must not silently rewrite FOSSIL architecture. Benchmark/model work must continue to record exact requested/actual model/provider/runtime identity, fallback attempts, latency/cost and receipt/trace identity.
-
-## Frozen invariants
+## Frozen authority rules
 
 - stable pack identity is independent of repository/database placement;
 - durable commit precedes replaceable projection;
-- new physical projection build => fresh build-scoped applied ledger;
-- rebuild order => `(recorded_at, event_id)`;
+- new physical projection build gets a fresh build-scoped applied ledger;
+- rebuild order is `(recorded_at, event_id)`;
 - migration compares stable FOSSIL semantics, not graph-native UUIDs;
 - reconstructed evidence cannot silently become verbatim;
 - exact citations resolve to immutable observed bytes/spans;
+- source quality is multidimensional and derivation is explicit;
 - ordinary intellectual revision is append-only;
 - privacy/legal erasure is exceptional tombstone-before-delete with non-resurrection;
-- retrieved/source text is untrusted data;
-- model confidence/tier/agreement is not evidence;
-- gateway fallback does not prove the requested model succeeded;
-- query execution receipts are observability/replay evidence, not mutation authority;
+- active projections/exports respect redaction;
+- Skills contain methodology, not canonical truth;
+- protocol adapters cannot become the durable knowledge model;
+- cognitive services expose provider/version metadata and compete behind interfaces;
+- retrieval rank, reranker score, model confidence, model tier, model agreement, transport health, and CI artifacts do not create truth authority;
+- retrieved/source text is untrusted data and cannot become executable policy merely because it was retrieved;
+- query execution receipts are replay/observability evidence, not canonical truth or mutation authority;
 - agents propose; deterministic validation/policy gates commit durable changes;
-- no provider-specific storage semantics may leak into the FOSSIL domain contract;
-- do not casually rename `src/fossil_core`; legacy `src/dkg` remains only a deprecated compatibility shim where still present.
+- do not casually rename `src/fossil_core`; legacy `src/dkg` is only a deprecated compatibility shim.
 
-## Workflow state
+## Claim / work-state rule
 
-Normal FOSSIL CI/assurance workflows remain repository-owned acceptance surfaces. The Graphiti live workflow remains a replaceable-projection proof, and the real S3-compatible fixture workflow is now part of the secretless storage evidence.
+GitHub issues track live implementation state; repository docs track durable decisions/evidence/contracts.
 
-The active Issue #124 live proof is a separate credential boundary. Ordinary PR code must not gain live cloud credentials merely because the fixture proof passed.
+Before mutation, claim in #94 and immediately re-fetch the ledger. Earliest valid unexpired claim wins. One mutating owner per repo lane unless explicit safe parallelism is declared.
 
-## Next decision boundary
+Close with exact `DONE`, `BLOCKED`, or `RELEASE` evidence.
 
-1. Complete or explicitly block Issue #124 with exact live evidence.
-2. Reconcile its result into #87/#86 and durable docs.
-3. Choose the next **FOSSIL-only** gate from evidence.
-4. Do not automatically schedule Cortex V5 or LiteLLM mutations; those require separate owner authorization.
+## Next-state rule
+
+The immediate next state is mechanical, not aspirational:
+
+1. resolve the current #125 review/configuration items under its existing owner/claim;
+2. obtain same-head secretless harness CI and owner-appropriate review state;
+3. only then run the explicit credentialed #124 workflow against an exact approved SHA when configuration exists;
+4. classify the live result as PASS / `BLOCKED_CREDENTIAL` / `BLOCKED_PROVIDER_COMPATIBILITY` from evidence;
+5. reconcile #87 and select the next **FOSSIL-only** gate from live #94;
+6. do not automatically mutate Cortex V5 or LiteLLM/CKFF.
+
+No production promotion is authorized by this document.


### PR DESCRIPTION
## Purpose

Follow-up to merged PR #126. The main FOSSIL handoff/project docs were reconciled, but `AGENTS.md` still pointed fresh agents to the old post-Gate-2 #48/#47 ordering and the merged docs used checkpoint SHAs in wording that could self-stale after merge.

## Changes

Docs only:
- `AGENTS.md` — current continuation contract: #86/#94 first, #87/#124 active durability lane, Cortex V5 + LiteLLM read-only boundary, claim/engineering rules.
- `docs/HANDOFF_CURRENT.md` — records exact SHAs as historical/checkpoint anchors rather than permanent `current main`, removes the completed parallel-docs lane, and records the current #125 review/configuration findings for future agents.
- `docs/PROJECT_STATE.md` — same current-state reconciliation plus explicit #124 acceptance/checkpoint caveats.

## #124 collision boundary

No #124/PR #125 workflow, harness, runtime, storage adapter, environment, or credential state is changed. The active OBJECT_STORE_LIVE-HARNESS owner remains untouched.

## External repos

No changes to Cortex V5 or LiteLLM/CKFF. They remain read-only unless separately owner-authorized.

## Validation

Compared with merged docs base `771216d79bdaaf324dff30c970c11be65d47d890`: exactly three documentation files changed, with no code/workflow/config files.