### PR TITLE
Fix OBJECT_STORE_LIVE runner-context validation

### DIFF
--- a/.github/workflows/object-store-live.yml
+++ b/.github/workflows/object-store-live.yml
@@ -51,7 +51,6 @@ jobs:
       FOSSIL_TARGET_SHA: ${{ inputs.ref }}
       FOSSIL_SOFTWARE_COMMIT: ${{ inputs.ref }}
       FOSSIL_PROOF_PREFIX: fossil-live-proof/${{ github.run_id }}/${{ github.run_attempt }}
-      FOSSIL_PROOF_RECEIPT_PATH: ${{ runner.temp }}/writer-receipt.json
       OBJECT_STORE_ENDPOINT: ${{ vars.R2_ENDPOINT }}
       OBJECT_STORE_BUCKET: ${{ vars.R2_BUCKET }}
       OBJECT_STORE_REGION: auto
@@ -63,6 +62,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+
+      - name: Set writer receipt path
+        shell: bash
+        run: echo "FOSSIL_PROOF_RECEIPT_PATH=$RUNNER_TEMP/writer-receipt.json" >> "$GITHUB_ENV"
 
       - name: Verify exact target checkout
         shell: bash
@@ -125,7 +128,6 @@ jobs:
       FOSSIL_SOFTWARE_COMMIT: ${{ inputs.ref }}
       FOSSIL_PROOF_PREFIX: ${{ needs.writer.outputs.proof_prefix }}
       FOSSIL_FIXTURE_IDENTITY: ${{ needs.writer.outputs.fixture_identity }}
-      FOSSIL_PROOF_RECEIPT_PATH: ${{ runner.temp }}/rebuild-receipt.json
       OBJECT_STORE_ENDPOINT: ${{ vars.R2_ENDPOINT }}
       OBJECT_STORE_BUCKET: ${{ vars.R2_BUCKET }}
       OBJECT_STORE_REGION: auto
@@ -137,6 +139,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+
+      - name: Set rebuild receipt path
+        shell: bash
+        run: echo "FOSSIL_PROOF_RECEIPT_PATH=$RUNNER_TEMP/rebuild-receipt.json" >> "$GITHUB_ENV"
 
       - name: Verify exact target checkout
         shell: bash

--- a/tests/test_object_store_live_harness.py
+++ b/tests/test_object_store_live_harness.py
@@ -26,12 +26,17 @@ def test_object_store_live_workflow_is_manual_exact_head_and_credential_scoped()
         "fossil-live-proof/${{ github.run_id }}/${{ github.run_attempt }}",
         "python scripts/live_object_store_proof.py write",
         "python scripts/live_object_store_rebuild_proof.py",
+        'FOSSIL_PROOF_RECEIPT_PATH=$RUNNER_TEMP/writer-receipt.json',
+        'FOSSIL_PROOF_RECEIPT_PATH=$RUNNER_TEMP/rebuild-receipt.json',
     ]
     for needle in required:
         assert needle in workflow, f"missing live object-store safety contract: {needle}"
 
     assert "pull_request:" not in workflow
     assert "push:" not in workflow
+    # The runner context is not valid in jobs.<job_id>.env. Resolve temporary
+    # paths only after the hosted runner has started.
+    assert "FOSSIL_PROOF_RECEIPT_PATH: ${{ runner.temp }}" not in workflow
 
 
 def test_writer_hands_runner_b_only_prefix_and_deterministic_fixture_identity() -> None:


### PR DESCRIPTION
Follow-up to #125 under #124/#94.

The merged manual workflow was rejected during GitHub workflow planning because `runner.temp` was referenced from `jobs.<job_id>.env`, where the `runner` context is unavailable. This PR resolves the receipt paths after each hosted runner starts by writing `$RUNNER_TEMP/...` through `$GITHUB_ENV`.

Scope is exactly two files: the manual workflow and its deterministic contract test. No live credentialed dispatch, provider selection, production action, or Cortex V5/LiteLLM change is included.