### PR TITLE
Wire OBJECT_STORE_LIVE to existing R2 proof setup

### DIFF
--- a/.github/workflows/object-store-live.yml
+++ b/.github/workflows/object-store-live.yml
@@ -43,7 +43,7 @@ jobs:
     needs: preflight
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment: object-store-live
+    environment: r2-proof
     outputs:
       proof_prefix: ${{ steps.proof_outputs.outputs.proof_prefix }}
       fixture_identity: ${{ steps.proof_outputs.outputs.fixture_identity }}
@@ -51,11 +51,11 @@ jobs:
       FOSSIL_TARGET_SHA: ${{ inputs.ref }}
       FOSSIL_SOFTWARE_COMMIT: ${{ inputs.ref }}
       FOSSIL_PROOF_PREFIX: fossil-live-proof/${{ github.run_id }}/${{ github.run_attempt }}
-      OBJECT_STORE_ENDPOINT: ${{ vars.R2_ENDPOINT }}
-      OBJECT_STORE_BUCKET: ${{ vars.R2_BUCKET }}
+      OBJECT_STORE_ENDPOINT: ${{ vars.R2_ENDPOINT || vars.FOSSIL_R2_ENDPOINT }}
+      OBJECT_STORE_BUCKET: ${{ vars.R2_BUCKET || vars.FOSSIL_R2_BUCKET }}
       OBJECT_STORE_REGION: auto
-      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID || secrets.FOSSIL_R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY || secrets.FOSSIL_R2_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: auto
       AWS_EC2_METADATA_DISABLED: "true"
     steps:
@@ -122,17 +122,17 @@ jobs:
     needs: writer
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment: object-store-live
+    environment: r2-proof
     env:
       FOSSIL_TARGET_SHA: ${{ inputs.ref }}
       FOSSIL_SOFTWARE_COMMIT: ${{ inputs.ref }}
       FOSSIL_PROOF_PREFIX: ${{ needs.writer.outputs.proof_prefix }}
       FOSSIL_FIXTURE_IDENTITY: ${{ needs.writer.outputs.fixture_identity }}
-      OBJECT_STORE_ENDPOINT: ${{ vars.R2_ENDPOINT }}
-      OBJECT_STORE_BUCKET: ${{ vars.R2_BUCKET }}
+      OBJECT_STORE_ENDPOINT: ${{ vars.R2_ENDPOINT || vars.FOSSIL_R2_ENDPOINT }}
+      OBJECT_STORE_BUCKET: ${{ vars.R2_BUCKET || vars.FOSSIL_R2_BUCKET }}
       OBJECT_STORE_REGION: auto
-      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID || secrets.FOSSIL_R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY || secrets.FOSSIL_R2_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: auto
       AWS_EC2_METADATA_DISABLED: "true"
     steps:

--- a/tests/test_object_store_live_harness.py
+++ b/tests/test_object_store_live_harness.py
@@ -15,13 +15,17 @@ def test_object_store_live_workflow_is_manual_exact_head_and_credential_scoped()
 
     required = [
         "workflow_dispatch:",
-        "environment: object-store-live",
+        "environment: r2-proof",
         "ref: ${{ inputs.ref }}",
         "git rev-parse HEAD",
         "vars.R2_ENDPOINT",
+        "vars.FOSSIL_R2_ENDPOINT",
         "vars.R2_BUCKET",
+        "vars.FOSSIL_R2_BUCKET",
         "secrets.R2_ACCESS_KEY_ID",
+        "secrets.FOSSIL_R2_ACCESS_KEY_ID",
         "secrets.R2_SECRET_ACCESS_KEY",
+        "secrets.FOSSIL_R2_SECRET_ACCESS_KEY",
         "AWS_EC2_METADATA_DISABLED: \"true\"",
         "fossil-live-proof/${{ github.run_id }}/${{ github.run_attempt }}",
         "python scripts/live_object_store_proof.py write",
@@ -32,6 +36,7 @@ def test_object_store_live_workflow_is_manual_exact_head_and_credential_scoped()
     for needle in required:
         assert needle in workflow, f"missing live object-store safety contract: {needle}"
 
+    assert "environment: object-store-live" not in workflow
     assert "pull_request:" not in workflow
     assert "push:" not in workflow
     # The runner context is not valid in jobs.<job_id>.env. Resolve temporary


### PR DESCRIPTION
Reconciles #124 with the owner's already-provisioned GitHub Environment instead of requiring duplicate credentials.

Scope is intentionally limited to the workflow boundary and its contract test:
- use existing `r2-proof` environment;
- accept both current `R2_*` and existing `FOSSIL_R2_*` variable/secret names;
- preserve manual dispatch, exact-SHA checkout, fail-closed validation, fresh-runner rebuild, redaction/non-resurrection, and provider-neutral storage semantics;
- no secret values are read or copied.

This does not run the live proof from PR code. After merge, the trusted default-branch manual workflow remains the credentialed gate.