### PR TITLE
Fix R2 object-scoped access preflight

### DIFF
--- a/scripts/live_object_store_proof.py
+++ b/scripts/live_object_store_proof.py
@@ -187,13 +187,38 @@ def _assert_raises(exc_type: type[BaseException], func: Any, message: str) -> No
     raise RuntimeError(message)
 
 
+def _verify_bucket_access(client: CountingClient, *, bucket: str, prefix: str) -> None:
+    """Verify bucket access with the object-scoped S3 operation we need.
+
+    R2 Object Read & Write credentials are scoped to objects in the proof
+    bucket.  ``HeadBucket`` is a bucket-level probe and can be rejected by a
+    correctly scoped credential even when the bucket, endpoint, and object
+    permissions are valid.  Listing only this run's empty proof prefix checks
+    the same endpoint/bucket and the required object-list capability without
+    enumerating unrelated remote state.
+    """
+
+    response = client.list_objects_v2(
+        Bucket=bucket,
+        Prefix=f"{prefix.strip('/')}/",
+        MaxKeys=1,
+    )
+    if (
+        not isinstance(response, dict)
+        or not isinstance(response.get("KeyCount"), int)
+        or not isinstance(response.get("IsTruncated"), bool)
+    ):
+        raise RuntimeError("object-store access probe returned a malformed response")
+
+
 def write_phase() -> None:
     started = time.monotonic()
     bucket = _required("OBJECT_STORE_BUCKET")
     software_commit = _required("FOSSIL_SOFTWARE_COMMIT")
+    proof_prefix = _prefix()
     client, artifacts, events = _stores()
 
-    client.head_bucket(Bucket=bucket)
+    _verify_bucket_access(client, bucket=bucket, prefix=proof_prefix)
 
     artifact_payload = b"FOSSIL OBJECT_STORE_LIVE canonical artifact v1\n"
     artifact = artifacts.put_bytes(artifact_payload, media_type="text/plain")

--- a/tests/test_object_store_live_harness.py
+++ b/tests/test_object_store_live_harness.py
@@ -79,8 +79,15 @@ def test_object_store_live_script_is_provider_neutral_and_fail_closed() -> None:
         "FOSSIL_PROOF_PREFIX",
         "writer-receipt.json",
         "rebuild-receipt.json",
+        "list_objects_v2",
+        "Prefix=f\"{prefix.strip('/')}/\"",
     ]:
         assert needle in source, f"missing live proof semantic: {needle}"
+
+    # Object-scoped R2 credentials may list objects in the proof bucket but
+    # reject the bucket-level HeadBucket probe.  Keep preflight scoped to the
+    # unique run prefix and never regress to that broader bucket operation.
+    assert "head_bucket" not in source
 
     # Provider-specific secret names belong at the workflow boundary, not in the
     # provider-neutral proof implementation or receipts.


### PR DESCRIPTION
## Summary

- replace the bucket-level `HeadBucket` preflight with a prefix-scoped `ListObjectsV2` probe
- keep the probe under the unique `fossil-live-proof/<run>/<attempt>/` prefix
- reject malformed probe responses and add a regression guard against `HeadBucket`

## Root cause

Cloudflare R2 bucket-scoped Object Read & Write credentials can list objects in the proof bucket while rejecting the broader bucket-level `HeadBucket` probe with HTTP 400. Cloudflare API verification confirmed bucket `fossil` exists in account `ea7c350a04679c4e3354157427736297`, jurisdiction `default`, location `ENAM`, with the default endpoint shape. The acceptance needs object-list access for the isolated prefix, not a bucket-owner probe.

## Validation

- `python -m pytest -q`
- 280 passed, 1 skipped

No credentials or secret values are included.