### PR TITLE
Clarify proprietary all-rights-reserved licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+FOSSIL PROPRIETARY RIGHTS NOTICE
+
+Copyright © 2026 Pukujan. All rights reserved.
+
+This repository and its original contents are proprietary software and are not open source.
+
+No license is granted to any person or entity to use, copy, modify, merge, publish, distribute, sublicense, sell, host, deploy, or create derivative works from this software or its original contents, in whole or in part, without prior express written permission from the copyright holder.
+
+Public availability of source code does not grant additional permission to use it. Viewing or forking through GitHub is subject only to the rights provided by GitHub's Terms of Service and does not create any additional license from the copyright holder.
+
+Third-party software, dependencies, data, documentation, or other materials included in or referenced by this repository remain subject to their respective licenses, terms, and rights holders.
+
+THE SOFTWARE AND ORIGINAL REPOSITORY CONTENTS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THE COPYRIGHT HOLDER SHALL NOT BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY ARISING FROM OR IN CONNECTION WITH THE SOFTWARE OR ITS USE.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ A local-first, migration-safe knowledge system for durable research and agent me
 
 The durable substrate is **DICS — Durable Intellectual Corpus System**.
 
+## License and rights
+
+**FOSSIL is proprietary software and is not open source.**
+
+Copyright © 2026 Pukujan. **All rights reserved.** No license is granted to use, copy, modify, distribute, sublicense, sell, host, deploy, or create derivative works from this repository or its original contents, in whole or in part, without prior express written permission from the copyright holder.
+
+Public visibility of this repository does not grant additional permission to use the code. Viewing or forking through GitHub remains subject only to the rights provided by GitHub's Terms of Service. Third-party software, dependencies, data, and other materials remain subject to their respective licenses and rights holders.
+
+See [`LICENSE`](LICENSE) for the repository's proprietary rights notice.
+
 ## Repository family
 
 - `fossil-core` — architecture, contracts, durable event/artifact core, projection adapters, storage/rebuild machinery, benchmarks, and project control plane;


### PR DESCRIPTION
## Scope

Docs/legal-notice only.

- add a prominent README notice that FOSSIL is proprietary and not open source;
- add a root `LICENSE` proprietary-rights notice;
- state that no license is granted to use/copy/modify/distribute/sublicense/sell/host/deploy/create derivatives without prior written permission;
- clarify that public GitHub visibility only carries the rights GitHub's Terms of Service provide for viewing/forking;
- preserve third-party licenses/rights separately.

No runtime, architecture, workflow, retrieval, Cortex, LiteLLM, or durability-gate changes.

Current repository check found no root LICENSE file, no PEP 621 license metadata, and no matching prior `license` commit in repository commit search. This PR does not make any claim about revoking rights that might have been granted outside the repository or under any historical external agreement.