### PR TITLE
[ARCH-P0] Freeze modularization dependency and public-API baseline

### DIFF
--- a/docs/architecture/modularization-phase0.md
+++ b/docs/architecture/modularization-phase0.md
@@ -1,0 +1,110 @@
+# FOSSIL modularization Phase 0 baseline
+
+Status: implementation baseline for #82 under architecture authority #81 and #86.
+
+This document freezes the dependency direction and migration rules before any structural package move. It does not change runtime behavior, storage semantics, identifiers, schemas, hashes, provider selection, or acceptance criteria.
+
+## Current package baseline
+
+`src/fossil_core/` is still predominantly a flat package. The first storage seam already exists, but its components are top-level modules:
+
+- `storage_ports.py` — provider-neutral storage Protocols.
+- `artifact_store.py` — filesystem/local artifact implementation and current concrete public export.
+- `event_store.py` — filesystem/local durable event implementation and current concrete public export.
+- `s3_storage.py` — S3-compatible artifact/event adapter.
+- `projection/` — the main existing bounded subpackage.
+
+The package root currently declares an explicit `__all__` surface. Phase 0 records that list as the **declared compatibility baseline**, not as a decision that every current concrete export must remain permanent. Direct submodule imports that exist today are migration inputs and must not be broken accidentally during the bounded refactor.
+
+Run the mechanical inventory with:
+
+```bash
+python scripts/architecture_inventory.py --pretty
+```
+
+The command parses source with the Python AST and does not import or execute `fossil_core`. It reports:
+
+- every Python module under `src/fossil_core`;
+- first-party `fossil_core` import edges; and
+- the package-root `__all__` declaration.
+
+The output is deterministic so two revisions can be compared mechanically during migration.
+
+## Target dependency direction
+
+The modular monolith target is:
+
+```text
+domain        -> no adapters/providers/runtime infrastructure
+ports         -> stable interfaces and types around domain/application capabilities
+application   -> orchestrates domain through ports, not concrete providers
+adapters      -> implements ports (filesystem, S3, Graphiti, Neo4j, vector, etc.)
+api/config    -> composition and wiring; never durable semantic authority
+```
+
+Allowed direction is inward toward domain/contracts. Provider dependencies stay at the adapter/composition edge.
+
+The following are architectural violations once the corresponding bounded packages exist:
+
+1. `domain -> adapters` imports.
+2. `domain -> provider SDK` imports.
+3. application code importing a concrete provider when an established port exists.
+4. provider-specific configuration changing durable identities, event schemas, canonical hashes, lifecycle semantics, redaction semantics, or rebuild truth.
+5. circular dependencies introduced to preserve an old flat import path.
+
+## Migration invariants
+
+Every package-move PR must satisfy all of the following:
+
+1. **Behavior freeze.** A move is not a feature change.
+2. **One bounded responsibility per PR.** No repository-wide mega-restructure.
+3. **Compatibility first.** Old supported paths remain thin forwarding imports until consumers migrate.
+4. **Stable durable truth.** IDs, canonical bytes/hashes, schemas, event ordering, provenance, lifecycle, redaction, conflict, and rebuild semantics remain unchanged.
+5. **Provider neutrality.** R2 remains a live S3-compatible candidate, not domain truth.
+6. **Exact-head verification.** Focused tests, the full deterministic suite, and required hosted gates remain at least as strict as before the move.
+7. **No architecture theater.** Do not create empty target directories in advance of moving a real responsibility.
+
+## First implementation slice after Phase 0
+
+Storage is the first bounded move because the provider-neutral seam and live proof already exist. The approximate target is:
+
+```text
+fossil_core/
+  ports/
+    artifact_store.py
+    event_store.py
+  adapters/
+    filesystem/
+    s3/
+```
+
+The move order is deliberately narrow:
+
+1. place the existing storage port definitions behind bounded `ports` paths without semantic changes;
+2. retain compatibility imports from `fossil_core.storage_ports`;
+3. move filesystem implementations behind `adapters/filesystem` while keeping supported compatibility paths;
+4. move the S3-compatible implementation behind `adapters/s3`;
+5. run the same storage contract suite against filesystem and S3 implementations;
+6. only after the imports are stable, add CI enforcement for dependency direction.
+
+No storage provider, production topology, microservice split, ContextProvider policy, or retrieval policy decision is part of that slice.
+
+## Public API policy during migration
+
+Until a later Phase 3 API reduction is explicitly approved:
+
+- the current package-root `__all__` is treated as a compatibility baseline;
+- removing or renaming an existing root export requires an explicit migration/deprecation decision;
+- new internal bounded paths do not automatically become permanent public API;
+- first-party consumers should migrate toward capability/contract imports rather than provider implementation details;
+- compatibility shims are temporary and tested, with removal handled in an explicit cleanup phase.
+
+## Phase 0 exit criteria
+
+Phase 0 is complete when:
+
+- the deterministic inventory tool is green in the normal test suite;
+- the current declared root API is mechanically recorded;
+- dependency direction and migration invariants are documented;
+- no runtime behavior or package path has moved; and
+- the next PR can perform the first storage port/adapter move with a small, reviewable diff.

--- a/scripts/architecture_inventory.py
+++ b/scripts/architecture_inventory.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+PACKAGE = "fossil_core"
+
+
+def _module_name(path: Path, source_root: Path) -> str:
+    relative = path.relative_to(source_root)
+    parts = list(relative.with_suffix("").parts)
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _package_for(module: str, path: Path) -> str:
+    if path.name == "__init__.py":
+        return module
+    return module.rpartition(".")[0]
+
+
+def _resolve_from(module: str | None, level: int, package: str) -> str | None:
+    if level == 0:
+        return module
+
+    package_parts = package.split(".") if package else []
+    trim = level - 1
+    if trim > len(package_parts):
+        return None
+    base = package_parts[: len(package_parts) - trim]
+    if module:
+        base.extend(module.split("."))
+    return ".".join(base)
+
+
+def _declared_exports(init_path: Path) -> list[str]:
+    tree = ast.parse(init_path.read_text(encoding="utf-8"), filename=str(init_path))
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if not any(isinstance(target, ast.Name) and target.id == "__all__" for target in targets):
+            continue
+        value = node.value
+        if value is None:
+            break
+        exports = ast.literal_eval(value)
+        if not isinstance(exports, (list, tuple)) or not all(
+            isinstance(item, str) for item in exports
+        ):
+            raise ValueError("fossil_core.__all__ must be a literal list/tuple of strings")
+        return list(exports)
+    return []
+
+
+def inventory(repo_root: Path) -> dict[str, Any]:
+    source_root = repo_root / "src"
+    package_root = source_root / PACKAGE
+    if not package_root.is_dir():
+        raise FileNotFoundError(f"missing package root: {package_root}")
+
+    modules: dict[str, dict[str, Any]] = {}
+    edges: set[tuple[str, str]] = set()
+
+    for path in sorted(package_root.rglob("*.py")):
+        module = _module_name(path, source_root)
+        package = _package_for(module, path)
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        imports: set[str] = set()
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == PACKAGE or alias.name.startswith(f"{PACKAGE}."):
+                        imports.add(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                resolved = _resolve_from(node.module, node.level, package)
+                if resolved and (
+                    resolved == PACKAGE or resolved.startswith(f"{PACKAGE}.")
+                ):
+                    imports.add(resolved)
+
+        for imported in imports:
+            edges.add((module, imported))
+
+        modules[module] = {
+            "path": path.relative_to(repo_root).as_posix(),
+            "internal_imports": sorted(imports),
+        }
+
+    declared_public_api = _declared_exports(package_root / "__init__.py")
+    return {
+        "schema": "fossil.architecture-inventory.v1",
+        "package": PACKAGE,
+        "declared_public_api": declared_public_api,
+        "modules": dict(sorted(modules.items())),
+        "internal_import_edges": [
+            {"from": source, "to": target} for source, target in sorted(edges)
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Emit a deterministic, import-free inventory of fossil_core."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="repository root (defaults to the parent of scripts/)",
+    )
+    parser.add_argument("--pretty", action="store_true")
+    args = parser.parse_args()
+
+    payload = inventory(args.repo_root.resolve())
+    if args.pretty:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_architecture_inventory.py
+++ b/tests/test_architecture_inventory.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "architecture_inventory.py"
+
+
+def _load_inventory_module():
+    spec = importlib.util.spec_from_file_location("architecture_inventory", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_architecture_inventory_is_import_free_and_tracks_storage_seams():
+    module = _load_inventory_module()
+    payload = module.inventory(ROOT)
+
+    assert payload["schema"] == "fossil.architecture-inventory.v1"
+    assert "fossil_core.storage_ports" in payload["modules"]
+    assert "fossil_core.s3_storage" in payload["modules"]
+    assert "fossil_core.artifact_store" in payload["modules"]
+    assert "fossil_core.event_store" in payload["modules"]
+
+
+def test_declared_package_root_api_is_explicit_baseline():
+    module = _load_inventory_module()
+    payload = module.inventory(ROOT)
+
+    assert payload["declared_public_api"] == [
+        "ArtifactIntegrityError",
+        "ArtifactStore",
+        "DurableEventStore",
+        "IdempotencyConflict",
+        "KnowledgeState",
+        "LifecycleError",
+        "RelationRecord",
+        "KnowledgePackValidator",
+        "PackAccess",
+        "PackBoundaryError",
+        "build_promotion_event",
+    ]
+
+
+def test_inventory_output_is_deterministic():
+    module = _load_inventory_module()
+    first = module.inventory(ROOT)
+    second = module.inventory(ROOT)
+
+    assert first == second
+    assert first["internal_import_edges"] == sorted(
+        first["internal_import_edges"], key=lambda edge: (edge["from"], edge["to"])
+    )


### PR DESCRIPTION
Closes the planning portion of #82 Phase 0 and prepares the first bounded storage modularization slice.

## Scope
- add deterministic, import-free `fossil_core` AST inventory tooling
- mechanically freeze the currently declared package-root `__all__` compatibility baseline
- document target dependency direction and migration invariants
- identify storage ports/adapters as the first bounded implementation slice

## Explicit non-goals
- no module/package moves
- no runtime behavior changes
- no storage/provider semantic changes
- no schema, stable-ID, canonical-hash, provenance, lifecycle, redaction, or rebuild changes
- no acceptance weakening
- no microservices or provider lock-in

## Verification
- focused architecture inventory tests
- full deterministic suite via hosted CI
- exact-head required workflows before merge readiness

Parent: #82
Architecture: #81, #86
OBJECT_STORE_LIVE gate: PASS run 31972764091 on base SHA `b5730a6b65e3923395d7af99a26073a9e9c935f1`.