### PR TITLE
[ARCH-P1] Move storage ports behind canonical package boundaries

### DIFF
--- a/src/fossil_core/ports/__init__.py
+++ b/src/fossil_core/ports/__init__.py
@@ -1,0 +1,6 @@
+"""Provider-neutral interfaces for FOSSIL capabilities."""
+
+from .artifact_store import ArtifactStorePort
+from .event_store import EventStorePort
+
+__all__ = ["ArtifactStorePort", "EventStorePort"]

--- a/src/fossil_core/ports/artifact_store.py
+++ b/src/fossil_core/ports/artifact_store.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ArtifactStorePort(Protocol):
+    """Durable artifact semantics independent of a physical storage provider."""
+
+    def put_bytes(
+        self,
+        data: bytes,
+        *,
+        media_type: str = "application/octet-stream",
+    ) -> dict[str, Any]: ...
+
+    def put_file(
+        self,
+        path: Path,
+        *,
+        media_type: str = "application/octet-stream",
+    ) -> dict[str, Any]: ...
+
+    def get_manifest(self, artifact_id: str) -> dict[str, Any]: ...
+
+    def is_redacted(self, artifact_id: str) -> bool: ...
+
+    def get_redaction(self, artifact_id: str) -> dict[str, Any] | None: ...
+
+    def read_bytes(self, artifact_id: str) -> bytes: ...
+
+    def verify(self, artifact_id: str) -> bool: ...
+
+    def redact(
+        self,
+        artifact_id: str,
+        *,
+        reason: str,
+        authority: str,
+        redacted_at: str,
+        request_ref: str | None = None,
+    ) -> dict[str, Any]: ...

--- a/src/fossil_core/ports/event_store.py
+++ b/src/fossil_core/ports/event_store.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any, Iterator, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class EventStorePort(Protocol):
+    """Durable event semantics independent of a physical storage provider."""
+
+    def prepare(self, event: dict[str, Any]) -> dict[str, Any]: ...
+
+    def validate(self, event: dict[str, Any]) -> dict[str, Any]: ...
+
+    def is_redacted(self, event_id: str) -> bool: ...
+
+    def get_redaction(self, event_id: str) -> dict[str, Any] | None: ...
+
+    def iter_redactions(self) -> Iterator[dict[str, Any]]: ...
+
+    def commit(self, event: dict[str, Any]) -> dict[str, Any]: ...
+
+    def get(self, event_id: str) -> dict[str, Any]: ...
+
+    def redact(
+        self,
+        event_id: str,
+        *,
+        reason: str,
+        authority: str,
+        redacted_at: str,
+        request_ref: str | None = None,
+    ) -> dict[str, Any]: ...
+
+    def iter_events(self) -> Iterator[dict[str, Any]]: ...

--- a/src/fossil_core/storage_ports.py
+++ b/src/fossil_core/storage_ports.py
@@ -1,74 +1,10 @@
-from __future__ import annotations
+"""Compatibility aliases for the canonical :mod:`fossil_core.ports` interfaces.
 
-from pathlib import Path
-from typing import Any, Iterator, Protocol, runtime_checkable
+New code should import storage contracts from ``fossil_core.ports`` or its
+bounded modules. This module remains intentionally thin while existing callers
+migrate; the exported objects are the canonical protocol classes themselves.
+"""
 
+from .ports import ArtifactStorePort, EventStorePort
 
-@runtime_checkable
-class ArtifactStorePort(Protocol):
-    """Durable artifact semantics independent of a physical storage provider."""
-
-    def put_bytes(
-        self,
-        data: bytes,
-        *,
-        media_type: str = "application/octet-stream",
-    ) -> dict[str, Any]: ...
-
-    def put_file(
-        self,
-        path: Path,
-        *,
-        media_type: str = "application/octet-stream",
-    ) -> dict[str, Any]: ...
-
-    def get_manifest(self, artifact_id: str) -> dict[str, Any]: ...
-
-    def is_redacted(self, artifact_id: str) -> bool: ...
-
-    def get_redaction(self, artifact_id: str) -> dict[str, Any] | None: ...
-
-    def read_bytes(self, artifact_id: str) -> bytes: ...
-
-    def verify(self, artifact_id: str) -> bool: ...
-
-    def redact(
-        self,
-        artifact_id: str,
-        *,
-        reason: str,
-        authority: str,
-        redacted_at: str,
-        request_ref: str | None = None,
-    ) -> dict[str, Any]: ...
-
-
-@runtime_checkable
-class EventStorePort(Protocol):
-    """Durable event semantics independent of a physical storage provider."""
-
-    def prepare(self, event: dict[str, Any]) -> dict[str, Any]: ...
-
-    def validate(self, event: dict[str, Any]) -> dict[str, Any]: ...
-
-    def is_redacted(self, event_id: str) -> bool: ...
-
-    def get_redaction(self, event_id: str) -> dict[str, Any] | None: ...
-
-    def iter_redactions(self) -> Iterator[dict[str, Any]]: ...
-
-    def commit(self, event: dict[str, Any]) -> dict[str, Any]: ...
-
-    def get(self, event_id: str) -> dict[str, Any]: ...
-
-    def redact(
-        self,
-        event_id: str,
-        *,
-        reason: str,
-        authority: str,
-        redacted_at: str,
-        request_ref: str | None = None,
-    ) -> dict[str, Any]: ...
-
-    def iter_events(self) -> Iterator[dict[str, Any]]: ...
+__all__ = ["ArtifactStorePort", "EventStorePort"]

--- a/tests/test_storage_port_compatibility.py
+++ b/tests/test_storage_port_compatibility.py
@@ -7,6 +7,7 @@ from fossil_core.event_store import DurableEventStore
 from fossil_core.ports import ArtifactStorePort, EventStorePort
 from fossil_core.ports.artifact_store import ArtifactStorePort as BoundedArtifactStorePort
 from fossil_core.ports.event_store import EventStorePort as BoundedEventStorePort
+from fossil_core.s3_storage import S3ArtifactStore, S3DurableEventStore
 from fossil_core.storage_ports import ArtifactStorePort as LegacyArtifactStorePort
 from fossil_core.storage_ports import EventStorePort as LegacyEventStorePort
 
@@ -25,6 +26,19 @@ def test_legacy_storage_port_paths_alias_canonical_protocols():
 def test_existing_filesystem_stores_satisfy_canonical_ports(tmp_path):
     artifact_store = ArtifactStore(tmp_path / "artifacts")
     event_store = DurableEventStore(tmp_path / "events", SCHEMA)
+
+    assert isinstance(artifact_store, ArtifactStorePort)
+    assert isinstance(event_store, EventStorePort)
+
+
+def test_existing_s3_stores_satisfy_canonical_ports_without_remote_calls():
+    inert_client = object()
+    artifact_store = S3ArtifactStore(bucket="contract-only", client=inert_client)
+    event_store = S3DurableEventStore(
+        bucket="contract-only",
+        schema_path=SCHEMA,
+        client=inert_client,
+    )
 
     assert isinstance(artifact_store, ArtifactStorePort)
     assert isinstance(event_store, EventStorePort)

--- a/tests/test_storage_port_compatibility.py
+++ b/tests/test_storage_port_compatibility.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fossil_core.artifact_store import ArtifactStore
+from fossil_core.event_store import DurableEventStore
+from fossil_core.ports import ArtifactStorePort, EventStorePort
+from fossil_core.ports.artifact_store import ArtifactStorePort as BoundedArtifactStorePort
+from fossil_core.ports.event_store import EventStorePort as BoundedEventStorePort
+from fossil_core.storage_ports import ArtifactStorePort as LegacyArtifactStorePort
+from fossil_core.storage_ports import EventStorePort as LegacyEventStorePort
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "events" / "v1.schema.json"
+
+
+def test_legacy_storage_port_paths_alias_canonical_protocols():
+    assert LegacyArtifactStorePort is ArtifactStorePort is BoundedArtifactStorePort
+    assert LegacyEventStorePort is EventStorePort is BoundedEventStorePort
+    assert ArtifactStorePort.__module__ == "fossil_core.ports.artifact_store"
+    assert EventStorePort.__module__ == "fossil_core.ports.event_store"
+
+
+def test_existing_filesystem_stores_satisfy_canonical_ports(tmp_path):
+    artifact_store = ArtifactStore(tmp_path / "artifacts")
+    event_store = DurableEventStore(tmp_path / "events", SCHEMA)
+
+    assert isinstance(artifact_store, ArtifactStorePort)
+    assert isinstance(event_store, EventStorePort)


### PR DESCRIPTION
Advances #82 Phase 1 with the smallest storage-boundary move.

## Scope
- establish canonical `fossil_core.ports.artifact_store.ArtifactStorePort`
- establish canonical `fossil_core.ports.event_store.EventStorePort`
- expose both through `fossil_core.ports`
- retain `fossil_core.storage_ports` as a thin compatibility alias layer
- prove legacy and canonical imports resolve to the same protocol class objects
- prove the existing filesystem and S3-compatible stores structurally satisfy the canonical runtime-checkable ports

## Compatibility
The package-root `fossil_core.__all__` baseline is unchanged. Existing `fossil_core.storage_ports` imports remain valid and alias the canonical protocol objects.

## Explicit non-goals
- no filesystem implementation move
- no S3 implementation move
- no behavior or storage-semantic changes
- no schema, stable-ID, canonical-hash, redaction, conflict, or rebuild changes
- no provider/runtime configuration changes
- no workflow/acceptance weakening

## Verification
- focused storage port compatibility tests
- full deterministic DKG suite on exact PR head
- review/merge with SHA fencing; final-main DKG required

Parent: #82
Architecture: #81, #86
Base: `212cf5bd0f70f66e0a7e56fc0418cb6d1392f1d8`