### PR TITLE
[ARCH-P2] Enforce established package boundaries in CI

### DIFF
--- a/.github/workflows/dependency-integrity.yml
+++ b/.github/workflows/dependency-integrity.yml
@@ -6,18 +6,37 @@ on:
     paths:
       - "pyproject.toml"
       - "src/**"
+      - "scripts/architecture_inventory.py"
+      - "scripts/check_architecture_boundaries.py"
+      - "tests/test_architecture_inventory.py"
+      - "tests/test_architecture_boundaries.py"
       - ".github/workflows/dependency-integrity.yml"
   push:
     branches: [main]
     paths:
       - "pyproject.toml"
       - "src/**"
+      - "scripts/architecture_inventory.py"
+      - "scripts/check_architecture_boundaries.py"
+      - "tests/test_architecture_inventory.py"
+      - "tests/test_architecture_boundaries.py"
       - ".github/workflows/dependency-integrity.yml"
 
 permissions:
   contents: read
 
 jobs:
+  architecture-boundaries:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Enforce modular-monolith dependency boundaries
+        run: python scripts/check_architecture_boundaries.py
+
   pyproject-consistency:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from architecture_inventory import inventory
+
+
+PACKAGE = "fossil_core"
+CANONICAL_MODULES = {
+    "fossil_core.ports",
+    "fossil_core.ports.artifact_store",
+    "fossil_core.ports.event_store",
+    "fossil_core.adapters",
+    "fossil_core.adapters.filesystem",
+    "fossil_core.adapters.filesystem.artifact_store",
+    "fossil_core.adapters.filesystem.event_store",
+    "fossil_core.adapters.s3",
+    "fossil_core.adapters.s3.storage",
+}
+
+COMPATIBILITY_IMPORTS = {
+    "fossil_core.storage_ports": {"fossil_core.ports"},
+    "fossil_core.artifact_store": {
+        "fossil_core.adapters.filesystem.artifact_store"
+    },
+    "fossil_core.event_store": {"fossil_core.adapters.filesystem.event_store"},
+    "fossil_core.s3_storage": {"fossil_core.adapters.s3"},
+}
+
+PORT_FORBIDDEN_PREFIXES = (
+    "fossil_core.adapters",
+    "fossil_core.artifact_store",
+    "fossil_core.event_store",
+    "fossil_core.s3_storage",
+)
+
+ADAPTER_SELF_SHIMS = {
+    "fossil_core.adapters.filesystem": {
+        "fossil_core.artifact_store",
+        "fossil_core.event_store",
+    },
+    "fossil_core.adapters.s3": {"fossil_core.s3_storage"},
+}
+
+
+def _matches_prefix(module: str, prefix: str) -> bool:
+    return module == prefix or module.startswith(f"{prefix}.")
+
+
+def _edges(payload: dict[str, Any]) -> dict[str, set[str]]:
+    modules = set(payload["modules"])
+    graph: dict[str, set[str]] = {module: set() for module in modules}
+    for edge in payload["internal_import_edges"]:
+        source = str(edge["from"])
+        target = str(edge["to"])
+        if source in modules and target in modules:
+            graph[source].add(target)
+    return graph
+
+
+def _strongly_connected_components(
+    graph: dict[str, set[str]],
+) -> list[tuple[str, ...]]:
+    """Return deterministic first-party cycles as strongly connected components."""
+
+    index = 0
+    indices: dict[str, int] = {}
+    lowlinks: dict[str, int] = {}
+    stack: list[str] = []
+    on_stack: set[str] = set()
+    components: list[tuple[str, ...]] = []
+
+    def visit(node: str) -> None:
+        nonlocal index
+        indices[node] = index
+        lowlinks[node] = index
+        index += 1
+        stack.append(node)
+        on_stack.add(node)
+
+        for target in sorted(graph[node]):
+            if target not in indices:
+                visit(target)
+                lowlinks[node] = min(lowlinks[node], lowlinks[target])
+            elif target in on_stack:
+                lowlinks[node] = min(lowlinks[node], indices[target])
+
+        if lowlinks[node] != indices[node]:
+            return
+
+        component: list[str] = []
+        while True:
+            member = stack.pop()
+            on_stack.remove(member)
+            component.append(member)
+            if member == node:
+                break
+
+        ordered = tuple(sorted(component))
+        if len(ordered) > 1 or node in graph[node]:
+            components.append(ordered)
+
+    for node in sorted(graph):
+        if node not in indices:
+            visit(node)
+
+    return sorted(components)
+
+
+def violations(payload: dict[str, Any]) -> list[str]:
+    modules = payload["modules"]
+    violations: list[str] = []
+
+    missing = sorted(CANONICAL_MODULES - set(modules))
+    for module in missing:
+        violations.append(f"missing canonical architecture module: {module}")
+
+    for module, expected in sorted(COMPATIBILITY_IMPORTS.items()):
+        details = modules.get(module)
+        if details is None:
+            violations.append(f"missing compatibility module: {module}")
+            continue
+        actual = set(details["internal_imports"])
+        if actual != expected:
+            violations.append(
+                f"compatibility module {module} must stay thin: "
+                f"expected imports {sorted(expected)}, got {sorted(actual)}"
+            )
+
+    for module, details in sorted(modules.items()):
+        internal_imports = set(details["internal_imports"])
+
+        if _matches_prefix(module, "fossil_core.ports"):
+            for imported in sorted(internal_imports):
+                if any(
+                    _matches_prefix(imported, prefix)
+                    for prefix in PORT_FORBIDDEN_PREFIXES
+                ):
+                    violations.append(
+                        f"ports boundary violation: {module} imports {imported}"
+                    )
+
+        for adapter_prefix, forbidden_shims in ADAPTER_SELF_SHIMS.items():
+            if not _matches_prefix(module, adapter_prefix):
+                continue
+            for imported in sorted(internal_imports):
+                if any(
+                    _matches_prefix(imported, shim) for shim in forbidden_shims
+                ):
+                    violations.append(
+                        f"adapter compatibility-cycle risk: {module} imports {imported}"
+                    )
+
+    for component in _strongly_connected_components(_edges(payload)):
+        violations.append(
+            "first-party import cycle: " + " -> ".join(component)
+        )
+
+    return sorted(set(violations))
+
+
+def check(repo_root: Path) -> list[str]:
+    return violations(inventory(repo_root))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail closed on established FOSSIL package-boundary drift."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="repository root (defaults to the parent of scripts/)",
+    )
+    args = parser.parse_args()
+
+    problems = check(args.repo_root.resolve())
+    if problems:
+        print("Architecture boundary check FAILED:")
+        for problem in problems:
+            print(f"- {problem}")
+        return 1
+
+    print("Architecture boundary check PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import check_architecture_boundaries as boundaries  # noqa: E402
+from architecture_inventory import inventory  # noqa: E402
+
+
+def _synthetic_clean_payload() -> dict:
+    modules = {
+        module: {"path": f"src/{module.replace('.', '/')}.py", "internal_imports": []}
+        for module in boundaries.CANONICAL_MODULES
+    }
+    for module, expected in boundaries.COMPATIBILITY_IMPORTS.items():
+        modules[module] = {
+            "path": f"src/{module.replace('.', '/')}.py",
+            "internal_imports": sorted(expected),
+        }
+    return {
+        "schema": "fossil.architecture-inventory.v1",
+        "package": "fossil_core",
+        "declared_public_api": [],
+        "modules": modules,
+        "internal_import_edges": [
+            {"from": source, "to": target}
+            for source, expected in sorted(boundaries.COMPATIBILITY_IMPORTS.items())
+            for target in sorted(expected)
+        ],
+    }
+
+
+def test_current_repository_satisfies_enforced_boundaries():
+    assert boundaries.check(ROOT) == []
+
+
+def test_ports_cannot_depend_on_concrete_adapters():
+    payload = _synthetic_clean_payload()
+    payload["modules"]["fossil_core.ports.artifact_store"]["internal_imports"] = [
+        "fossil_core.adapters.s3"
+    ]
+
+    problems = boundaries.violations(payload)
+
+    assert any("ports boundary violation" in problem for problem in problems)
+
+
+def test_compatibility_modules_must_remain_thin():
+    payload = _synthetic_clean_payload()
+    payload["modules"]["fossil_core.s3_storage"]["internal_imports"].append(
+        "fossil_core.ids"
+    )
+
+    problems = boundaries.violations(payload)
+
+    assert any(
+        "compatibility module fossil_core.s3_storage must stay thin" in problem
+        for problem in problems
+    )
+
+
+def test_adapter_cannot_import_its_own_legacy_shim():
+    payload = _synthetic_clean_payload()
+    payload["modules"]["fossil_core.adapters.s3.storage"]["internal_imports"] = [
+        "fossil_core.s3_storage"
+    ]
+
+    problems = boundaries.violations(payload)
+
+    assert any("adapter compatibility-cycle risk" in problem for problem in problems)
+
+
+def test_first_party_import_cycles_fail_closed():
+    payload = deepcopy(_synthetic_clean_payload())
+    payload["modules"]["fossil_core.ports.artifact_store"]["internal_imports"] = [
+        "fossil_core.ports.event_store"
+    ]
+    payload["modules"]["fossil_core.ports.event_store"]["internal_imports"] = [
+        "fossil_core.ports.artifact_store"
+    ]
+    payload["internal_import_edges"].extend(
+        [
+            {
+                "from": "fossil_core.ports.artifact_store",
+                "to": "fossil_core.ports.event_store",
+            },
+            {
+                "from": "fossil_core.ports.event_store",
+                "to": "fossil_core.ports.artifact_store",
+            },
+        ]
+    )
+
+    problems = boundaries.violations(payload)
+
+    assert any("first-party import cycle" in problem for problem in problems)
+
+
+def test_inventory_remains_the_single_source_of_import_edges():
+    payload = inventory(ROOT)
+
+    assert payload["schema"] == "fossil.architecture-inventory.v1"
+    assert payload["internal_import_edges"] == sorted(
+        payload["internal_import_edges"], key=lambda edge: (edge["from"], edge["to"])
+    )


### PR DESCRIPTION
Advances #82 Phase 2 after the storage ports/filesystem/S3 boundaries landed in #134/#135/#137.

## Scope
- add a deterministic stdlib architecture-boundary checker built on the Phase 0 AST inventory
- fail closed if established `fossil_core.ports` modules depend on adapters or legacy concrete-store shims
- require the four legacy storage compatibility modules to remain thin, exact import-forwarding surfaces
- prevent canonical filesystem/S3 adapters from importing their own legacy shims
- detect first-party import cycles through strongly connected components
- assert the currently established canonical storage boundary modules remain present
- add regression tests for the current repository and synthetic violation cases
- add a blocking `architecture-boundaries` job to `Dependency integrity`
- extend workflow path filters so future checker/inventory/test changes cannot bypass the gate

## Important boundary
This PR enforces only boundaries that actually exist today. It does **not** create empty `domain/` or `application/` packages or pretend those future boundaries are already implemented.

## Explicit non-goals
- no runtime/package moves
- no storage behavior/provider changes
- no schema, stable-ID, canonical-hash, redaction, or rebuild changes
- no package-root public API changes
- no dependency/provider additions
- no acceptance weakening

## Verification
- current-repository architecture check must report zero violations
- synthetic tests prove ports/adapters/shim/cycle violations fail closed
- full deterministic DKG suite
- Dependency integrity including the new blocking architecture job
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `8ebcb9f57e3b14a62b675101b499b8eae210b172`