### PR TITLE
[ARCH-P3] Make Python public API explicit and versioned

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -1,0 +1,131 @@
+{
+  "schema": "fossil.python-public-api.v1",
+  "policy": {
+    "unlisted_modules": "internal_until_explicitly_promoted",
+    "compatibility_modules": "temporary_until_explicit_cleanup_phase",
+    "runtime_deprecation_warnings": false
+  },
+  "surfaces": {
+    "package_root": {
+      "module": "fossil_core",
+      "status": "supported",
+      "symbols": [
+        "ArtifactIntegrityError",
+        "ArtifactStore",
+        "DurableEventStore",
+        "IdempotencyConflict",
+        "KnowledgeState",
+        "LifecycleError",
+        "RelationRecord",
+        "KnowledgePackValidator",
+        "PackAccess",
+        "PackBoundaryError",
+        "build_promotion_event"
+      ]
+    },
+    "storage_ports": {
+      "module": "fossil_core.ports",
+      "status": "supported",
+      "symbols": [
+        "ArtifactStorePort",
+        "EventStorePort"
+      ]
+    },
+    "filesystem_adapter": {
+      "module": "fossil_core.adapters.filesystem",
+      "status": "supported_bounded_adapter",
+      "symbols": [
+        "ArtifactIntegrityError",
+        "ArtifactRedactedError",
+        "ArtifactStore",
+        "DurableEventStore",
+        "EventRedactedError",
+        "EventRedactionConflict",
+        "IdempotencyConflict"
+      ]
+    },
+    "s3_adapter": {
+      "module": "fossil_core.adapters.s3",
+      "status": "supported_bounded_adapter",
+      "symbols": [
+        "RemoteObjectConflict",
+        "RemoteStoreUnavailable",
+        "S3ArtifactStore",
+        "S3DurableEventStore"
+      ]
+    }
+  },
+  "compatibility_modules": {
+    "fossil_core.storage_ports": {
+      "replacement": "fossil_core.ports",
+      "symbols": [
+        "ArtifactStorePort",
+        "EventStorePort"
+      ],
+      "star_exported_symbols": [
+        "ArtifactStorePort",
+        "EventStorePort"
+      ]
+    },
+    "fossil_core.artifact_store": {
+      "replacement": "fossil_core.adapters.filesystem",
+      "symbols": [
+        "ArtifactIntegrityError",
+        "ArtifactRedactedError",
+        "ArtifactStore"
+      ],
+      "star_exported_symbols": [
+        "ArtifactIntegrityError",
+        "ArtifactRedactedError",
+        "ArtifactStore"
+      ]
+    },
+    "fossil_core.event_store": {
+      "replacement": "fossil_core.adapters.filesystem",
+      "symbols": [
+        "DurableEventStore",
+        "EventRedactedError",
+        "EventRedactionConflict",
+        "IdempotencyConflict"
+      ],
+      "star_exported_symbols": [
+        "DurableEventStore",
+        "EventRedactedError",
+        "EventRedactionConflict",
+        "IdempotencyConflict"
+      ]
+    },
+    "fossil_core.s3_storage": {
+      "replacement": "fossil_core.adapters.s3",
+      "symbols": [
+        "RemoteObjectConflict",
+        "RemoteStoreUnavailable",
+        "S3ArtifactStore",
+        "S3DurableEventStore"
+      ],
+      "star_exported_symbols": [
+        "RemoteStoreUnavailable",
+        "S3ArtifactStore",
+        "S3DurableEventStore"
+      ]
+    }
+  },
+  "identity_aliases": [
+    {
+      "source": "fossil_core.ArtifactIntegrityError",
+      "target": "fossil_core.adapters.filesystem.ArtifactIntegrityError"
+    },
+    {
+      "source": "fossil_core.ArtifactStore",
+      "target": "fossil_core.adapters.filesystem.ArtifactStore"
+    },
+    {
+      "source": "fossil_core.DurableEventStore",
+      "target": "fossil_core.adapters.filesystem.DurableEventStore"
+    },
+    {
+      "source": "fossil_core.IdempotencyConflict",
+      "target": "fossil_core.adapters.filesystem.IdempotencyConflict"
+    }
+  ]
+}

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -1,0 +1,89 @@
+# FOSSIL Python public API
+
+Status: Phase 3 public-API contract for #82 under architecture authority #81 and #86.
+
+The machine-readable source of truth is [`contracts/python-public-api-v1.json`](../../contracts/python-public-api-v1.json). Tests must fail if the declared imports, `__all__` surfaces, or compatibility aliases drift from that contract.
+
+## Supported package-root API
+
+The small package-root surface remains supported during modularization:
+
+```python
+from fossil_core import (
+    ArtifactIntegrityError,
+    ArtifactStore,
+    DurableEventStore,
+    IdempotencyConflict,
+    KnowledgeState,
+    LifecycleError,
+    RelationRecord,
+    KnowledgePackValidator,
+    PackAccess,
+    PackBoundaryError,
+    build_promotion_event,
+)
+```
+
+This is the compatibility-stable root surface. Phase 3 does not remove, rename, or warn on any of these imports.
+
+## Canonical provider-neutral storage ports
+
+New code that depends on storage capabilities rather than a concrete implementation should use:
+
+```python
+from fossil_core.ports import ArtifactStorePort, EventStorePort
+```
+
+These are the canonical provider-neutral storage interfaces. Application/domain code should depend on these boundaries rather than on S3/R2/filesystem implementation details when a port is sufficient.
+
+## Canonical concrete adapters
+
+Code that intentionally performs composition/wiring or directly selects a concrete provider may use the bounded adapter packages.
+
+Filesystem:
+
+```python
+from fossil_core.adapters.filesystem import ArtifactStore, DurableEventStore
+```
+
+S3-compatible:
+
+```python
+from fossil_core.adapters.s3 import S3ArtifactStore, S3DurableEventStore
+```
+
+Adapter imports are supported bounded surfaces, but they are not domain truth. Selecting R2, AWS S3, MinIO, local filesystem, or another compatible implementation must not alter durable IDs, hashes, event schemas, provenance, lifecycle, conflict, redaction, or rebuild semantics.
+
+## Compatibility-only modules
+
+The following flat paths remain valid only to prevent migration breakage:
+
+| Compatibility path | Canonical replacement |
+| --- | --- |
+| `fossil_core.storage_ports` | `fossil_core.ports` |
+| `fossil_core.artifact_store` | `fossil_core.adapters.filesystem` |
+| `fossil_core.event_store` | `fossil_core.adapters.filesystem` |
+| `fossil_core.s3_storage` | `fossil_core.adapters.s3` |
+
+They intentionally preserve object identity with the canonical classes/protocols. No runtime deprecation warnings are emitted in this phase because adding warnings would be a behavior change mixed into structural migration.
+
+Removal is not authorized by this document. Compatibility modules may be removed only in an explicit cleanup phase after first-party consumers, clean-install tests, cross-repository contracts, and required hosted gates demonstrate that the old paths are no longer needed.
+
+## Internal-by-default rule
+
+A module or symbol is **internal until explicitly promoted** into the versioned API contract. Being importable from Python does not by itself make a module a supported API.
+
+This rule lets bounded domain/application packages move incrementally without accidentally turning every implementation path into a permanent external contract.
+
+## Change policy
+
+Any change to a supported surface must be deliberate:
+
+1. update the versioned public-API contract;
+2. update compatibility policy or migration guidance as needed;
+3. update contract tests;
+4. keep behavior-preserving aliases when required for existing consumers;
+5. pass the deterministic suite and architecture-boundary gate on the exact head;
+6. use a separate explicit cleanup decision for removals.
+
+Package movement alone is not permission to change semantics, stable identities, schemas, canonical hashes, provider policy, or acceptance thresholds.

--- a/tests/test_architecture_inventory.py
+++ b/tests/test_architecture_inventory.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "architecture_inventory.py"
+PUBLIC_API_CONTRACT = ROOT / "contracts" / "python-public-api-v1.json"
 
 
 def _load_inventory_module():
@@ -27,22 +29,13 @@ def test_architecture_inventory_is_import_free_and_tracks_storage_seams():
     assert "fossil_core.event_store" in payload["modules"]
 
 
-def test_declared_package_root_api_is_explicit_baseline():
+def test_declared_package_root_api_matches_versioned_public_contract():
     module = _load_inventory_module()
     payload = module.inventory(ROOT)
+    contract = json.loads(PUBLIC_API_CONTRACT.read_text(encoding="utf-8"))
 
-    assert payload["declared_public_api"] == [
-        "ArtifactIntegrityError",
-        "ArtifactStore",
-        "DurableEventStore",
-        "IdempotencyConflict",
-        "KnowledgeState",
-        "LifecycleError",
-        "RelationRecord",
-        "KnowledgePackValidator",
-        "PackAccess",
-        "PackBoundaryError",
-        "build_promotion_event",
+    assert payload["declared_public_api"] == contract["surfaces"]["package_root"][
+        "symbols"
     ]
 
 

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = ROOT / "contracts" / "python-public-api-v1.json"
+
+
+def _contract() -> dict:
+    return json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def _resolve_symbol(path: str):
+    module_name, symbol = path.rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    return getattr(module, symbol)
+
+
+def test_supported_surfaces_match_declared_exports():
+    contract = _contract()
+
+    assert contract["schema"] == "fossil.python-public-api.v1"
+    for surface in contract["surfaces"].values():
+        module = importlib.import_module(surface["module"])
+        symbols = surface["symbols"]
+
+        assert len(symbols) == len(set(symbols))
+        assert module.__all__ == symbols
+        for symbol in symbols:
+            assert getattr(module, symbol) is not None
+
+
+def test_compatibility_modules_preserve_identity_and_star_exports():
+    contract = _contract()
+
+    for module_name, compatibility in contract["compatibility_modules"].items():
+        legacy = importlib.import_module(module_name)
+        replacement = importlib.import_module(compatibility["replacement"])
+
+        assert legacy.__all__ == compatibility["star_exported_symbols"]
+        for symbol in compatibility["symbols"]:
+            assert getattr(legacy, symbol) is getattr(replacement, symbol)
+
+
+def test_explicit_root_aliases_preserve_canonical_object_identity():
+    contract = _contract()
+
+    for alias in contract["identity_aliases"]:
+        assert _resolve_symbol(alias["source"]) is _resolve_symbol(alias["target"])
+
+
+def test_contract_policy_keeps_compatibility_non_behavioral():
+    policy = _contract()["policy"]
+
+    assert policy == {
+        "unlisted_modules": "internal_until_explicitly_promoted",
+        "compatibility_modules": "temporary_until_explicit_cleanup_phase",
+        "runtime_deprecation_warnings": False,
+    }


### PR DESCRIPTION
Advances #82 Phase 3 after storage boundaries and CI enforcement landed in #134/#135/#137/#138.

## Scope
- add versioned machine-readable `contracts/python-public-api-v1.json`
- declare the existing 11-symbol `fossil_core` package-root surface as supported without changing it
- declare `fossil_core.ports` as the canonical provider-neutral storage interface
- declare `fossil_core.adapters.filesystem` and `fossil_core.adapters.s3` as supported bounded concrete-adapter surfaces
- explicitly classify the old flat storage modules as temporary compatibility-only paths with canonical replacements
- preserve historical `__all__` behavior and object identity, including direct `RemoteObjectConflict` compatibility
- add executable contract tests for supported exports, compatibility identities, root aliases, and non-behavioral deprecation policy
- make the Phase 0 architecture inventory consume the versioned contract as the single source of truth for package-root exports
- document supported import examples and cleanup rules

## Explicit non-goals
- no package-root export removal or expansion
- no runtime deprecation warnings
- no runtime/package moves
- no storage/provider behavior changes
- no schema, stable-ID, canonical-hash, redaction, or rebuild changes
- no compatibility-module removal
- no acceptance weakening

## Verification
- full deterministic DKG suite on exact PR head
- public API contract tests must match every supported `__all__` and compatibility identity
- SHA-fenced merge + exact-main DKG

Parent: #82
Architecture: #81, #86
Base: `a9d86d257b9a40cc053953874929dd81cd722074`