### PR TITLE
[ARCH-P4] Move lifecycle model behind domain boundary

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -53,6 +53,18 @@
         "S3ArtifactStore",
         "S3DurableEventStore"
       ]
+    },
+    "lifecycle_domain": {
+      "module": "fossil_core.domain.lifecycle",
+      "status": "supported_domain_model",
+      "symbols": [
+        "CLAIM_STATES",
+        "RELATION_STATES",
+        "RELATION_TYPES",
+        "LifecycleError",
+        "RelationRecord",
+        "KnowledgeState"
+      ]
     }
   },
   "compatibility_modules": {
@@ -108,6 +120,30 @@
         "S3ArtifactStore",
         "S3DurableEventStore"
       ]
+    },
+    "fossil_core.lifecycle": {
+      "replacement": "fossil_core.domain.lifecycle",
+      "symbols": [
+        "CLAIM_STATES",
+        "RELATION_STATES",
+        "RELATION_TYPES",
+        "LifecycleError",
+        "RelationRecord",
+        "KnowledgeState"
+      ],
+      "star_exported_symbols": null,
+      "implicit_star_exported_symbols": [
+        "Any",
+        "CLAIM_STATES",
+        "Iterable",
+        "KnowledgeState",
+        "LifecycleError",
+        "RELATION_STATES",
+        "RELATION_TYPES",
+        "RelationRecord",
+        "dataclass",
+        "field"
+      ]
     }
   },
   "identity_aliases": [
@@ -126,6 +162,18 @@
     {
       "source": "fossil_core.IdempotencyConflict",
       "target": "fossil_core.adapters.filesystem.IdempotencyConflict"
+    },
+    {
+      "source": "fossil_core.KnowledgeState",
+      "target": "fossil_core.domain.lifecycle.KnowledgeState"
+    },
+    {
+      "source": "fossil_core.LifecycleError",
+      "target": "fossil_core.domain.lifecycle.LifecycleError"
+    },
+    {
+      "source": "fossil_core.RelationRecord",
+      "target": "fossil_core.domain.lifecycle.RelationRecord"
     }
   ]
 }

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -1,6 +1,6 @@
 # FOSSIL Python public API
 
-Status: Phase 3 public-API contract for #82 under architecture authority #81 and #86.
+Status: versioned public-API contract for #82 under architecture authority #81 and #86.
 
 The machine-readable source of truth is [`contracts/python-public-api-v1.json`](../../contracts/python-public-api-v1.json). Tests must fail if the declared imports, `__all__` surfaces, or compatibility aliases drift from that contract.
 
@@ -24,7 +24,24 @@ from fossil_core import (
 )
 ```
 
-This is the compatibility-stable root surface. Phase 3 does not remove, rename, or warn on any of these imports.
+This is the compatibility-stable root surface. Bounded migration does not remove, rename, or warn on any of these imports.
+
+## Canonical lifecycle domain
+
+New code that works directly with claim/relation lifecycle semantics should use the pure domain boundary:
+
+```python
+from fossil_core.domain.lifecycle import (
+    CLAIM_STATES,
+    RELATION_STATES,
+    RELATION_TYPES,
+    KnowledgeState,
+    LifecycleError,
+    RelationRecord,
+)
+```
+
+This module contains deterministic domain state and invariants only. Architecture CI forbids it from importing ports, concrete adapters, or legacy storage shims.
 
 ## Canonical provider-neutral storage ports
 
@@ -34,7 +51,7 @@ New code that depends on storage capabilities rather than a concrete implementat
 from fossil_core.ports import ArtifactStorePort, EventStorePort
 ```
 
-These are the canonical provider-neutral storage interfaces. Application/domain code should depend on these boundaries rather than on S3/R2/filesystem implementation details when a port is sufficient.
+These are the canonical provider-neutral storage interfaces. Application/domain code should depend on bounded capabilities rather than on S3/R2/filesystem implementation details when a port is sufficient; pure domain modules must not depend on storage ports at all.
 
 ## Canonical concrete adapters
 
@@ -60,12 +77,13 @@ The following flat paths remain valid only to prevent migration breakage:
 
 | Compatibility path | Canonical replacement |
 | --- | --- |
+| `fossil_core.lifecycle` | `fossil_core.domain.lifecycle` |
 | `fossil_core.storage_ports` | `fossil_core.ports` |
 | `fossil_core.artifact_store` | `fossil_core.adapters.filesystem` |
 | `fossil_core.event_store` | `fossil_core.adapters.filesystem` |
 | `fossil_core.s3_storage` | `fossil_core.adapters.s3` |
 
-They intentionally preserve object identity with the canonical classes/protocols. No runtime deprecation warnings are emitted in this phase because adding warnings would be a behavior change mixed into structural migration.
+They intentionally preserve object identity with canonical classes/protocols. The lifecycle shim also preserves its historical implicit star-import names rather than adding a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
 
 Removal is not authorized by this document. Compatibility modules may be removed only in an explicit cleanup phase after first-party consumers, clean-install tests, cross-repository contracts, and required hosted gates demonstrate that the old paths are no longer needed.
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -10,6 +10,8 @@ from architecture_inventory import inventory
 
 PACKAGE = "fossil_core"
 CANONICAL_MODULES = {
+    "fossil_core.domain",
+    "fossil_core.domain.lifecycle",
     "fossil_core.ports",
     "fossil_core.ports.artifact_store",
     "fossil_core.ports.event_store",
@@ -22,6 +24,7 @@ CANONICAL_MODULES = {
 }
 
 COMPATIBILITY_IMPORTS = {
+    "fossil_core.lifecycle": {"fossil_core.domain.lifecycle"},
     "fossil_core.storage_ports": {"fossil_core.ports"},
     "fossil_core.artifact_store": {
         "fossil_core.adapters.filesystem.artifact_store"
@@ -32,6 +35,15 @@ COMPATIBILITY_IMPORTS = {
 
 PORT_FORBIDDEN_PREFIXES = (
     "fossil_core.adapters",
+    "fossil_core.artifact_store",
+    "fossil_core.event_store",
+    "fossil_core.s3_storage",
+)
+
+DOMAIN_FORBIDDEN_PREFIXES = (
+    "fossil_core.ports",
+    "fossil_core.adapters",
+    "fossil_core.storage_ports",
     "fossil_core.artifact_store",
     "fossil_core.event_store",
     "fossil_core.s3_storage",
@@ -132,6 +144,16 @@ def violations(payload: dict[str, Any]) -> list[str]:
 
     for module, details in sorted(modules.items()):
         internal_imports = set(details["internal_imports"])
+
+        if _matches_prefix(module, "fossil_core.domain"):
+            for imported in sorted(internal_imports):
+                if any(
+                    _matches_prefix(imported, prefix)
+                    for prefix in DOMAIN_FORBIDDEN_PREFIXES
+                ):
+                    violations.append(
+                        f"domain boundary violation: {module} imports {imported}"
+                    )
 
         if _matches_prefix(module, "fossil_core.ports"):
             for imported in sorted(internal_imports):

--- a/src/fossil_core/domain/__init__.py
+++ b/src/fossil_core/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Pure durable-knowledge domain models and invariants."""

--- a/src/fossil_core/domain/lifecycle.py
+++ b/src/fossil_core/domain/lifecycle.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+CLAIM_STATES = frozenset({
+    "proposed",
+    "open",
+    "supported",
+    "disputed",
+    "rejected",
+    "superseded",
+    "retracted",
+    "stale_pending_review",
+})
+RELATION_STATES = frozenset({"proposed", "active", "disputed", "superseded", "invalidated"})
+RELATION_TYPES = frozenset({
+    "SUPPORTS",
+    "CHALLENGES",
+    "CONTRADICTS",
+    "REFINES",
+    "DEPENDS_ON",
+    "ASSUMES",
+    "DERIVED_FROM",
+    "EXEMPLIFIES",
+    "SUPERSEDES",
+    "RELATED_TO",
+    "BROADER_THAN",
+    "NARROWER_THAN",
+})
+
+
+class LifecycleError(ValueError):
+    pass
+
+
+@dataclass
+class RelationRecord:
+    relation_id: str
+    relation_type: str
+    source_ref: str
+    target_ref: str
+    state: str = "proposed"
+
+
+@dataclass
+class KnowledgeState:
+    """Deterministic current-state projection built by replaying durable events.
+
+    Histories are retained as state sequences for convenient inspection, while
+    the immutable event store remains the authoritative historical record.
+    """
+
+    claims: dict[str, str] = field(default_factory=dict)
+    claim_history: dict[str, list[str]] = field(default_factory=dict)
+    relations: dict[str, RelationRecord] = field(default_factory=dict)
+    relation_history: dict[str, list[str]] = field(default_factory=dict)
+
+    @classmethod
+    def replay(cls, events: Iterable[dict[str, Any]]) -> "KnowledgeState":
+        state = cls()
+        for event in events:
+            state.apply(event)
+        return state
+
+    def apply(self, event: dict[str, Any]) -> None:
+        kind = event["event_type"]
+        payload = event["payload"]
+        subject = event["subject_refs"][0]
+
+        if kind == "claim.proposed":
+            if subject in self.claims:
+                raise LifecycleError(f"claim already exists: {subject}")
+            self.claims[subject] = "proposed"
+            self.claim_history[subject] = ["proposed"]
+            return
+
+        if kind == "claim.state_changed":
+            self.change_claim(subject, payload["to_state"], payload.get("from_state"))
+            return
+
+        if kind == "claim.superseded":
+            self.change_claim(subject, "superseded", payload.get("from_state"))
+            self.mark_dependents_stale(subject)
+            return
+
+        if kind == "relation.proposed":
+            relation_id = payload["relation_id"]
+            if relation_id in self.relations:
+                raise LifecycleError(f"relation already exists: {relation_id}")
+            relation_type = payload["relation_type"]
+            if relation_type not in RELATION_TYPES:
+                raise LifecycleError(f"invalid relation type: {relation_type}")
+            state = payload.get("state", "proposed")
+            if state not in RELATION_STATES:
+                raise LifecycleError(f"invalid relation state: {state}")
+            self.relations[relation_id] = RelationRecord(
+                relation_id=relation_id,
+                relation_type=relation_type,
+                source_ref=payload["source_ref"],
+                target_ref=payload["target_ref"],
+                state=state,
+            )
+            self.relation_history[relation_id] = [state]
+            return
+
+        if kind in {"relation.state_changed", "relation.superseded"}:
+            relation = self.relations[payload["relation_id"]]
+            expected = payload.get("from_state")
+            if expected is not None and relation.state != expected:
+                raise LifecycleError("relation from_state does not match current state")
+            target = "superseded" if kind == "relation.superseded" else payload["to_state"]
+            if target not in RELATION_STATES:
+                raise LifecycleError(f"invalid relation state: {target}")
+            relation.state = target
+            self.relation_history[relation.relation_id].append(target)
+
+    def change_claim(self, claim_id: str, target: str, expected: str | None = None) -> None:
+        if claim_id not in self.claims:
+            raise LifecycleError(f"unknown claim: {claim_id}")
+        if target not in CLAIM_STATES:
+            raise LifecycleError(f"invalid claim state: {target}")
+        if expected is not None and self.claims[claim_id] != expected:
+            raise LifecycleError("claim from_state does not match current state")
+        self.claims[claim_id] = target
+        self.claim_history[claim_id].append(target)
+
+    def mark_dependents_stale(self, premise_id: str) -> None:
+        terminal = {"superseded", "retracted", "rejected"}
+        for relation in self.relations.values():
+            if relation.relation_type != "DEPENDS_ON" or relation.state != "active":
+                continue
+            if relation.target_ref != premise_id or relation.source_ref not in self.claims:
+                continue
+            if self.claims[relation.source_ref] not in terminal:
+                self.change_claim(relation.source_ref, "stale_pending_review")
+
+
+__all__ = [
+    "CLAIM_STATES",
+    "RELATION_STATES",
+    "RELATION_TYPES",
+    "LifecycleError",
+    "RelationRecord",
+    "KnowledgeState",
+]

--- a/src/fossil_core/lifecycle.py
+++ b/src/fossil_core/lifecycle.py
@@ -1,136 +1,18 @@
-from __future__ import annotations
+"""Compatibility imports for the canonical lifecycle domain model.
+
+New code should import lifecycle semantics from ``fossil_core.domain.lifecycle``.
+This module intentionally preserves the historical implicit star-import names
+while existing callers migrate; no runtime deprecation warning is added here.
+"""
 
 from dataclasses import dataclass, field
 from typing import Any, Iterable
 
-CLAIM_STATES = frozenset({
-    "proposed",
-    "open",
-    "supported",
-    "disputed",
-    "rejected",
-    "superseded",
-    "retracted",
-    "stale_pending_review",
-})
-RELATION_STATES = frozenset({"proposed", "active", "disputed", "superseded", "invalidated"})
-RELATION_TYPES = frozenset({
-    "SUPPORTS",
-    "CHALLENGES",
-    "CONTRADICTS",
-    "REFINES",
-    "DEPENDS_ON",
-    "ASSUMES",
-    "DERIVED_FROM",
-    "EXEMPLIFIES",
-    "SUPERSEDES",
-    "RELATED_TO",
-    "BROADER_THAN",
-    "NARROWER_THAN",
-})
-
-
-class LifecycleError(ValueError):
-    pass
-
-
-@dataclass
-class RelationRecord:
-    relation_id: str
-    relation_type: str
-    source_ref: str
-    target_ref: str
-    state: str = "proposed"
-
-
-@dataclass
-class KnowledgeState:
-    """Deterministic current-state projection built by replaying durable events.
-
-    Histories are retained as state sequences for convenient inspection, while
-    the immutable event store remains the authoritative historical record.
-    """
-
-    claims: dict[str, str] = field(default_factory=dict)
-    claim_history: dict[str, list[str]] = field(default_factory=dict)
-    relations: dict[str, RelationRecord] = field(default_factory=dict)
-    relation_history: dict[str, list[str]] = field(default_factory=dict)
-
-    @classmethod
-    def replay(cls, events: Iterable[dict[str, Any]]) -> "KnowledgeState":
-        state = cls()
-        for event in events:
-            state.apply(event)
-        return state
-
-    def apply(self, event: dict[str, Any]) -> None:
-        kind = event["event_type"]
-        payload = event["payload"]
-        subject = event["subject_refs"][0]
-
-        if kind == "claim.proposed":
-            if subject in self.claims:
-                raise LifecycleError(f"claim already exists: {subject}")
-            self.claims[subject] = "proposed"
-            self.claim_history[subject] = ["proposed"]
-            return
-
-        if kind == "claim.state_changed":
-            self.change_claim(subject, payload["to_state"], payload.get("from_state"))
-            return
-
-        if kind == "claim.superseded":
-            self.change_claim(subject, "superseded", payload.get("from_state"))
-            self.mark_dependents_stale(subject)
-            return
-
-        if kind == "relation.proposed":
-            relation_id = payload["relation_id"]
-            if relation_id in self.relations:
-                raise LifecycleError(f"relation already exists: {relation_id}")
-            relation_type = payload["relation_type"]
-            if relation_type not in RELATION_TYPES:
-                raise LifecycleError(f"invalid relation type: {relation_type}")
-            state = payload.get("state", "proposed")
-            if state not in RELATION_STATES:
-                raise LifecycleError(f"invalid relation state: {state}")
-            self.relations[relation_id] = RelationRecord(
-                relation_id=relation_id,
-                relation_type=relation_type,
-                source_ref=payload["source_ref"],
-                target_ref=payload["target_ref"],
-                state=state,
-            )
-            self.relation_history[relation_id] = [state]
-            return
-
-        if kind in {"relation.state_changed", "relation.superseded"}:
-            relation = self.relations[payload["relation_id"]]
-            expected = payload.get("from_state")
-            if expected is not None and relation.state != expected:
-                raise LifecycleError("relation from_state does not match current state")
-            target = "superseded" if kind == "relation.superseded" else payload["to_state"]
-            if target not in RELATION_STATES:
-                raise LifecycleError(f"invalid relation state: {target}")
-            relation.state = target
-            self.relation_history[relation.relation_id].append(target)
-
-    def change_claim(self, claim_id: str, target: str, expected: str | None = None) -> None:
-        if claim_id not in self.claims:
-            raise LifecycleError(f"unknown claim: {claim_id}")
-        if target not in CLAIM_STATES:
-            raise LifecycleError(f"invalid claim state: {target}")
-        if expected is not None and self.claims[claim_id] != expected:
-            raise LifecycleError("claim from_state does not match current state")
-        self.claims[claim_id] = target
-        self.claim_history[claim_id].append(target)
-
-    def mark_dependents_stale(self, premise_id: str) -> None:
-        terminal = {"superseded", "retracted", "rejected"}
-        for relation in self.relations.values():
-            if relation.relation_type != "DEPENDS_ON" or relation.state != "active":
-                continue
-            if relation.target_ref != premise_id or relation.source_ref not in self.claims:
-                continue
-            if self.claims[relation.source_ref] not in terminal:
-                self.change_claim(relation.source_ref, "stale_pending_review")
+from .domain.lifecycle import (
+    CLAIM_STATES,
+    RELATION_STATES,
+    RELATION_TYPES,
+    KnowledgeState,
+    LifecycleError,
+    RelationRecord,
+)

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -41,6 +41,18 @@ def test_current_repository_satisfies_enforced_boundaries():
     assert boundaries.check(ROOT) == []
 
 
+def test_domain_cannot_depend_on_ports_or_concrete_adapters():
+    payload = _synthetic_clean_payload()
+    payload["modules"]["fossil_core.domain.lifecycle"]["internal_imports"] = [
+        "fossil_core.ports",
+        "fossil_core.adapters.s3",
+    ]
+
+    problems = boundaries.violations(payload)
+
+    assert sum("domain boundary violation" in problem for problem in problems) == 2
+
+
 def test_ports_cannot_depend_on_concrete_adapters():
     payload = _synthetic_clean_payload()
     payload["modules"]["fossil_core.ports.artifact_store"]["internal_imports"] = [

--- a/tests/test_lifecycle_domain_compatibility.py
+++ b/tests/test_lifecycle_domain_compatibility.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib
+
+import fossil_core
+import fossil_core.lifecycle as legacy_lifecycle
+from fossil_core.domain.lifecycle import (
+    CLAIM_STATES,
+    RELATION_STATES,
+    RELATION_TYPES,
+    KnowledgeState,
+    LifecycleError,
+    RelationRecord,
+)
+
+
+def test_legacy_lifecycle_path_aliases_canonical_domain_objects():
+    assert legacy_lifecycle.CLAIM_STATES is CLAIM_STATES
+    assert legacy_lifecycle.RELATION_STATES is RELATION_STATES
+    assert legacy_lifecycle.RELATION_TYPES is RELATION_TYPES
+    assert legacy_lifecycle.KnowledgeState is KnowledgeState
+    assert legacy_lifecycle.LifecycleError is LifecycleError
+    assert legacy_lifecycle.RelationRecord is RelationRecord
+
+
+def test_package_root_lifecycle_exports_alias_canonical_domain_objects():
+    assert fossil_core.KnowledgeState is KnowledgeState
+    assert fossil_core.LifecycleError is LifecycleError
+    assert fossil_core.RelationRecord is RelationRecord
+
+
+def test_legacy_dkg_lifecycle_exports_still_alias_canonical_domain_objects():
+    dkg = importlib.import_module("dkg")
+
+    assert dkg.KnowledgeState is KnowledgeState
+    assert dkg.LifecycleError is LifecycleError
+    assert dkg.RelationRecord is RelationRecord

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -40,7 +40,16 @@ def test_compatibility_modules_preserve_identity_and_star_exports():
         legacy = importlib.import_module(module_name)
         replacement = importlib.import_module(compatibility["replacement"])
 
-        assert legacy.__all__ == compatibility["star_exported_symbols"]
+        star_exports = compatibility["star_exported_symbols"]
+        if star_exports is None:
+            assert not hasattr(legacy, "__all__")
+            public_names = sorted(
+                name for name in vars(legacy) if not name.startswith("_")
+            )
+            assert public_names == compatibility["implicit_star_exported_symbols"]
+        else:
+            assert legacy.__all__ == star_exports
+
         for symbol in compatibility["symbols"]:
             assert getattr(legacy, symbol) is getattr(replacement, symbol)
 


### PR DESCRIPTION
Advances #82 Phase 4 with one pure domain slice.

## Scope
- move claim/relation lifecycle definitions behind `fossil_core.domain.lifecycle`
- preserve `fossil_core.lifecycle` as a thin compatibility shim
- preserve existing package-root and legacy `dkg` `KnowledgeState` / `LifecycleError` / `RelationRecord` object identity
- preserve the legacy lifecycle module's historical implicit star-import names and absence of `__all__`
- add the canonical lifecycle domain to the versioned public-API contract
- classify `fossil_core.lifecycle` as compatibility-only with explicit migration guidance
- enforce that `fossil_core.domain` cannot import ports, adapters, or storage compatibility shims
- add canonical/legacy/root/`dkg` compatibility tests

## Explicit non-goals
- no lifecycle behavior or claim/relation semantic change
- no event/schema/stable-ID/canonical-hash change
- no storage/provider/application move
- no package-root API change
- no runtime deprecation warning changes
- no acceptance weakening

## Verification
- existing lifecycle behavior tests
- public-API identity + implicit-star compatibility contract tests
- architecture boundary tests
- full deterministic DKG suite
- Dependency integrity including the blocking architecture-boundary job
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `6d12528267ca4c201b6748452990946c3f5f55cd`