### PR TITLE
[ARCH-P4] Move pack access boundaries into pure domain

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -65,6 +65,14 @@
         "RelationRecord",
         "KnowledgeState"
       ]
+    },
+    "pack_boundary_domain": {
+      "module": "fossil_core.domain.pack",
+      "status": "supported_domain_model",
+      "symbols": [
+        "PackBoundaryError",
+        "PackAccess"
+      ]
     }
   },
   "compatibility_modules": {
@@ -174,6 +182,14 @@
     {
       "source": "fossil_core.RelationRecord",
       "target": "fossil_core.domain.lifecycle.RelationRecord"
+    },
+    {
+      "source": "fossil_core.PackAccess",
+      "target": "fossil_core.domain.pack.PackAccess"
+    },
+    {
+      "source": "fossil_core.PackBoundaryError",
+      "target": "fossil_core.domain.pack.PackBoundaryError"
     }
   ]
 }

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -43,6 +43,18 @@ from fossil_core.domain.lifecycle import (
 
 This module contains deterministic domain state and invariants only. Architecture CI forbids it from importing ports, concrete adapters, or legacy storage shims.
 
+## Canonical pack-boundary domain
+
+Pure pack access and boundary checks are canonical under:
+
+```python
+from fossil_core.domain.pack import PackAccess, PackBoundaryError
+```
+
+`PackAccess` is a domain capability describing readable mounts and writable targets. It has no JSON Schema, filesystem, storage-provider, or runtime dependency.
+
+`KnowledgePackValidator` intentionally remains available from `fossil_core` / `fossil_core.pack`. It performs JSON Schema-backed manifest validation and file loading, so this bounded move does not relabel that validation/integration concern as pure domain logic.
+
 ## Canonical provider-neutral storage ports
 
 New code that depends on storage capabilities rather than a concrete implementation should use:
@@ -84,6 +96,8 @@ The following flat paths remain valid only to prevent migration breakage:
 | `fossil_core.s3_storage` | `fossil_core.adapters.s3` |
 
 They intentionally preserve object identity with canonical classes/protocols. The lifecycle shim also preserves its historical implicit star-import names rather than adding a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
+
+`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary.
 
 Removal is not authorized by this document. Compatibility modules may be removed only in an explicit cleanup phase after first-party consumers, clean-install tests, cross-repository contracts, and required hosted gates demonstrate that the old paths are no longer needed.
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -12,6 +12,7 @@ PACKAGE = "fossil_core"
 CANONICAL_MODULES = {
     "fossil_core.domain",
     "fossil_core.domain.lifecycle",
+    "fossil_core.domain.pack",
     "fossil_core.ports",
     "fossil_core.ports.artifact_store",
     "fossil_core.ports.event_store",

--- a/src/fossil_core/domain/pack.py
+++ b/src/fossil_core/domain/pack.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+class PackBoundaryError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class PackAccess:
+    pack_id: str
+    read_mounts: frozenset[str]
+    write_targets: frozenset[str]
+
+    @classmethod
+    def from_manifest(cls, manifest: dict[str, Any]) -> "PackAccess":
+        return cls(
+            pack_id=manifest["pack_id"],
+            read_mounts=frozenset(manifest["read_mounts"]),
+            write_targets=frozenset(manifest["write_targets"]),
+        )
+
+    def require_read(self, pack_id: str) -> None:
+        if pack_id not in self.read_mounts:
+            raise PackBoundaryError(f"pack {pack_id} is not mounted for reading")
+
+    def require_write(self, pack_id: str) -> None:
+        if pack_id not in self.write_targets:
+            raise PackBoundaryError(f"pack {pack_id} is not an allowed write target")
+
+
+__all__ = ["PackBoundaryError", "PackAccess"]

--- a/src/fossil_core/pack.py
+++ b/src/fossil_core/pack.py
@@ -7,32 +7,7 @@ from typing import Any, Iterable
 
 from jsonschema import Draft202012Validator, FormatChecker
 
-
-class PackBoundaryError(ValueError):
-    pass
-
-
-@dataclass(frozen=True)
-class PackAccess:
-    pack_id: str
-    read_mounts: frozenset[str]
-    write_targets: frozenset[str]
-
-    @classmethod
-    def from_manifest(cls, manifest: dict[str, Any]) -> "PackAccess":
-        return cls(
-            pack_id=manifest["pack_id"],
-            read_mounts=frozenset(manifest["read_mounts"]),
-            write_targets=frozenset(manifest["write_targets"]),
-        )
-
-    def require_read(self, pack_id: str) -> None:
-        if pack_id not in self.read_mounts:
-            raise PackBoundaryError(f"pack {pack_id} is not mounted for reading")
-
-    def require_write(self, pack_id: str) -> None:
-        if pack_id not in self.write_targets:
-            raise PackBoundaryError(f"pack {pack_id} is not an allowed write target")
+from .domain.pack import PackAccess, PackBoundaryError
 
 
 class KnowledgePackValidator:

--- a/tests/test_pack_domain_compatibility.py
+++ b/tests/test_pack_domain_compatibility.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib
+
+import fossil_core
+import fossil_core.pack as legacy_pack
+from fossil_core.domain.pack import PackAccess, PackBoundaryError
+
+
+def test_pack_module_uses_canonical_domain_boundary_objects():
+    assert legacy_pack.PackAccess is PackAccess
+    assert legacy_pack.PackBoundaryError is PackBoundaryError
+    assert not hasattr(legacy_pack, "__all__")
+
+
+def test_package_root_pack_boundary_exports_alias_canonical_domain_objects():
+    assert fossil_core.PackAccess is PackAccess
+    assert fossil_core.PackBoundaryError is PackBoundaryError
+
+
+def test_legacy_dkg_pack_boundary_exports_alias_canonical_domain_objects():
+    dkg = importlib.import_module("dkg")
+
+    assert dkg.PackAccess is PackAccess
+    assert dkg.PackBoundaryError is PackBoundaryError
+
+
+def test_json_schema_validator_stays_outside_pure_domain_boundary():
+    assert legacy_pack.KnowledgePackValidator.__module__ == "fossil_core.pack"
+    assert not hasattr(importlib.import_module("fossil_core.domain.pack"), "KnowledgePackValidator")


### PR DESCRIPTION
Advances #82 Phase 4 with one narrowly bounded pack-domain slice.

## Scope
- move `PackAccess` and `PackBoundaryError` behind `fossil_core.domain.pack`
- preserve `fossil_core.pack`, package-root, and legacy `dkg` object identity for those types
- keep `KnowledgePackValidator` in `fossil_core.pack`; JSON Schema validation/file loading are deliberately not relabeled as pure domain logic
- add the canonical pack-boundary surface to the versioned Python API contract
- require `fossil_core.domain.pack` in architecture-boundary CI
- add compatibility tests proving root/legacy/`dkg` identity and proving the validator remains outside the pure domain module
- document the domain-vs-validator split

## Explicit non-goals
- no validator behavior change
- no manifest/schema changes
- no stable-ID/hash/event/storage/provider/application changes
- no package-root API change
- no runtime deprecation warnings
- no acceptance weakening

## Verification
- existing pack validation/access tests
- new pack-domain identity/separation tests
- public API contract tests
- architecture boundary tests
- full DKG + Dependency integrity on exact head
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `8f652990746b8e7023c8608150ef8c4e7a2083c2`