### PR TITLE
[ARCH-P4] Move corpus identity helpers behind domain boundary

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -169,6 +169,7 @@
       ],
       "star_exported_symbols": null,
       "implicit_star_exported_symbols": [
+        "annotations",
         "deterministic_event_id",
         "hashlib",
         "new_id",

--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -73,6 +73,14 @@
         "PackBoundaryError",
         "PackAccess"
       ]
+    },
+    "identity_domain": {
+      "module": "fossil_core.domain.identity",
+      "status": "supported_domain_model",
+      "symbols": [
+        "new_id",
+        "deterministic_event_id"
+      ]
     }
   },
   "compatibility_modules": {
@@ -152,6 +160,20 @@
         "dataclass",
         "field"
       ]
+    },
+    "fossil_core.ids": {
+      "replacement": "fossil_core.domain.identity",
+      "symbols": [
+        "new_id",
+        "deterministic_event_id"
+      ],
+      "star_exported_symbols": null,
+      "implicit_star_exported_symbols": [
+        "deterministic_event_id",
+        "hashlib",
+        "new_id",
+        "uuid"
+      ]
     }
   },
   "identity_aliases": [
@@ -190,6 +212,14 @@
     {
       "source": "fossil_core.PackBoundaryError",
       "target": "fossil_core.domain.pack.PackBoundaryError"
+    },
+    {
+      "source": "fossil_core.ids.new_id",
+      "target": "fossil_core.domain.identity.new_id"
+    },
+    {
+      "source": "fossil_core.ids.deterministic_event_id",
+      "target": "fossil_core.domain.identity.deterministic_event_id"
     }
   ]
 }

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -55,6 +55,18 @@ from fossil_core.domain.pack import PackAccess, PackBoundaryError
 
 `KnowledgePackValidator` intentionally remains available from `fossil_core` / `fossil_core.pack`. It performs JSON Schema-backed manifest validation and file loading, so this bounded move does not relabel that validation/integration concern as pure domain logic.
 
+## Canonical identity domain
+
+Corpus-owned identity helpers are canonical under:
+
+```python
+from fossil_core.domain.identity import deterministic_event_id, new_id
+```
+
+These helpers define FOSSIL-owned durable identity rather than provider- or storage-native identity. Storage object keys, database IDs, projection IDs, or provider-specific identifiers must not become durable semantic identity.
+
+The exact deterministic event-ID derivation is compatibility-sensitive. Moving this code between packages does not authorize changing its input framing, SHA-256 derivation, prefix, truncation, or output shape. Likewise, `new_id` retains the existing `<prefix>_<uuid4 hex>` shape.
+
 ## Canonical provider-neutral storage ports
 
 New code that depends on storage capabilities rather than a concrete implementation should use:
@@ -89,13 +101,14 @@ The following flat paths remain valid only to prevent migration breakage:
 
 | Compatibility path | Canonical replacement |
 | --- | --- |
+| `fossil_core.ids` | `fossil_core.domain.identity` |
 | `fossil_core.lifecycle` | `fossil_core.domain.lifecycle` |
 | `fossil_core.storage_ports` | `fossil_core.ports` |
 | `fossil_core.artifact_store` | `fossil_core.adapters.filesystem` |
 | `fossil_core.event_store` | `fossil_core.adapters.filesystem` |
 | `fossil_core.s3_storage` | `fossil_core.adapters.s3` |
 
-They intentionally preserve object identity with canonical classes/protocols. The lifecycle shim also preserves its historical implicit star-import names rather than adding a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
+They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `hashlib` and `uuid` names as well as the two identity functions; it does not add a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
 
 `fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary.
 

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -108,7 +108,7 @@ The following flat paths remain valid only to prevent migration breakage:
 | `fossil_core.event_store` | `fossil_core.adapters.filesystem` |
 | `fossil_core.s3_storage` | `fossil_core.adapters.s3` |
 
-They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `hashlib` and `uuid` names as well as the two identity functions; it does not add a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
+They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `annotations`, `hashlib`, and `uuid` names as well as the two identity functions; it does not add a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
 
 `fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary.
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -11,6 +11,7 @@ from architecture_inventory import inventory
 PACKAGE = "fossil_core"
 CANONICAL_MODULES = {
     "fossil_core.domain",
+    "fossil_core.domain.identity",
     "fossil_core.domain.lifecycle",
     "fossil_core.domain.pack",
     "fossil_core.ports",
@@ -25,6 +26,7 @@ CANONICAL_MODULES = {
 }
 
 COMPATIBILITY_IMPORTS = {
+    "fossil_core.ids": {"fossil_core.domain.identity"},
     "fossil_core.lifecycle": {"fossil_core.domain.lifecycle"},
     "fossil_core.storage_ports": {"fossil_core.ports"},
     "fossil_core.artifact_store": {

--- a/src/fossil_core/domain/identity.py
+++ b/src/fossil_core/domain/identity.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+
+
+def new_id(prefix: str) -> str:
+    """Create a corpus-owned globally unique ID.
+
+    Storage-native IDs must never become durable identity.
+    """
+    return f"{prefix}_{uuid.uuid4().hex}"
+
+
+def deterministic_event_id(pack_id: str, idempotency_key: str) -> str:
+    """Map one logical retryable operation to one stable event ID."""
+    digest = hashlib.sha256(f"{pack_id}\x00{idempotency_key}".encode("utf-8")).hexdigest()
+    return f"evt_{digest[:32]}"
+
+
+__all__ = ["new_id", "deterministic_event_id"]

--- a/src/fossil_core/ids.py
+++ b/src/fossil_core/ids.py
@@ -3,16 +3,4 @@ from __future__ import annotations
 import hashlib
 import uuid
 
-
-def new_id(prefix: str) -> str:
-    """Create a corpus-owned globally unique ID.
-
-    Storage-native IDs must never become durable identity.
-    """
-    return f"{prefix}_{uuid.uuid4().hex}"
-
-
-def deterministic_event_id(pack_id: str, idempotency_key: str) -> str:
-    """Map one logical retryable operation to one stable event ID."""
-    digest = hashlib.sha256(f"{pack_id}\x00{idempotency_key}".encode("utf-8")).hexdigest()
-    return f"evt_{digest[:32]}"
+from .domain.identity import deterministic_event_id, new_id

--- a/tests/test_identity_domain_compatibility.py
+++ b/tests/test_identity_domain_compatibility.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import string
+
+import fossil_core.ids as legacy_ids
+from fossil_core.domain.identity import deterministic_event_id, new_id
+
+
+def test_legacy_identity_module_preserves_canonical_function_identity():
+    assert legacy_ids.new_id is new_id
+    assert legacy_ids.deterministic_event_id is deterministic_event_id
+
+
+def test_deterministic_event_id_regression_vector_is_unchanged():
+    assert (
+        deterministic_event_id("pack-a", "retry-1")
+        == "evt_d45980b2e134f30d603bb913ff0b9005"
+    )
+
+
+def test_new_id_keeps_corpus_prefix_and_uuid_hex_shape():
+    value = new_id("claim")
+
+    assert value.startswith("claim_")
+    suffix = value.removeprefix("claim_")
+    assert len(suffix) == 32
+    assert set(suffix) <= set(string.hexdigits.lower())
+    assert suffix == suffix.lower()
+
+
+def test_legacy_ids_preserves_historical_implicit_star_surface():
+    assert not hasattr(legacy_ids, "__all__")
+    public_names = sorted(name for name in vars(legacy_ids) if not name.startswith("_"))
+    assert public_names == ["deterministic_event_id", "hashlib", "new_id", "uuid"]

--- a/tests/test_identity_domain_compatibility.py
+++ b/tests/test_identity_domain_compatibility.py
@@ -31,4 +31,10 @@ def test_new_id_keeps_corpus_prefix_and_uuid_hex_shape():
 def test_legacy_ids_preserves_historical_implicit_star_surface():
     assert not hasattr(legacy_ids, "__all__")
     public_names = sorted(name for name in vars(legacy_ids) if not name.startswith("_"))
-    assert public_names == ["deterministic_event_id", "hashlib", "new_id", "uuid"]
+    assert public_names == [
+        "annotations",
+        "deterministic_event_id",
+        "hashlib",
+        "new_id",
+        "uuid",
+    ]


### PR DESCRIPTION
Advances #82 Phase 4 with one pure identity-domain slice.

## Scope
- move `new_id` and `deterministic_event_id` behind `fossil_core.domain.identity`
- preserve `fossil_core.ids` function object identity
- preserve the legacy `ids` module's historical implicit star-import surface, including `hashlib` and `uuid`, without adding `__all__`
- add the canonical identity surface to the versioned Python API contract
- require `fossil_core.domain.identity` and a thin `fossil_core.ids` shim in architecture-boundary CI
- add exact deterministic-event-ID regression coverage and `new_id` shape coverage
- document corpus-owned identity and compatibility-sensitive derivation

## Explicit non-goals
- no ID algorithm or output changes
- no event/schema/canonical-hash changes
- no storage/provider/application/root-API changes
- no runtime deprecation warning changes
- no acceptance weakening

## Verification
- exact deterministic regression vector: `deterministic_event_id("pack-a", "retry-1") == "evt_d45980b2e134f30d603bb913ff0b9005"`
- identity/shim compatibility tests
- public API contract tests
- architecture boundary tests
- full deterministic DKG suite
- Dependency integrity including blocking architecture-boundary job
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `08adf12d85ad7dccb484d20af5169c01294d3095`