### PR TITLE
[ARCH-P4] Move cross-pack promotion factory behind domain boundary

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -81,6 +81,13 @@
         "new_id",
         "deterministic_event_id"
       ]
+    },
+    "promotion_domain": {
+      "module": "fossil_core.domain.promotion",
+      "status": "supported_domain_model",
+      "symbols": [
+        "build_promotion_event"
+      ]
     }
   },
   "compatibility_modules": {
@@ -175,6 +182,19 @@
         "new_id",
         "uuid"
       ]
+    },
+    "fossil_core.promotion": {
+      "replacement": "fossil_core.domain.promotion",
+      "symbols": [
+        "build_promotion_event"
+      ],
+      "star_exported_symbols": null,
+      "implicit_star_exported_symbols": [
+        "Any",
+        "Iterable",
+        "annotations",
+        "build_promotion_event"
+      ]
     }
   },
   "identity_aliases": [
@@ -221,6 +241,10 @@
     {
       "source": "fossil_core.ids.deterministic_event_id",
       "target": "fossil_core.domain.identity.deterministic_event_id"
+    },
+    {
+      "source": "fossil_core.build_promotion_event",
+      "target": "fossil_core.domain.promotion.build_promotion_event"
     }
   ]
 }

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -67,6 +67,18 @@ These helpers define FOSSIL-owned durable identity rather than provider- or stor
 
 The exact deterministic event-ID derivation is compatibility-sensitive. Moving this code between packages does not authorize changing its input framing, SHA-256 derivation, prefix, truncation, or output shape. Likewise, `new_id` retains the existing `<prefix>_<uuid4 hex>` shape.
 
+## Canonical promotion domain
+
+Cross-pack promotion event construction is canonical under:
+
+```python
+from fossil_core.domain.promotion import build_promotion_event
+```
+
+This is a pure domain event factory. It enforces that promotion has at least one stable subject reference and crosses a real pack boundary, then returns the existing `dkg.event.v1` `knowledge.promoted` event. It does not persist the event or select a storage provider; committing and schema validation remain outside the pure domain module.
+
+Promotion is append-only: the source pack is not mutated. The target records a new durable event whose payload points to the source pack and whose evidence/provenance fields preserve why the promotion was accepted. The existing event type, schema version, payload keys, provenance method, and validation messages are compatibility-sensitive and are not changed by package movement.
+
 ## Canonical provider-neutral storage ports
 
 New code that depends on storage capabilities rather than a concrete implementation should use:
@@ -103,12 +115,13 @@ The following flat paths remain valid only to prevent migration breakage:
 | --- | --- |
 | `fossil_core.ids` | `fossil_core.domain.identity` |
 | `fossil_core.lifecycle` | `fossil_core.domain.lifecycle` |
+| `fossil_core.promotion` | `fossil_core.domain.promotion` |
 | `fossil_core.storage_ports` | `fossil_core.ports` |
 | `fossil_core.artifact_store` | `fossil_core.adapters.filesystem` |
 | `fossil_core.event_store` | `fossil_core.adapters.filesystem` |
 | `fossil_core.s3_storage` | `fossil_core.adapters.s3` |
 
-They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `annotations`, `hashlib`, and `uuid` names as well as the two identity functions; it does not add a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
+They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `annotations`, `hashlib`, and `uuid` names as well as the two identity functions. The promotion shim preserves its historical `Any`, `Iterable`, `annotations`, and `build_promotion_event` names. None of these compatibility-only modules gains a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
 
 `fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary.
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -14,6 +14,7 @@ CANONICAL_MODULES = {
     "fossil_core.domain.identity",
     "fossil_core.domain.lifecycle",
     "fossil_core.domain.pack",
+    "fossil_core.domain.promotion",
     "fossil_core.ports",
     "fossil_core.ports.artifact_store",
     "fossil_core.ports.event_store",
@@ -28,6 +29,7 @@ CANONICAL_MODULES = {
 COMPATIBILITY_IMPORTS = {
     "fossil_core.ids": {"fossil_core.domain.identity"},
     "fossil_core.lifecycle": {"fossil_core.domain.lifecycle"},
+    "fossil_core.promotion": {"fossil_core.domain.promotion"},
     "fossil_core.storage_ports": {"fossil_core.ports"},
     "fossil_core.artifact_store": {
         "fossil_core.adapters.filesystem.artifact_store"

--- a/src/fossil_core/domain/promotion.py
+++ b/src/fossil_core/domain/promotion.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+def build_promotion_event(
+    *,
+    source_pack_id: str,
+    target_pack_id: str,
+    subject_refs: Iterable[str],
+    actor: dict[str, Any],
+    occurred_at: str,
+    recorded_at: str,
+    idempotency_key: str,
+    evidence_refs: Iterable[str] = (),
+    reason: str = "",
+) -> dict[str, Any]:
+    """Create the explicit durable event for cross-pack knowledge promotion.
+
+    Promotion never mutates the source pack. The target pack records a new
+    event whose payload points back to the source pack and whose evidence refs
+    preserve why the promotion was accepted.
+    """
+    subjects = list(subject_refs)
+    if not subjects:
+        raise ValueError("promotion requires at least one stable subject reference")
+    if source_pack_id == target_pack_id:
+        raise ValueError("promotion requires different source and target packs")
+
+    return {
+        "schema_version": "dkg.event.v1",
+        "event_type": "knowledge.promoted",
+        "occurred_at": occurred_at,
+        "recorded_at": recorded_at,
+        "pack_id": target_pack_id,
+        "actor": actor,
+        "subject_refs": subjects,
+        "idempotency_key": idempotency_key,
+        "evidence_refs": list(evidence_refs),
+        "payload": {
+            "source_pack_id": source_pack_id,
+            "target_pack_id": target_pack_id,
+            "reason": reason,
+        },
+        "provenance": {
+            "method": "explicit_cross_pack_promotion",
+        },
+    }
+
+
+__all__ = ["build_promotion_event"]

--- a/src/fossil_core/promotion.py
+++ b/src/fossil_core/promotion.py
@@ -2,47 +2,4 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-
-def build_promotion_event(
-    *,
-    source_pack_id: str,
-    target_pack_id: str,
-    subject_refs: Iterable[str],
-    actor: dict[str, Any],
-    occurred_at: str,
-    recorded_at: str,
-    idempotency_key: str,
-    evidence_refs: Iterable[str] = (),
-    reason: str = "",
-) -> dict[str, Any]:
-    """Create the explicit durable event for cross-pack knowledge promotion.
-
-    Promotion never mutates the source pack. The target pack records a new
-    event whose payload points back to the source pack and whose evidence refs
-    preserve why the promotion was accepted.
-    """
-    subjects = list(subject_refs)
-    if not subjects:
-        raise ValueError("promotion requires at least one stable subject reference")
-    if source_pack_id == target_pack_id:
-        raise ValueError("promotion requires different source and target packs")
-
-    return {
-        "schema_version": "dkg.event.v1",
-        "event_type": "knowledge.promoted",
-        "occurred_at": occurred_at,
-        "recorded_at": recorded_at,
-        "pack_id": target_pack_id,
-        "actor": actor,
-        "subject_refs": subjects,
-        "idempotency_key": idempotency_key,
-        "evidence_refs": list(evidence_refs),
-        "payload": {
-            "source_pack_id": source_pack_id,
-            "target_pack_id": target_pack_id,
-            "reason": reason,
-        },
-        "provenance": {
-            "method": "explicit_cross_pack_promotion",
-        },
-    }
+from .domain.promotion import build_promotion_event

--- a/tests/test_promotion_domain_compatibility.py
+++ b/tests/test_promotion_domain_compatibility.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import importlib
+import warnings
+
+import pytest
+
+import fossil_core
+import fossil_core.promotion as legacy_promotion
+from fossil_core.domain.promotion import build_promotion_event
+
+
+def _event() -> dict:
+    return build_promotion_event(
+        source_pack_id="pack_source",
+        target_pack_id="pack_target",
+        subject_refs=["clm_1", "clm_2"],
+        actor={"actor_type": "human", "actor_id": "user"},
+        occurred_at="2026-08-09T17:21:00Z",
+        recorded_at="2026-08-09T17:21:01Z",
+        idempotency_key="promote:source:target:1",
+        evidence_refs=["src_1"],
+        reason="Reviewed for cross-pack reuse.",
+    )
+
+
+def test_promotion_exports_preserve_canonical_object_identity():
+    assert legacy_promotion.build_promotion_event is build_promotion_event
+    assert fossil_core.build_promotion_event is build_promotion_event
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        legacy_dkg = importlib.import_module("dkg")
+    assert legacy_dkg.build_promotion_event is build_promotion_event
+
+
+def test_promotion_event_shape_is_unchanged():
+    assert _event() == {
+        "schema_version": "dkg.event.v1",
+        "event_type": "knowledge.promoted",
+        "occurred_at": "2026-08-09T17:21:00Z",
+        "recorded_at": "2026-08-09T17:21:01Z",
+        "pack_id": "pack_target",
+        "actor": {"actor_type": "human", "actor_id": "user"},
+        "subject_refs": ["clm_1", "clm_2"],
+        "idempotency_key": "promote:source:target:1",
+        "evidence_refs": ["src_1"],
+        "payload": {
+            "source_pack_id": "pack_source",
+            "target_pack_id": "pack_target",
+            "reason": "Reviewed for cross-pack reuse.",
+        },
+        "provenance": {"method": "explicit_cross_pack_promotion"},
+    }
+
+
+def test_promotion_still_requires_subject_and_cross_pack_boundary():
+    common = {
+        "actor": {"actor_type": "human", "actor_id": "user"},
+        "occurred_at": "2026-08-09T17:21:00Z",
+        "recorded_at": "2026-08-09T17:21:01Z",
+        "idempotency_key": "promotion-test",
+    }
+
+    with pytest.raises(
+        ValueError, match="promotion requires at least one stable subject reference"
+    ):
+        build_promotion_event(
+            source_pack_id="pack_source",
+            target_pack_id="pack_target",
+            subject_refs=[],
+            **common,
+        )
+
+    with pytest.raises(
+        ValueError, match="promotion requires different source and target packs"
+    ):
+        build_promotion_event(
+            source_pack_id="pack_same",
+            target_pack_id="pack_same",
+            subject_refs=["clm_1"],
+            **common,
+        )
+
+
+def test_legacy_promotion_preserves_historical_implicit_star_surface():
+    assert not hasattr(legacy_promotion, "__all__")
+    public_names = sorted(
+        name for name in vars(legacy_promotion) if not name.startswith("_")
+    )
+    assert public_names == ["Any", "Iterable", "annotations", "build_promotion_event"]


### PR DESCRIPTION
Advances #82 Phase 4 with one pure promotion-domain slice.

## Scope
- move `build_promotion_event` behind `fossil_core.domain.promotion`
- preserve `fossil_core.promotion`, package-root, and legacy `dkg` object identity
- preserve the legacy promotion module's actual implicit star-import surface without adding `__all__`
- freeze the full existing `knowledge.promoted` event dictionary and both cross-pack validation invariants
- add the canonical promotion surface to the versioned Python API contract
- require `fossil_core.domain.promotion` and a thin promotion shim in architecture-boundary CI
- document that event construction is pure domain logic while persistence/schema validation remain outside it

## Explicit non-goals
- no event type/schema version/payload/provenance shape changes
- no validation-message changes
- no stable-ID/canonical-hash changes
- no storage/provider/application/root-API changes
- no runtime deprecation warnings
- no acceptance weakening

## Verification
- exact promotion event-shape regression test
- empty-subject and same-pack invariant tests
- canonical/legacy/root/`dkg` identity tests
- public API contract tests
- architecture boundary tests
- full deterministic DKG suite
- Dependency integrity including blocking architecture-boundary job
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `a654f9cff45ff560a1a96ad8679393f1bd8b0985`