### PR TITLE
[ARCH-P4] Move projection contract behind canonical port

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -28,7 +28,17 @@
       "status": "supported",
       "symbols": [
         "ArtifactStorePort",
-        "EventStorePort"
+        "EventStorePort",
+        "ProjectionReceipt",
+        "ProjectionAdapter"
+      ]
+    },
+    "projection_port": {
+      "module": "fossil_core.ports.projection",
+      "status": "supported",
+      "symbols": [
+        "ProjectionReceipt",
+        "ProjectionAdapter"
       ]
     },
     "filesystem_adapter": {
@@ -245,6 +255,14 @@
     {
       "source": "fossil_core.build_promotion_event",
       "target": "fossil_core.domain.promotion.build_promotion_event"
+    },
+    {
+      "source": "fossil_core.contracts.ProjectionReceipt",
+      "target": "fossil_core.ports.projection.ProjectionReceipt"
+    },
+    {
+      "source": "fossil_core.contracts.ProjectionAdapter",
+      "target": "fossil_core.ports.projection.ProjectionAdapter"
     }
   ]
 }

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -79,7 +79,7 @@ This is a pure domain event factory. It enforces that promotion has at least one
 
 Promotion is append-only: the source pack is not mutated. The target records a new durable event whose payload points to the source pack and whose evidence/provenance fields preserve why the promotion was accepted. The existing event type, schema version, payload keys, provenance method, and validation messages are compatibility-sensitive and are not changed by package movement.
 
-## Canonical provider-neutral storage ports
+## Canonical provider-neutral ports
 
 New code that depends on storage capabilities rather than a concrete implementation should use:
 
@@ -88,6 +88,18 @@ from fossil_core.ports import ArtifactStorePort, EventStorePort
 ```
 
 These are the canonical provider-neutral storage interfaces. Application/domain code should depend on bounded capabilities rather than on S3/R2/filesystem implementation details when a port is sufficient; pure domain modules must not depend on storage ports at all.
+
+Replaceable projection code should use:
+
+```python
+from fossil_core.ports import ProjectionAdapter, ProjectionReceipt
+# equivalent canonical module:
+from fossil_core.ports.projection import ProjectionAdapter, ProjectionReceipt
+```
+
+`ProjectionAdapter` describes a replaceable materialized view of already-durable knowledge. `ProjectionReceipt` records the outcome of applying or rebuilding that view. Neither type makes Graphiti, Neo4j, a local ledger, or any other projection authoritative durable truth.
+
+`fossil_core.contracts.ProjectionAdapter` and `fossil_core.contracts.ProjectionReceipt` remain identity-preserving aliases during migration. The entire `fossil_core.contracts` module is **not** classified as compatibility-only yet because it still owns the existing cognitive-service protocols (`Retriever`, `EmbeddingProvider`, `Reranker`, `ContextProvider`, `ModelService`, and `VerificationService`). Those interfaces require separate bounded migrations rather than one broad package move.
 
 ## Canonical concrete adapters
 
@@ -123,7 +135,7 @@ The following flat paths remain valid only to prevent migration breakage:
 
 They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `annotations`, `hashlib`, and `uuid` names as well as the two identity functions. The promotion shim preserves its historical `Any`, `Iterable`, `annotations`, and `build_promotion_event` names. None of these compatibility-only modules gains a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
 
-`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary.
+`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. Likewise, `fossil_core.contracts` remains a mixed active module while its projection types forward to the canonical projection port.
 
 Removal is not authorized by this document. Compatibility modules may be removed only in an explicit cleanup phase after first-party consumers, clean-install tests, cross-repository contracts, and required hosted gates demonstrate that the old paths are no longer needed.
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -18,6 +18,7 @@ CANONICAL_MODULES = {
     "fossil_core.ports",
     "fossil_core.ports.artifact_store",
     "fossil_core.ports.event_store",
+    "fossil_core.ports.projection",
     "fossil_core.adapters",
     "fossil_core.adapters.filesystem",
     "fossil_core.adapters.filesystem.artifact_store",

--- a/src/fossil_core/contracts.py
+++ b/src/fossil_core/contracts.py
@@ -4,30 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
-
-@dataclass(frozen=True)
-class ProjectionReceipt:
-    projection: str
-    projection_version: str
-    event_id: str
-    status: str
-    detail: str | None = None
-
-
-class ProjectionAdapter(Protocol):
-    """Replaceable materialized view of durable knowledge."""
-
-    @property
-    def name(self) -> str: ...
-
-    @property
-    def version(self) -> str: ...
-
-    def apply_event(self, event: dict[str, Any]) -> ProjectionReceipt: ...
-
-    def rebuild(self, *, events_root: Path) -> list[ProjectionReceipt]: ...
-
-    def health(self) -> dict[str, Any]: ...
+from .ports.projection import ProjectionAdapter, ProjectionReceipt
 
 
 class VersionedCognitiveService(Protocol):

--- a/src/fossil_core/ports/__init__.py
+++ b/src/fossil_core/ports/__init__.py
@@ -2,5 +2,11 @@
 
 from .artifact_store import ArtifactStorePort
 from .event_store import EventStorePort
+from .projection import ProjectionAdapter, ProjectionReceipt
 
-__all__ = ["ArtifactStorePort", "EventStorePort"]
+__all__ = [
+    "ArtifactStorePort",
+    "EventStorePort",
+    "ProjectionReceipt",
+    "ProjectionAdapter",
+]

--- a/src/fossil_core/ports/projection.py
+++ b/src/fossil_core/ports/projection.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class ProjectionReceipt:
+    projection: str
+    projection_version: str
+    event_id: str
+    status: str
+    detail: str | None = None
+
+
+class ProjectionAdapter(Protocol):
+    """Replaceable materialized view of durable knowledge."""
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def version(self) -> str: ...
+
+    def apply_event(self, event: dict[str, Any]) -> ProjectionReceipt: ...
+
+    def rebuild(self, *, events_root: Path) -> list[ProjectionReceipt]: ...
+
+    def health(self) -> dict[str, Any]: ...
+
+
+__all__ = ["ProjectionReceipt", "ProjectionAdapter"]

--- a/src/fossil_core/projection/graphiti.py
+++ b/src/fossil_core/projection/graphiti.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from fossil_core.contracts import ProjectionReceipt
+from fossil_core.ports.projection import ProjectionReceipt
 from fossil_core.projection.ledger import ProjectionLedger
 from fossil_core.projection.migration import ordered_events
 

--- a/src/fossil_core/projection/null.py
+++ b/src/fossil_core/projection/null.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from fossil_core.contracts import ProjectionReceipt
+from fossil_core.ports.projection import ProjectionReceipt
 
 
 class NullProjection:

--- a/tests/test_projection_port_compatibility.py
+++ b/tests/test_projection_port_compatibility.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import fossil_core.contracts as legacy_contracts
+import fossil_core.ports as ports
+from fossil_core.ports.projection import ProjectionAdapter, ProjectionReceipt
+from fossil_core.projection.graphiti import GraphitiProjectionAdapter
+from fossil_core.projection.null import NullProjection
+
+
+def test_projection_port_is_canonical_and_legacy_contracts_preserve_identity():
+    assert legacy_contracts.ProjectionReceipt is ProjectionReceipt
+    assert legacy_contracts.ProjectionAdapter is ProjectionAdapter
+    assert ports.ProjectionReceipt is ProjectionReceipt
+    assert ports.ProjectionAdapter is ProjectionAdapter
+
+
+def test_projection_receipt_shape_is_unchanged():
+    receipt = ProjectionReceipt("graphiti-neo4j", "1", "evt_example", "applied")
+
+    assert receipt.projection == "graphiti-neo4j"
+    assert receipt.projection_version == "1"
+    assert receipt.event_id == "evt_example"
+    assert receipt.status == "applied"
+    assert receipt.detail is None
+
+
+def test_existing_projection_implementations_keep_expected_runtime_shape():
+    projection = NullProjection()
+
+    assert projection.name == "null"
+    assert projection.version == "1"
+    assert projection.apply_event({"event_id": "evt_example"}) == ProjectionReceipt(
+        "null", "1", "evt_example", "applied"
+    )
+    assert hasattr(GraphitiProjectionAdapter, "apply_event")
+    assert hasattr(GraphitiProjectionAdapter, "rebuild")
+    assert hasattr(GraphitiProjectionAdapter, "health")
+
+
+def test_legacy_contracts_implicit_surface_is_unchanged():
+    assert not hasattr(legacy_contracts, "__all__")
+    public_names = sorted(
+        name for name in vars(legacy_contracts) if not name.startswith("_")
+    )
+
+    assert public_names == [
+        "Any",
+        "ContextProvider",
+        "EmbeddingProvider",
+        "ModelService",
+        "Path",
+        "ProjectionAdapter",
+        "ProjectionReceipt",
+        "Protocol",
+        "Reranker",
+        "Retriever",
+        "VerificationService",
+        "VersionedCognitiveService",
+        "annotations",
+        "dataclass",
+    ]


### PR DESCRIPTION
Advances #82 Phase 4 with one bounded projection-port slice.

## Scope
- move `ProjectionReceipt` and `ProjectionAdapter` from flat `fossil_core.contracts` to canonical `fossil_core.ports.projection`
- export the projection port from `fossil_core.ports`
- preserve `fossil_core.contracts` object identity and its historical implicit import surface
- point `NullProjection` and `GraphitiProjectionAdapter` at the canonical projection port
- add exact receipt-shape and compatibility tests
- add the canonical projection port to the versioned Python API contract and architecture-boundary enforcement
- document that projections remain replaceable materialized views, not durable truth

## Explicit non-goals
- no Graphiti/Neo4j behavior or configuration changes
- no projection rebuild ordering/redaction semantics changes
- no event/schema/stable-ID/canonical-hash changes
- no storage/provider changes
- no cognitive-service protocol migration in this PR
- no acceptance weakening

## Verification
- exact legacy `fossil_core.contracts` public namespace regression
- canonical/legacy object-identity tests
- `ProjectionReceipt` shape regression
- Null/Graphiti projection interface regression
- public API contract tests
- architecture-boundary tests
- full deterministic DKG suite
- Dependency Integrity
- any Graphiti workflow GitHub schedules because `projection/graphiti.py` changed
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `55daf1065a364e5425d17f0ae36b59103b0f3614`