### PR TITLE
[ARCH-P4] Extract shared cognitive metadata port

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -30,7 +30,8 @@
         "ArtifactStorePort",
         "EventStorePort",
         "ProjectionReceipt",
-        "ProjectionAdapter"
+        "ProjectionAdapter",
+        "VersionedCognitiveService"
       ]
     },
     "projection_port": {
@@ -39,6 +40,13 @@
       "symbols": [
         "ProjectionReceipt",
         "ProjectionAdapter"
+      ]
+    },
+    "cognitive_service_port": {
+      "module": "fossil_core.ports.cognitive_service",
+      "status": "supported",
+      "symbols": [
+        "VersionedCognitiveService"
       ]
     },
     "filesystem_adapter": {
@@ -263,6 +271,10 @@
     {
       "source": "fossil_core.contracts.ProjectionAdapter",
       "target": "fossil_core.ports.projection.ProjectionAdapter"
+    },
+    {
+      "source": "fossil_core.contracts.VersionedCognitiveService",
+      "target": "fossil_core.ports.cognitive_service.VersionedCognitiveService"
     }
   ]
 }

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -99,7 +99,17 @@ from fossil_core.ports.projection import ProjectionAdapter, ProjectionReceipt
 
 `ProjectionAdapter` describes a replaceable materialized view of already-durable knowledge. `ProjectionReceipt` records the outcome of applying or rebuilding that view. Neither type makes Graphiti, Neo4j, a local ledger, or any other projection authoritative durable truth.
 
-`fossil_core.contracts.ProjectionAdapter` and `fossil_core.contracts.ProjectionReceipt` remain identity-preserving aliases during migration. The entire `fossil_core.contracts` module is **not** classified as compatibility-only yet because it still owns the existing cognitive-service protocols (`Retriever`, `EmbeddingProvider`, `Reranker`, `ContextProvider`, `ModelService`, and `VerificationService`). Those interfaces require separate bounded migrations rather than one broad package move.
+Every replaceable cognitive capability shares the canonical metadata contract:
+
+```python
+from fossil_core.ports import VersionedCognitiveService
+# equivalent canonical module:
+from fossil_core.ports.cognitive_service import VersionedCognitiveService
+```
+
+`VersionedCognitiveService` requires the existing `metadata()` surface used to record implementation/provider/model/runtime provenance. This shared prerequisite is intentionally separated before `Retriever` and `ContextProvider` move into their target port modules, so those future ports do not depend on each other or on the legacy aggregate solely to inherit metadata behavior.
+
+`fossil_core.contracts.ProjectionAdapter`, `fossil_core.contracts.ProjectionReceipt`, and `fossil_core.contracts.VersionedCognitiveService` remain identity-preserving aliases during migration. The entire `fossil_core.contracts` module is **not** classified as compatibility-only yet because it still owns the existing cognitive capability protocols (`Retriever`, `EmbeddingProvider`, `Reranker`, `ContextProvider`, `ModelService`, and `VerificationService`). Those interfaces require separate bounded migrations rather than one broad package move.
 
 ## Canonical concrete adapters
 
@@ -135,7 +145,7 @@ The following flat paths remain valid only to prevent migration breakage:
 
 They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `annotations`, `hashlib`, and `uuid` names as well as the two identity functions. The promotion shim preserves its historical `Any`, `Iterable`, `annotations`, and `build_promotion_event` names. None of these compatibility-only modules gains a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
 
-`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. Likewise, `fossil_core.contracts` remains a mixed active module while its projection types forward to the canonical projection port.
+`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. Likewise, `fossil_core.contracts` remains a mixed active module while its projection and shared cognitive-metadata types forward to canonical ports.
 
 Removal is not authorized by this document. Compatibility modules may be removed only in an explicit cleanup phase after first-party consumers, clean-install tests, cross-repository contracts, and required hosted gates demonstrate that the old paths are no longer needed.
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -17,6 +17,7 @@ CANONICAL_MODULES = {
     "fossil_core.domain.promotion",
     "fossil_core.ports",
     "fossil_core.ports.artifact_store",
+    "fossil_core.ports.cognitive_service",
     "fossil_core.ports.event_store",
     "fossil_core.ports.projection",
     "fossil_core.adapters",

--- a/src/fossil_core/contracts.py
+++ b/src/fossil_core/contracts.py
@@ -4,13 +4,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
+from .ports.cognitive_service import VersionedCognitiveService
 from .ports.projection import ProjectionAdapter, ProjectionReceipt
-
-
-class VersionedCognitiveService(Protocol):
-    """Every replaceable cognitive service must expose durable provenance metadata."""
-
-    def metadata(self) -> dict[str, Any]: ...
 
 
 class Retriever(VersionedCognitiveService, Protocol):

--- a/src/fossil_core/ports/__init__.py
+++ b/src/fossil_core/ports/__init__.py
@@ -1,6 +1,7 @@
 """Provider-neutral interfaces for FOSSIL capabilities."""
 
 from .artifact_store import ArtifactStorePort
+from .cognitive_service import VersionedCognitiveService
 from .event_store import EventStorePort
 from .projection import ProjectionAdapter, ProjectionReceipt
 
@@ -9,4 +10,5 @@ __all__ = [
     "EventStorePort",
     "ProjectionReceipt",
     "ProjectionAdapter",
+    "VersionedCognitiveService",
 ]

--- a/src/fossil_core/ports/cognitive_service.py
+++ b/src/fossil_core/ports/cognitive_service.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class VersionedCognitiveService(Protocol):
+    """Every replaceable cognitive service must expose durable provenance metadata."""
+
+    def metadata(self) -> dict[str, Any]: ...
+
+
+__all__ = ["VersionedCognitiveService"]

--- a/tests/test_cognitive_service_port_compatibility.py
+++ b/tests/test_cognitive_service_port_compatibility.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import fossil_core.contracts as legacy_contracts
+import fossil_core.ports as ports
+from fossil_core.ports.cognitive_service import VersionedCognitiveService
+
+
+def test_cognitive_metadata_port_is_canonical_and_legacy_contract_preserves_identity():
+    assert legacy_contracts.VersionedCognitiveService is VersionedCognitiveService
+    assert ports.VersionedCognitiveService is VersionedCognitiveService
+
+
+def test_remaining_cognitive_protocols_keep_canonical_metadata_base():
+    for protocol in (
+        legacy_contracts.Retriever,
+        legacy_contracts.EmbeddingProvider,
+        legacy_contracts.Reranker,
+        legacy_contracts.ContextProvider,
+        legacy_contracts.ModelService,
+        legacy_contracts.VerificationService,
+    ):
+        assert VersionedCognitiveService in protocol.__mro__
+        assert hasattr(protocol, "metadata")
+
+
+def test_legacy_contracts_namespace_remains_frozen_after_metadata_extraction():
+    assert not hasattr(legacy_contracts, "__all__")
+    public_names = sorted(
+        name for name in vars(legacy_contracts) if not name.startswith("_")
+    )
+    assert public_names == [
+        "Any",
+        "ContextProvider",
+        "EmbeddingProvider",
+        "ModelService",
+        "Path",
+        "ProjectionAdapter",
+        "ProjectionReceipt",
+        "Protocol",
+        "Reranker",
+        "Retriever",
+        "VerificationService",
+        "VersionedCognitiveService",
+        "annotations",
+        "dataclass",
+    ]


### PR DESCRIPTION
Advances #82 Phase 4 with one prerequisite cognitive-port slice.

## Scope
- move `VersionedCognitiveService` from flat `fossil_core.contracts` to canonical `fossil_core.ports.cognitive_service`
- export the shared metadata Protocol from `fossil_core.ports`
- preserve `fossil_core.contracts.VersionedCognitiveService` object identity and the exact historical `contracts.py` implicit namespace
- keep `Retriever`, `EmbeddingProvider`, `Reranker`, `ContextProvider`, `ModelService`, and `VerificationService` in `fossil_core.contracts` for later bounded migrations
- preserve those six protocols inheriting the same canonical metadata base
- add public API declaration, architecture enforcement, compatibility tests, and migration guidance

## Why this prerequisite
#81 explicitly targets separate `ports/retriever.py` and `ports/context_provider.py` seams. Extracting their shared metadata base first prevents future target ports from depending on each other or back on the legacy aggregate solely for `metadata()`.

## Explicit non-goals
- no Retriever/ContextProvider/cognitive capability migration in this PR
- no metadata method/signature change
- no retrieval/context/model/verification behavior or policy change
- no projection/storage/provider change
- no event/schema/stable-ID/canonical-hash change
- no acceptance weakening

## Verification
- canonical/legacy/ports object identity
- all six remaining cognitive protocols preserve canonical metadata base
- exact legacy `fossil_core.contracts` namespace regression
- public API contract tests
- architecture-boundary tests
- full deterministic DKG suite
- Dependency Integrity
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `6e1e0da0d934d18ccd440e4bfeea77f74dadf4f4`