### PR TITLE
[ARCH-P4] Move Retriever contract behind canonical port

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -119,59 +119,174 @@
   "compatibility_modules": {
     "fossil_core.storage_ports": {
       "replacement": "fossil_core.ports",
-      "symbols": ["ArtifactStorePort", "EventStorePort"],
-      "star_exported_symbols": ["ArtifactStorePort", "EventStorePort"]
+      "symbols": [
+        "ArtifactStorePort",
+        "EventStorePort"
+      ],
+      "star_exported_symbols": [
+        "ArtifactStorePort",
+        "EventStorePort"
+      ]
     },
     "fossil_core.artifact_store": {
       "replacement": "fossil_core.adapters.filesystem",
-      "symbols": ["ArtifactIntegrityError", "ArtifactRedactedError", "ArtifactStore"],
-      "star_exported_symbols": ["ArtifactIntegrityError", "ArtifactRedactedError", "ArtifactStore"]
+      "symbols": [
+        "ArtifactIntegrityError",
+        "ArtifactRedactedError",
+        "ArtifactStore"
+      ],
+      "star_exported_symbols": [
+        "ArtifactIntegrityError",
+        "ArtifactRedactedError",
+        "ArtifactStore"
+      ]
     },
     "fossil_core.event_store": {
       "replacement": "fossil_core.adapters.filesystem",
-      "symbols": ["DurableEventStore", "EventRedactedError", "EventRedactionConflict", "IdempotencyConflict"],
-      "star_exported_symbols": ["DurableEventStore", "EventRedactedError", "EventRedactionConflict", "IdempotencyConflict"]
+      "symbols": [
+        "DurableEventStore",
+        "EventRedactedError",
+        "EventRedactionConflict",
+        "IdempotencyConflict"
+      ],
+      "star_exported_symbols": [
+        "DurableEventStore",
+        "EventRedactedError",
+        "EventRedactionConflict",
+        "IdempotencyConflict"
+      ]
     },
     "fossil_core.s3_storage": {
       "replacement": "fossil_core.adapters.s3",
-      "symbols": ["RemoteObjectConflict", "RemoteStoreUnavailable", "S3ArtifactStore", "S3DurableEventStore"],
-      "star_exported_symbols": ["RemoteStoreUnavailable", "S3ArtifactStore", "S3DurableEventStore"]
+      "symbols": [
+        "RemoteObjectConflict",
+        "RemoteStoreUnavailable",
+        "S3ArtifactStore",
+        "S3DurableEventStore"
+      ],
+      "star_exported_symbols": [
+        "RemoteStoreUnavailable",
+        "S3ArtifactStore",
+        "S3DurableEventStore"
+      ]
     },
     "fossil_core.lifecycle": {
       "replacement": "fossil_core.domain.lifecycle",
-      "symbols": ["CLAIM_STATES", "RELATION_STATES", "RELATION_TYPES", "LifecycleError", "RelationRecord", "KnowledgeState"],
+      "symbols": [
+        "CLAIM_STATES",
+        "RELATION_STATES",
+        "RELATION_TYPES",
+        "LifecycleError",
+        "RelationRecord",
+        "KnowledgeState"
+      ],
       "star_exported_symbols": null,
-      "implicit_star_exported_symbols": ["Any", "CLAIM_STATES", "Iterable", "KnowledgeState", "LifecycleError", "RELATION_STATES", "RELATION_TYPES", "RelationRecord", "dataclass", "field"]
+      "implicit_star_exported_symbols": [
+        "Any",
+        "CLAIM_STATES",
+        "Iterable",
+        "KnowledgeState",
+        "LifecycleError",
+        "RELATION_STATES",
+        "RELATION_TYPES",
+        "RelationRecord",
+        "dataclass",
+        "field"
+      ]
     },
     "fossil_core.ids": {
       "replacement": "fossil_core.domain.identity",
-      "symbols": ["new_id", "deterministic_event_id"],
+      "symbols": [
+        "new_id",
+        "deterministic_event_id"
+      ],
       "star_exported_symbols": null,
-      "implicit_star_exported_symbols": ["annotations", "deterministic_event_id", "hashlib", "new_id", "uuid"]
+      "implicit_star_exported_symbols": [
+        "annotations",
+        "deterministic_event_id",
+        "hashlib",
+        "new_id",
+        "uuid"
+      ]
     },
     "fossil_core.promotion": {
       "replacement": "fossil_core.domain.promotion",
-      "symbols": ["build_promotion_event"],
+      "symbols": [
+        "build_promotion_event"
+      ],
       "star_exported_symbols": null,
-      "implicit_star_exported_symbols": ["Any", "Iterable", "annotations", "build_promotion_event"]
+      "implicit_star_exported_symbols": [
+        "Any",
+        "Iterable",
+        "annotations",
+        "build_promotion_event"
+      ]
     }
   },
   "identity_aliases": [
-    {"source": "fossil_core.ArtifactIntegrityError", "target": "fossil_core.adapters.filesystem.ArtifactIntegrityError"},
-    {"source": "fossil_core.ArtifactStore", "target": "fossil_core.adapters.filesystem.ArtifactStore"},
-    {"source": "fossil_core.DurableEventStore", "target": "fossil_core.adapters.filesystem.DurableEventStore"},
-    {"source": "fossil_core.IdempotencyConflict", "target": "fossil_core.adapters.filesystem.IdempotencyConflict"},
-    {"source": "fossil_core.KnowledgeState", "target": "fossil_core.domain.lifecycle.KnowledgeState"},
-    {"source": "fossil_core.LifecycleError", "target": "fossil_core.domain.lifecycle.LifecycleError"},
-    {"source": "fossil_core.RelationRecord", "target": "fossil_core.domain.lifecycle.RelationRecord"},
-    {"source": "fossil_core.PackAccess", "target": "fossil_core.domain.pack.PackAccess"},
-    {"source": "fossil_core.PackBoundaryError", "target": "fossil_core.domain.pack.PackBoundaryError"},
-    {"source": "fossil_core.ids.new_id", "target": "fossil_core.domain.identity.new_id"},
-    {"source": "fossil_core.ids.deterministic_event_id", "target": "fossil_core.domain.identity.deterministic_event_id"},
-    {"source": "fossil_core.build_promotion_event", "target": "fossil_core.domain.promotion.build_promotion_event"},
-    {"source": "fossil_core.contracts.ProjectionReceipt", "target": "fossil_core.ports.projection.ProjectionReceipt"},
-    {"source": "fossil_core.contracts.ProjectionAdapter", "target": "fossil_core.ports.projection.ProjectionAdapter"},
-    {"source": "fossil_core.contracts.VersionedCognitiveService", "target": "fossil_core.ports.cognitive_service.VersionedCognitiveService"},
-    {"source": "fossil_core.contracts.Retriever", "target": "fossil_core.ports.retriever.Retriever"}
+    {
+      "source": "fossil_core.ArtifactIntegrityError",
+      "target": "fossil_core.adapters.filesystem.ArtifactIntegrityError"
+    },
+    {
+      "source": "fossil_core.ArtifactStore",
+      "target": "fossil_core.adapters.filesystem.ArtifactStore"
+    },
+    {
+      "source": "fossil_core.DurableEventStore",
+      "target": "fossil_core.adapters.filesystem.DurableEventStore"
+    },
+    {
+      "source": "fossil_core.IdempotencyConflict",
+      "target": "fossil_core.adapters.filesystem.IdempotencyConflict"
+    },
+    {
+      "source": "fossil_core.KnowledgeState",
+      "target": "fossil_core.domain.lifecycle.KnowledgeState"
+    },
+    {
+      "source": "fossil_core.LifecycleError",
+      "target": "fossil_core.domain.lifecycle.LifecycleError"
+    },
+    {
+      "source": "fossil_core.RelationRecord",
+      "target": "fossil_core.domain.lifecycle.RelationRecord"
+    },
+    {
+      "source": "fossil_core.PackAccess",
+      "target": "fossil_core.domain.pack.PackAccess"
+    },
+    {
+      "source": "fossil_core.PackBoundaryError",
+      "target": "fossil_core.domain.pack.PackBoundaryError"
+    },
+    {
+      "source": "fossil_core.ids.new_id",
+      "target": "fossil_core.domain.identity.new_id"
+    },
+    {
+      "source": "fossil_core.ids.deterministic_event_id",
+      "target": "fossil_core.domain.identity.deterministic_event_id"
+    },
+    {
+      "source": "fossil_core.build_promotion_event",
+      "target": "fossil_core.domain.promotion.build_promotion_event"
+    },
+    {
+      "source": "fossil_core.contracts.ProjectionReceipt",
+      "target": "fossil_core.ports.projection.ProjectionReceipt"
+    },
+    {
+      "source": "fossil_core.contracts.ProjectionAdapter",
+      "target": "fossil_core.ports.projection.ProjectionAdapter"
+    },
+    {
+      "source": "fossil_core.contracts.VersionedCognitiveService",
+      "target": "fossil_core.ports.cognitive_service.VersionedCognitiveService"
+    },
+    {
+      "source": "fossil_core.contracts.Retriever",
+      "target": "fossil_core.ports.retriever.Retriever"
+    }
   ]
 }

--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -31,7 +31,8 @@
         "EventStorePort",
         "ProjectionReceipt",
         "ProjectionAdapter",
-        "VersionedCognitiveService"
+        "VersionedCognitiveService",
+        "Retriever"
       ]
     },
     "projection_port": {
@@ -47,6 +48,13 @@
       "status": "supported",
       "symbols": [
         "VersionedCognitiveService"
+      ]
+    },
+    "retriever_port": {
+      "module": "fossil_core.ports.retriever",
+      "status": "supported",
+      "symbols": [
+        "Retriever"
       ]
     },
     "filesystem_adapter": {
@@ -111,170 +119,59 @@
   "compatibility_modules": {
     "fossil_core.storage_ports": {
       "replacement": "fossil_core.ports",
-      "symbols": [
-        "ArtifactStorePort",
-        "EventStorePort"
-      ],
-      "star_exported_symbols": [
-        "ArtifactStorePort",
-        "EventStorePort"
-      ]
+      "symbols": ["ArtifactStorePort", "EventStorePort"],
+      "star_exported_symbols": ["ArtifactStorePort", "EventStorePort"]
     },
     "fossil_core.artifact_store": {
       "replacement": "fossil_core.adapters.filesystem",
-      "symbols": [
-        "ArtifactIntegrityError",
-        "ArtifactRedactedError",
-        "ArtifactStore"
-      ],
-      "star_exported_symbols": [
-        "ArtifactIntegrityError",
-        "ArtifactRedactedError",
-        "ArtifactStore"
-      ]
+      "symbols": ["ArtifactIntegrityError", "ArtifactRedactedError", "ArtifactStore"],
+      "star_exported_symbols": ["ArtifactIntegrityError", "ArtifactRedactedError", "ArtifactStore"]
     },
     "fossil_core.event_store": {
       "replacement": "fossil_core.adapters.filesystem",
-      "symbols": [
-        "DurableEventStore",
-        "EventRedactedError",
-        "EventRedactionConflict",
-        "IdempotencyConflict"
-      ],
-      "star_exported_symbols": [
-        "DurableEventStore",
-        "EventRedactedError",
-        "EventRedactionConflict",
-        "IdempotencyConflict"
-      ]
+      "symbols": ["DurableEventStore", "EventRedactedError", "EventRedactionConflict", "IdempotencyConflict"],
+      "star_exported_symbols": ["DurableEventStore", "EventRedactedError", "EventRedactionConflict", "IdempotencyConflict"]
     },
     "fossil_core.s3_storage": {
       "replacement": "fossil_core.adapters.s3",
-      "symbols": [
-        "RemoteObjectConflict",
-        "RemoteStoreUnavailable",
-        "S3ArtifactStore",
-        "S3DurableEventStore"
-      ],
-      "star_exported_symbols": [
-        "RemoteStoreUnavailable",
-        "S3ArtifactStore",
-        "S3DurableEventStore"
-      ]
+      "symbols": ["RemoteObjectConflict", "RemoteStoreUnavailable", "S3ArtifactStore", "S3DurableEventStore"],
+      "star_exported_symbols": ["RemoteStoreUnavailable", "S3ArtifactStore", "S3DurableEventStore"]
     },
     "fossil_core.lifecycle": {
       "replacement": "fossil_core.domain.lifecycle",
-      "symbols": [
-        "CLAIM_STATES",
-        "RELATION_STATES",
-        "RELATION_TYPES",
-        "LifecycleError",
-        "RelationRecord",
-        "KnowledgeState"
-      ],
+      "symbols": ["CLAIM_STATES", "RELATION_STATES", "RELATION_TYPES", "LifecycleError", "RelationRecord", "KnowledgeState"],
       "star_exported_symbols": null,
-      "implicit_star_exported_symbols": [
-        "Any",
-        "CLAIM_STATES",
-        "Iterable",
-        "KnowledgeState",
-        "LifecycleError",
-        "RELATION_STATES",
-        "RELATION_TYPES",
-        "RelationRecord",
-        "dataclass",
-        "field"
-      ]
+      "implicit_star_exported_symbols": ["Any", "CLAIM_STATES", "Iterable", "KnowledgeState", "LifecycleError", "RELATION_STATES", "RELATION_TYPES", "RelationRecord", "dataclass", "field"]
     },
     "fossil_core.ids": {
       "replacement": "fossil_core.domain.identity",
-      "symbols": [
-        "new_id",
-        "deterministic_event_id"
-      ],
+      "symbols": ["new_id", "deterministic_event_id"],
       "star_exported_symbols": null,
-      "implicit_star_exported_symbols": [
-        "annotations",
-        "deterministic_event_id",
-        "hashlib",
-        "new_id",
-        "uuid"
-      ]
+      "implicit_star_exported_symbols": ["annotations", "deterministic_event_id", "hashlib", "new_id", "uuid"]
     },
     "fossil_core.promotion": {
       "replacement": "fossil_core.domain.promotion",
-      "symbols": [
-        "build_promotion_event"
-      ],
+      "symbols": ["build_promotion_event"],
       "star_exported_symbols": null,
-      "implicit_star_exported_symbols": [
-        "Any",
-        "Iterable",
-        "annotations",
-        "build_promotion_event"
-      ]
+      "implicit_star_exported_symbols": ["Any", "Iterable", "annotations", "build_promotion_event"]
     }
   },
   "identity_aliases": [
-    {
-      "source": "fossil_core.ArtifactIntegrityError",
-      "target": "fossil_core.adapters.filesystem.ArtifactIntegrityError"
-    },
-    {
-      "source": "fossil_core.ArtifactStore",
-      "target": "fossil_core.adapters.filesystem.ArtifactStore"
-    },
-    {
-      "source": "fossil_core.DurableEventStore",
-      "target": "fossil_core.adapters.filesystem.DurableEventStore"
-    },
-    {
-      "source": "fossil_core.IdempotencyConflict",
-      "target": "fossil_core.adapters.filesystem.IdempotencyConflict"
-    },
-    {
-      "source": "fossil_core.KnowledgeState",
-      "target": "fossil_core.domain.lifecycle.KnowledgeState"
-    },
-    {
-      "source": "fossil_core.LifecycleError",
-      "target": "fossil_core.domain.lifecycle.LifecycleError"
-    },
-    {
-      "source": "fossil_core.RelationRecord",
-      "target": "fossil_core.domain.lifecycle.RelationRecord"
-    },
-    {
-      "source": "fossil_core.PackAccess",
-      "target": "fossil_core.domain.pack.PackAccess"
-    },
-    {
-      "source": "fossil_core.PackBoundaryError",
-      "target": "fossil_core.domain.pack.PackBoundaryError"
-    },
-    {
-      "source": "fossil_core.ids.new_id",
-      "target": "fossil_core.domain.identity.new_id"
-    },
-    {
-      "source": "fossil_core.ids.deterministic_event_id",
-      "target": "fossil_core.domain.identity.deterministic_event_id"
-    },
-    {
-      "source": "fossil_core.build_promotion_event",
-      "target": "fossil_core.domain.promotion.build_promotion_event"
-    },
-    {
-      "source": "fossil_core.contracts.ProjectionReceipt",
-      "target": "fossil_core.ports.projection.ProjectionReceipt"
-    },
-    {
-      "source": "fossil_core.contracts.ProjectionAdapter",
-      "target": "fossil_core.ports.projection.ProjectionAdapter"
-    },
-    {
-      "source": "fossil_core.contracts.VersionedCognitiveService",
-      "target": "fossil_core.ports.cognitive_service.VersionedCognitiveService"
-    }
+    {"source": "fossil_core.ArtifactIntegrityError", "target": "fossil_core.adapters.filesystem.ArtifactIntegrityError"},
+    {"source": "fossil_core.ArtifactStore", "target": "fossil_core.adapters.filesystem.ArtifactStore"},
+    {"source": "fossil_core.DurableEventStore", "target": "fossil_core.adapters.filesystem.DurableEventStore"},
+    {"source": "fossil_core.IdempotencyConflict", "target": "fossil_core.adapters.filesystem.IdempotencyConflict"},
+    {"source": "fossil_core.KnowledgeState", "target": "fossil_core.domain.lifecycle.KnowledgeState"},
+    {"source": "fossil_core.LifecycleError", "target": "fossil_core.domain.lifecycle.LifecycleError"},
+    {"source": "fossil_core.RelationRecord", "target": "fossil_core.domain.lifecycle.RelationRecord"},
+    {"source": "fossil_core.PackAccess", "target": "fossil_core.domain.pack.PackAccess"},
+    {"source": "fossil_core.PackBoundaryError", "target": "fossil_core.domain.pack.PackBoundaryError"},
+    {"source": "fossil_core.ids.new_id", "target": "fossil_core.domain.identity.new_id"},
+    {"source": "fossil_core.ids.deterministic_event_id", "target": "fossil_core.domain.identity.deterministic_event_id"},
+    {"source": "fossil_core.build_promotion_event", "target": "fossil_core.domain.promotion.build_promotion_event"},
+    {"source": "fossil_core.contracts.ProjectionReceipt", "target": "fossil_core.ports.projection.ProjectionReceipt"},
+    {"source": "fossil_core.contracts.ProjectionAdapter", "target": "fossil_core.ports.projection.ProjectionAdapter"},
+    {"source": "fossil_core.contracts.VersionedCognitiveService", "target": "fossil_core.ports.cognitive_service.VersionedCognitiveService"},
+    {"source": "fossil_core.contracts.Retriever", "target": "fossil_core.ports.retriever.Retriever"}
   ]
 }

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -107,9 +107,19 @@ from fossil_core.ports import VersionedCognitiveService
 from fossil_core.ports.cognitive_service import VersionedCognitiveService
 ```
 
-`VersionedCognitiveService` requires the existing `metadata()` surface used to record implementation/provider/model/runtime provenance. This shared prerequisite is intentionally separated before `Retriever` and `ContextProvider` move into their target port modules, so those future ports do not depend on each other or on the legacy aggregate solely to inherit metadata behavior.
+`VersionedCognitiveService` requires the existing `metadata()` surface used to record implementation/provider/model/runtime provenance.
 
-`fossil_core.contracts.ProjectionAdapter`, `fossil_core.contracts.ProjectionReceipt`, and `fossil_core.contracts.VersionedCognitiveService` remain identity-preserving aliases during migration. The entire `fossil_core.contracts` module is **not** classified as compatibility-only yet because it still owns the existing cognitive capability protocols (`Retriever`, `EmbeddingProvider`, `Reranker`, `ContextProvider`, `ModelService`, and `VerificationService`). Those interfaces require separate bounded migrations rather than one broad package move.
+Retrieval capability code should depend on the canonical Retriever port:
+
+```python
+from fossil_core.ports import Retriever
+# equivalent canonical module:
+from fossil_core.ports.retriever import Retriever
+```
+
+`Retriever.search` retains the existing contract: `query`, keyword-only `pack_ids`, and keyword-only `limit=20`, returning ranked candidate dictionaries. Moving the Protocol does not alter lexical, embedding, hybrid, reranking, filtering, or query semantics implemented by concrete services.
+
+`fossil_core.contracts.ProjectionAdapter`, `fossil_core.contracts.ProjectionReceipt`, `fossil_core.contracts.VersionedCognitiveService`, and `fossil_core.contracts.Retriever` remain identity-preserving aliases during migration. The entire `fossil_core.contracts` module is **not** classified as compatibility-only yet because it still owns `EmbeddingProvider`, `Reranker`, `ContextProvider`, `ModelService`, and `VerificationService`. Those interfaces require separate bounded migrations rather than one broad package move.
 
 ## Canonical concrete adapters
 
@@ -145,7 +155,7 @@ The following flat paths remain valid only to prevent migration breakage:
 
 They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `annotations`, `hashlib`, and `uuid` names as well as the two identity functions. The promotion shim preserves its historical `Any`, `Iterable`, `annotations`, and `build_promotion_event` names. None of these compatibility-only modules gains a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
 
-`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. Likewise, `fossil_core.contracts` remains a mixed active module while its projection and shared cognitive-metadata types forward to canonical ports.
+`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. Likewise, `fossil_core.contracts` remains a mixed active module while migrated projection, cognitive-metadata, and Retriever types forward to canonical ports.
 
 Removal is not authorized by this document. Compatibility modules may be removed only in an explicit cleanup phase after first-party consumers, clean-install tests, cross-repository contracts, and required hosted gates demonstrate that the old paths are no longer needed.
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -20,6 +20,7 @@ CANONICAL_MODULES = {
     "fossil_core.ports.cognitive_service",
     "fossil_core.ports.event_store",
     "fossil_core.ports.projection",
+    "fossil_core.ports.retriever",
     "fossil_core.adapters",
     "fossil_core.adapters.filesystem",
     "fossil_core.adapters.filesystem.artifact_store",

--- a/src/fossil_core/contracts.py
+++ b/src/fossil_core/contracts.py
@@ -6,16 +6,7 @@ from typing import Any, Protocol
 
 from .ports.cognitive_service import VersionedCognitiveService
 from .ports.projection import ProjectionAdapter, ProjectionReceipt
-
-
-class Retriever(VersionedCognitiveService, Protocol):
-    def search(
-        self,
-        query: str,
-        *,
-        pack_ids: list[str],
-        limit: int = 20,
-    ) -> list[dict[str, Any]]: ...
+from .ports.retriever import Retriever
 
 
 class EmbeddingProvider(VersionedCognitiveService, Protocol):

--- a/src/fossil_core/ports/__init__.py
+++ b/src/fossil_core/ports/__init__.py
@@ -4,6 +4,7 @@ from .artifact_store import ArtifactStorePort
 from .cognitive_service import VersionedCognitiveService
 from .event_store import EventStorePort
 from .projection import ProjectionAdapter, ProjectionReceipt
+from .retriever import Retriever
 
 __all__ = [
     "ArtifactStorePort",
@@ -11,4 +12,5 @@ __all__ = [
     "ProjectionReceipt",
     "ProjectionAdapter",
     "VersionedCognitiveService",
+    "Retriever",
 ]

--- a/src/fossil_core/ports/retriever.py
+++ b/src/fossil_core/ports/retriever.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from .cognitive_service import VersionedCognitiveService
+
+
+class Retriever(VersionedCognitiveService, Protocol):
+    def search(
+        self,
+        query: str,
+        *,
+        pack_ids: list[str],
+        limit: int = 20,
+    ) -> list[dict[str, Any]]: ...
+
+
+__all__ = ["Retriever"]

--- a/tests/test_retriever_port_compatibility.py
+++ b/tests/test_retriever_port_compatibility.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import inspect
+
+import fossil_core.contracts as legacy_contracts
+import fossil_core.ports as ports
+from fossil_core.ports.cognitive_service import VersionedCognitiveService
+from fossil_core.ports.retriever import Retriever
+
+
+def test_retriever_port_is_canonical_and_legacy_contract_preserves_identity():
+    assert legacy_contracts.Retriever is Retriever
+    assert ports.Retriever is Retriever
+    assert VersionedCognitiveService in Retriever.__mro__
+
+
+def test_retriever_search_contract_is_unchanged():
+    signature = inspect.signature(Retriever.search)
+    parameters = list(signature.parameters.values())
+
+    assert [parameter.name for parameter in parameters] == [
+        "self",
+        "query",
+        "pack_ids",
+        "limit",
+    ]
+    assert parameters[2].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters[3].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters[3].default == 20
+
+
+def test_legacy_contracts_namespace_remains_frozen_after_retriever_extraction():
+    assert not hasattr(legacy_contracts, "__all__")
+    public_names = sorted(
+        name for name in vars(legacy_contracts) if not name.startswith("_")
+    )
+    assert public_names == [
+        "Any",
+        "ContextProvider",
+        "EmbeddingProvider",
+        "ModelService",
+        "Path",
+        "ProjectionAdapter",
+        "ProjectionReceipt",
+        "Protocol",
+        "Reranker",
+        "Retriever",
+        "VerificationService",
+        "VersionedCognitiveService",
+        "annotations",
+        "dataclass",
+    ]


### PR DESCRIPTION
Advances #82 Phase 4 with the explicit #81 Retriever port seam.

## Scope
- move `Retriever` from flat `fossil_core.contracts` to canonical `fossil_core.ports.retriever`
- inherit the canonical `VersionedCognitiveService` metadata base
- export `Retriever` from `fossil_core.ports`
- preserve `fossil_core.contracts.Retriever` object identity and the exact historical `contracts.py` implicit namespace
- freeze the existing `search(query, *, pack_ids, limit=20)` Protocol signature
- add public API declaration, architecture enforcement, compatibility tests, and migration guidance

## Explicit non-goals
- no retrieval implementation or scoring changes
- no lexical/embedding/hybrid/query/filter semantics changes
- no EmbeddingProvider or Reranker migration
- no ContextProvider/ModelService/VerificationService migration
- no event/schema/stable-ID/canonical-hash changes
- no storage/provider/projection changes
- no acceptance weakening

## Verification
- canonical/legacy/ports object identity
- exact Retriever search signature regression
- exact legacy `fossil_core.contracts` namespace regression
- public API contract tests
- architecture-boundary tests
- full deterministic DKG suite
- Dependency Integrity
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `b86bd42774dc9a708d47736290f746627ac26033`