### PR TITLE
[ARCH-P4] Move ContextProvider contract behind canonical port

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -32,7 +32,8 @@
         "ProjectionReceipt",
         "ProjectionAdapter",
         "VersionedCognitiveService",
-        "Retriever"
+        "Retriever",
+        "ContextProvider"
       ]
     },
     "projection_port": {
@@ -55,6 +56,13 @@
       "status": "supported",
       "symbols": [
         "Retriever"
+      ]
+    },
+    "context_provider_port": {
+      "module": "fossil_core.ports.context_provider",
+      "status": "supported",
+      "symbols": [
+        "ContextProvider"
       ]
     },
     "filesystem_adapter": {
@@ -287,6 +295,10 @@
     {
       "source": "fossil_core.contracts.Retriever",
       "target": "fossil_core.ports.retriever.Retriever"
+    },
+    {
+      "source": "fossil_core.contracts.ContextProvider",
+      "target": "fossil_core.ports.context_provider.ContextProvider"
     }
   ]
 }

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -119,7 +119,17 @@ from fossil_core.ports.retriever import Retriever
 
 `Retriever.search` retains the existing contract: `query`, keyword-only `pack_ids`, and keyword-only `limit=20`, returning ranked candidate dictionaries. Moving the Protocol does not alter lexical, embedding, hybrid, reranking, filtering, or query semantics implemented by concrete services.
 
-`fossil_core.contracts.ProjectionAdapter`, `fossil_core.contracts.ProjectionReceipt`, `fossil_core.contracts.VersionedCognitiveService`, and `fossil_core.contracts.Retriever` remain identity-preserving aliases during migration. The entire `fossil_core.contracts` module is **not** classified as compatibility-only yet because it still owns `EmbeddingProvider`, `Reranker`, `ContextProvider`, `ModelService`, and `VerificationService`. Those interfaces require separate bounded migrations rather than one broad package move.
+Context-construction capability code should depend on the canonical ContextProvider port:
+
+```python
+from fossil_core.ports import ContextProvider
+# equivalent canonical module:
+from fossil_core.ports.context_provider import ContextProvider
+```
+
+`ContextProvider.build_context` retains the existing `build_context(request) -> dict[str, Any]` contract. Moving the Protocol does not change context budgets, compression policy, source selection, redaction/security policy, ranking, or any concrete context-construction implementation.
+
+`fossil_core.contracts.ProjectionAdapter`, `fossil_core.contracts.ProjectionReceipt`, `fossil_core.contracts.VersionedCognitiveService`, `fossil_core.contracts.Retriever`, and `fossil_core.contracts.ContextProvider` remain identity-preserving aliases during migration. The entire `fossil_core.contracts` module is **not** classified as compatibility-only yet because it still owns `EmbeddingProvider`, `Reranker`, `ModelService`, and `VerificationService`. Those interfaces require separate bounded migrations rather than one broad package move.
 
 ## Canonical concrete adapters
 
@@ -155,7 +165,7 @@ The following flat paths remain valid only to prevent migration breakage:
 
 They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `annotations`, `hashlib`, and `uuid` names as well as the two identity functions. The promotion shim preserves its historical `Any`, `Iterable`, `annotations`, and `build_promotion_event` names. None of these compatibility-only modules gains a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
 
-`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. Likewise, `fossil_core.contracts` remains a mixed active module while migrated projection, cognitive-metadata, and Retriever types forward to canonical ports.
+`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. Likewise, `fossil_core.contracts` remains a mixed active module while migrated projection, cognitive-metadata, Retriever, and ContextProvider types forward to canonical ports.
 
 Removal is not authorized by this document. Compatibility modules may be removed only in an explicit cleanup phase after first-party consumers, clean-install tests, cross-repository contracts, and required hosted gates demonstrate that the old paths are no longer needed.
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -18,6 +18,7 @@ CANONICAL_MODULES = {
     "fossil_core.ports",
     "fossil_core.ports.artifact_store",
     "fossil_core.ports.cognitive_service",
+    "fossil_core.ports.context_provider",
     "fossil_core.ports.event_store",
     "fossil_core.ports.projection",
     "fossil_core.ports.retriever",

--- a/src/fossil_core/contracts.py
+++ b/src/fossil_core/contracts.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from .ports.cognitive_service import VersionedCognitiveService
+from .ports.context_provider import ContextProvider
 from .ports.projection import ProjectionAdapter, ProjectionReceipt
 from .ports.retriever import Retriever
 
@@ -24,10 +25,6 @@ class Reranker(VersionedCognitiveService, Protocol):
         *,
         limit: int,
     ) -> list[dict[str, Any]]: ...
-
-
-class ContextProvider(VersionedCognitiveService, Protocol):
-    def build_context(self, request: dict[str, Any]) -> dict[str, Any]: ...
 
 
 class ModelService(VersionedCognitiveService, Protocol):

--- a/src/fossil_core/ports/__init__.py
+++ b/src/fossil_core/ports/__init__.py
@@ -2,6 +2,7 @@
 
 from .artifact_store import ArtifactStorePort
 from .cognitive_service import VersionedCognitiveService
+from .context_provider import ContextProvider
 from .event_store import EventStorePort
 from .projection import ProjectionAdapter, ProjectionReceipt
 from .retriever import Retriever
@@ -13,4 +14,5 @@ __all__ = [
     "ProjectionAdapter",
     "VersionedCognitiveService",
     "Retriever",
+    "ContextProvider",
 ]

--- a/src/fossil_core/ports/context_provider.py
+++ b/src/fossil_core/ports/context_provider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from .cognitive_service import VersionedCognitiveService
+
+
+class ContextProvider(VersionedCognitiveService, Protocol):
+    def build_context(self, request: dict[str, Any]) -> dict[str, Any]: ...
+
+
+__all__ = ["ContextProvider"]

--- a/tests/test_context_provider_port_compatibility.py
+++ b/tests/test_context_provider_port_compatibility.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import inspect
+
+import fossil_core.contracts as legacy_contracts
+import fossil_core.ports as ports
+from fossil_core.ports.cognitive_service import VersionedCognitiveService
+from fossil_core.ports.context_provider import ContextProvider
+
+
+def test_context_provider_port_is_canonical_and_legacy_contract_preserves_identity():
+    assert legacy_contracts.ContextProvider is ContextProvider
+    assert ports.ContextProvider is ContextProvider
+    assert VersionedCognitiveService in ContextProvider.__mro__
+
+
+def test_context_provider_build_contract_is_unchanged():
+    signature = inspect.signature(ContextProvider.build_context)
+    parameters = list(signature.parameters.values())
+
+    assert [parameter.name for parameter in parameters] == ["self", "request"]
+    assert parameters[1].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+
+
+def test_legacy_contracts_namespace_remains_frozen_after_context_provider_extraction():
+    assert not hasattr(legacy_contracts, "__all__")
+    public_names = sorted(
+        name for name in vars(legacy_contracts) if not name.startswith("_")
+    )
+    assert public_names == [
+        "Any",
+        "ContextProvider",
+        "EmbeddingProvider",
+        "ModelService",
+        "Path",
+        "ProjectionAdapter",
+        "ProjectionReceipt",
+        "Protocol",
+        "Reranker",
+        "Retriever",
+        "VerificationService",
+        "VersionedCognitiveService",
+        "annotations",
+        "dataclass",
+    ]


### PR DESCRIPTION
Advances #82 Phase 4 with the explicit #81 ContextProvider port seam.

## Scope
- move `ContextProvider` from flat `fossil_core.contracts` to canonical `fossil_core.ports.context_provider`
- inherit the canonical `VersionedCognitiveService` metadata base
- export `ContextProvider` from `fossil_core.ports`
- preserve `fossil_core.contracts.ContextProvider` object identity and the exact historical `contracts.py` implicit namespace
- freeze the existing `build_context(request) -> dict[str, Any]` Protocol signature
- add public API declaration, architecture enforcement, compatibility tests, and migration guidance

## Explicit non-goals
- no context budgeting/compression/source-selection/security-policy changes
- no context implementation move
- no retrieval/model/verification behavior changes
- no EmbeddingProvider or Reranker migration
- no event/schema/stable-ID/canonical-hash changes
- no storage/provider/projection changes
- no acceptance weakening

## Verification
- canonical/legacy/ports object identity
- exact ContextProvider build_context signature regression
- exact legacy `fossil_core.contracts` namespace regression
- public API contract tests
- architecture-boundary tests
- full deterministic DKG suite
- Dependency Integrity
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `b4b5549e08f1a03abda660d82b1d3f3000c6ecc0`