### PR TITLE
[ARCH-P4] Move EmbeddingProvider contract behind canonical port

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -33,7 +33,8 @@
         "ProjectionAdapter",
         "VersionedCognitiveService",
         "Retriever",
-        "ContextProvider"
+        "ContextProvider",
+        "EmbeddingProvider"
       ]
     },
     "projection_port": {
@@ -63,6 +64,13 @@
       "status": "supported",
       "symbols": [
         "ContextProvider"
+      ]
+    },
+    "embedding_provider_port": {
+      "module": "fossil_core.ports.embedding_provider",
+      "status": "supported",
+      "symbols": [
+        "EmbeddingProvider"
       ]
     },
     "filesystem_adapter": {
@@ -299,6 +307,10 @@
     {
       "source": "fossil_core.contracts.ContextProvider",
       "target": "fossil_core.ports.context_provider.ContextProvider"
+    },
+    {
+      "source": "fossil_core.contracts.EmbeddingProvider",
+      "target": "fossil_core.ports.embedding_provider.EmbeddingProvider"
     }
   ]
 }

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -129,7 +129,17 @@ from fossil_core.ports.context_provider import ContextProvider
 
 `ContextProvider.build_context` retains the existing `build_context(request) -> dict[str, Any]` contract. Moving the Protocol does not change context budgets, compression policy, source selection, redaction/security policy, ranking, or any concrete context-construction implementation.
 
-`fossil_core.contracts.ProjectionAdapter`, `fossil_core.contracts.ProjectionReceipt`, `fossil_core.contracts.VersionedCognitiveService`, `fossil_core.contracts.Retriever`, and `fossil_core.contracts.ContextProvider` remain identity-preserving aliases during migration. The entire `fossil_core.contracts` module is **not** classified as compatibility-only yet because it still owns `EmbeddingProvider`, `Reranker`, `ModelService`, and `VerificationService`. Those interfaces require separate bounded migrations rather than one broad package move.
+Embedding capability code should depend on the canonical EmbeddingProvider port:
+
+```python
+from fossil_core.ports import EmbeddingProvider
+# equivalent canonical module:
+from fossil_core.ports.embedding_provider import EmbeddingProvider
+```
+
+`EmbeddingProvider` retains the existing `model_id` property and `embed(texts) -> list[list[float]]` contract. Moving the Protocol does not select a provider/model, change vector dimensions or normalization, alter batching/caching behavior, or change any retrieval/reranking policy.
+
+`fossil_core.contracts.ProjectionAdapter`, `fossil_core.contracts.ProjectionReceipt`, `fossil_core.contracts.VersionedCognitiveService`, `fossil_core.contracts.Retriever`, `fossil_core.contracts.ContextProvider`, and `fossil_core.contracts.EmbeddingProvider` remain identity-preserving aliases during migration. The entire `fossil_core.contracts` module is **not** classified as compatibility-only yet because it still owns `Reranker`, `ModelService`, and `VerificationService`. Those interfaces require separate bounded migrations rather than one broad package move.
 
 ## Canonical concrete adapters
 
@@ -165,7 +175,7 @@ The following flat paths remain valid only to prevent migration breakage:
 
 They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `annotations`, `hashlib`, and `uuid` names as well as the two identity functions. The promotion shim preserves its historical `Any`, `Iterable`, `annotations`, and `build_promotion_event` names. None of these compatibility-only modules gains a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
 
-`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. Likewise, `fossil_core.contracts` remains a mixed active module while migrated projection, cognitive-metadata, Retriever, and ContextProvider types forward to canonical ports.
+`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. Likewise, `fossil_core.contracts` remains a mixed active module while migrated projection, cognitive-metadata, Retriever, ContextProvider, and EmbeddingProvider types forward to canonical ports.
 
 Removal is not authorized by this document. Compatibility modules may be removed only in an explicit cleanup phase after first-party consumers, clean-install tests, cross-repository contracts, and required hosted gates demonstrate that the old paths are no longer needed.
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -19,6 +19,7 @@ CANONICAL_MODULES = {
     "fossil_core.ports.artifact_store",
     "fossil_core.ports.cognitive_service",
     "fossil_core.ports.context_provider",
+    "fossil_core.ports.embedding_provider",
     "fossil_core.ports.event_store",
     "fossil_core.ports.projection",
     "fossil_core.ports.retriever",

--- a/src/fossil_core/contracts.py
+++ b/src/fossil_core/contracts.py
@@ -6,15 +6,9 @@ from typing import Any, Protocol
 
 from .ports.cognitive_service import VersionedCognitiveService
 from .ports.context_provider import ContextProvider
+from .ports.embedding_provider import EmbeddingProvider
 from .ports.projection import ProjectionAdapter, ProjectionReceipt
 from .ports.retriever import Retriever
-
-
-class EmbeddingProvider(VersionedCognitiveService, Protocol):
-    @property
-    def model_id(self) -> str: ...
-
-    def embed(self, texts: list[str]) -> list[list[float]]: ...
 
 
 class Reranker(VersionedCognitiveService, Protocol):

--- a/src/fossil_core/ports/__init__.py
+++ b/src/fossil_core/ports/__init__.py
@@ -3,6 +3,7 @@
 from .artifact_store import ArtifactStorePort
 from .cognitive_service import VersionedCognitiveService
 from .context_provider import ContextProvider
+from .embedding_provider import EmbeddingProvider
 from .event_store import EventStorePort
 from .projection import ProjectionAdapter, ProjectionReceipt
 from .retriever import Retriever
@@ -15,4 +16,5 @@ __all__ = [
     "VersionedCognitiveService",
     "Retriever",
     "ContextProvider",
+    "EmbeddingProvider",
 ]

--- a/src/fossil_core/ports/embedding_provider.py
+++ b/src/fossil_core/ports/embedding_provider.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from .cognitive_service import VersionedCognitiveService
+
+
+class EmbeddingProvider(VersionedCognitiveService, Protocol):
+    @property
+    def model_id(self) -> str: ...
+
+    def embed(self, texts: list[str]) -> list[list[float]]: ...
+
+
+__all__ = ["EmbeddingProvider"]

--- a/tests/test_embedding_provider_port_compatibility.py
+++ b/tests/test_embedding_provider_port_compatibility.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import inspect
+
+import fossil_core.contracts as legacy_contracts
+import fossil_core.ports as ports
+from fossil_core.ports.cognitive_service import VersionedCognitiveService
+from fossil_core.ports.embedding_provider import EmbeddingProvider
+
+
+def test_embedding_provider_port_is_canonical_and_legacy_contract_preserves_identity():
+    assert legacy_contracts.EmbeddingProvider is EmbeddingProvider
+    assert ports.EmbeddingProvider is EmbeddingProvider
+    assert VersionedCognitiveService in EmbeddingProvider.__mro__
+
+
+def test_embedding_provider_contract_is_unchanged():
+    assert isinstance(EmbeddingProvider.model_id, property)
+    model_id_signature = inspect.signature(EmbeddingProvider.model_id.fget)
+    assert list(model_id_signature.parameters) == ["self"]
+
+    embed_signature = inspect.signature(EmbeddingProvider.embed)
+    parameters = list(embed_signature.parameters.values())
+    assert [parameter.name for parameter in parameters] == ["self", "texts"]
+    assert parameters[1].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+
+
+def test_legacy_contracts_namespace_remains_frozen_after_embedding_provider_extraction():
+    assert not hasattr(legacy_contracts, "__all__")
+    public_names = sorted(
+        name for name in vars(legacy_contracts) if not name.startswith("_")
+    )
+    assert public_names == [
+        "Any",
+        "ContextProvider",
+        "EmbeddingProvider",
+        "ModelService",
+        "Path",
+        "ProjectionAdapter",
+        "ProjectionReceipt",
+        "Protocol",
+        "Reranker",
+        "Retriever",
+        "VerificationService",
+        "VersionedCognitiveService",
+        "annotations",
+        "dataclass",
+    ]


### PR DESCRIPTION
Advances #82 Phase 4 with one bounded provider-neutral EmbeddingProvider port seam.

## Scope
- move `EmbeddingProvider` from flat `fossil_core.contracts` to canonical `fossil_core.ports.embedding_provider`
- inherit the canonical `VersionedCognitiveService` metadata base
- export `EmbeddingProvider` from `fossil_core.ports`
- preserve `fossil_core.contracts.EmbeddingProvider` object identity and the exact historical `contracts.py` implicit namespace
- freeze the existing `model_id` property and `embed(texts) -> list[list[float]]` Protocol surface
- add public API declaration, architecture enforcement, compatibility tests, and migration guidance

## Explicit non-goals
- no embedding model/provider selection changes
- no embedding algorithm/vector dimension/normalization/batching/caching changes
- no retrieval/reranking policy changes
- no Reranker/ModelService/VerificationService migration
- no event/schema/stable-ID/canonical-hash changes
- no storage/provider/projection changes
- no acceptance weakening

## Verification
- canonical/legacy/ports object identity
- exact `model_id` property + `embed(self, texts)` contract regression
- exact legacy `fossil_core.contracts` namespace regression
- public API contract tests
- architecture-boundary tests
- full deterministic DKG suite
- Dependency Integrity
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `c9611d7975d2e6e90c8e9bd755de9f7e20dba22d`