### PR TITLE
[ARCH-P4] Move Reranker contract behind canonical port

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -34,7 +34,8 @@
         "VersionedCognitiveService",
         "Retriever",
         "ContextProvider",
-        "EmbeddingProvider"
+        "EmbeddingProvider",
+        "Reranker"
       ]
     },
     "projection_port": {
@@ -71,6 +72,13 @@
       "status": "supported",
       "symbols": [
         "EmbeddingProvider"
+      ]
+    },
+    "reranker_port": {
+      "module": "fossil_core.ports.reranker",
+      "status": "supported",
+      "symbols": [
+        "Reranker"
       ]
     },
     "filesystem_adapter": {
@@ -311,6 +319,10 @@
     {
       "source": "fossil_core.contracts.EmbeddingProvider",
       "target": "fossil_core.ports.embedding_provider.EmbeddingProvider"
+    },
+    {
+      "source": "fossil_core.contracts.Reranker",
+      "target": "fossil_core.ports.reranker.Reranker"
     }
   ]
 }

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -139,7 +139,17 @@ from fossil_core.ports.embedding_provider import EmbeddingProvider
 
 `EmbeddingProvider` retains the existing `model_id` property and `embed(texts) -> list[list[float]]` contract. Moving the Protocol does not select a provider/model, change vector dimensions or normalization, alter batching/caching behavior, or change any retrieval/reranking policy.
 
-`fossil_core.contracts.ProjectionAdapter`, `fossil_core.contracts.ProjectionReceipt`, `fossil_core.contracts.VersionedCognitiveService`, `fossil_core.contracts.Retriever`, `fossil_core.contracts.ContextProvider`, and `fossil_core.contracts.EmbeddingProvider` remain identity-preserving aliases during migration. The entire `fossil_core.contracts` module is **not** classified as compatibility-only yet because it still owns `Reranker`, `ModelService`, and `VerificationService`. Those interfaces require separate bounded migrations rather than one broad package move.
+Reranking capability code should depend on the canonical Reranker port:
+
+```python
+from fossil_core.ports import Reranker
+# equivalent canonical module:
+from fossil_core.ports.reranker import Reranker
+```
+
+`Reranker.rerank` retains the existing `query`, `candidates`, and keyword-only `limit` contract. Moving the Protocol does not select a reranking provider/model or change candidate scoring, ordering, truncation, filtering, retrieval, or context-construction behavior.
+
+`fossil_core.contracts.ProjectionAdapter`, `fossil_core.contracts.ProjectionReceipt`, `fossil_core.contracts.VersionedCognitiveService`, `fossil_core.contracts.Retriever`, `fossil_core.contracts.ContextProvider`, `fossil_core.contracts.EmbeddingProvider`, and `fossil_core.contracts.Reranker` remain identity-preserving aliases during migration. The entire `fossil_core.contracts` module is **not** classified as compatibility-only yet because it still owns `ModelService` and `VerificationService`. Those interfaces require separate bounded migrations rather than one broad package move.
 
 ## Canonical concrete adapters
 
@@ -175,7 +185,7 @@ The following flat paths remain valid only to prevent migration breakage:
 
 They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `annotations`, `hashlib`, and `uuid` names as well as the two identity functions. The promotion shim preserves its historical `Any`, `Iterable`, `annotations`, and `build_promotion_event` names. None of these compatibility-only modules gains a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
 
-`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. Likewise, `fossil_core.contracts` remains a mixed active module while migrated projection, cognitive-metadata, Retriever, ContextProvider, and EmbeddingProvider types forward to canonical ports.
+`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. Likewise, `fossil_core.contracts` remains a mixed active module while migrated projection, cognitive-metadata, Retriever, ContextProvider, EmbeddingProvider, and Reranker types forward to canonical ports.
 
 Removal is not authorized by this document. Compatibility modules may be removed only in an explicit cleanup phase after first-party consumers, clean-install tests, cross-repository contracts, and required hosted gates demonstrate that the old paths are no longer needed.
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -22,6 +22,7 @@ CANONICAL_MODULES = {
     "fossil_core.ports.embedding_provider",
     "fossil_core.ports.event_store",
     "fossil_core.ports.projection",
+    "fossil_core.ports.reranker",
     "fossil_core.ports.retriever",
     "fossil_core.adapters",
     "fossil_core.adapters.filesystem",

--- a/src/fossil_core/contracts.py
+++ b/src/fossil_core/contracts.py
@@ -8,17 +8,8 @@ from .ports.cognitive_service import VersionedCognitiveService
 from .ports.context_provider import ContextProvider
 from .ports.embedding_provider import EmbeddingProvider
 from .ports.projection import ProjectionAdapter, ProjectionReceipt
+from .ports.reranker import Reranker
 from .ports.retriever import Retriever
-
-
-class Reranker(VersionedCognitiveService, Protocol):
-    def rerank(
-        self,
-        query: str,
-        candidates: list[dict[str, Any]],
-        *,
-        limit: int,
-    ) -> list[dict[str, Any]]: ...
 
 
 class ModelService(VersionedCognitiveService, Protocol):

--- a/src/fossil_core/ports/__init__.py
+++ b/src/fossil_core/ports/__init__.py
@@ -6,6 +6,7 @@ from .context_provider import ContextProvider
 from .embedding_provider import EmbeddingProvider
 from .event_store import EventStorePort
 from .projection import ProjectionAdapter, ProjectionReceipt
+from .reranker import Reranker
 from .retriever import Retriever
 
 __all__ = [
@@ -17,4 +18,5 @@ __all__ = [
     "Retriever",
     "ContextProvider",
     "EmbeddingProvider",
+    "Reranker",
 ]

--- a/src/fossil_core/ports/reranker.py
+++ b/src/fossil_core/ports/reranker.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from .cognitive_service import VersionedCognitiveService
+
+
+class Reranker(VersionedCognitiveService, Protocol):
+    def rerank(
+        self,
+        query: str,
+        candidates: list[dict[str, Any]],
+        *,
+        limit: int,
+    ) -> list[dict[str, Any]]: ...
+
+
+__all__ = ["Reranker"]

--- a/tests/test_reranker_port_compatibility.py
+++ b/tests/test_reranker_port_compatibility.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import inspect
+
+import fossil_core.contracts as legacy_contracts
+import fossil_core.ports as ports
+from fossil_core.ports.cognitive_service import VersionedCognitiveService
+from fossil_core.ports.reranker import Reranker
+
+
+def test_reranker_port_is_canonical_and_legacy_contract_preserves_identity():
+    assert legacy_contracts.Reranker is Reranker
+    assert ports.Reranker is Reranker
+    assert VersionedCognitiveService in Reranker.__mro__
+
+
+def test_reranker_contract_is_unchanged():
+    signature = inspect.signature(Reranker.rerank)
+    parameters = list(signature.parameters.values())
+    assert [parameter.name for parameter in parameters] == [
+        "self",
+        "query",
+        "candidates",
+        "limit",
+    ]
+    assert parameters[1].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert parameters[2].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert parameters[3].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+def test_legacy_contracts_namespace_remains_frozen_after_reranker_extraction():
+    assert not hasattr(legacy_contracts, "__all__")
+    public_names = sorted(
+        name for name in vars(legacy_contracts) if not name.startswith("_")
+    )
+    assert public_names == [
+        "Any",
+        "ContextProvider",
+        "EmbeddingProvider",
+        "ModelService",
+        "Path",
+        "ProjectionAdapter",
+        "ProjectionReceipt",
+        "Protocol",
+        "Reranker",
+        "Retriever",
+        "VerificationService",
+        "VersionedCognitiveService",
+        "annotations",
+        "dataclass",
+    ]


### PR DESCRIPTION
Advances #82 Phase 4 with one bounded provider-neutral Reranker port seam.

## Scope
- move `Reranker` from flat `fossil_core.contracts` to canonical `fossil_core.ports.reranker`
- inherit canonical `VersionedCognitiveService`
- export `Reranker` from `fossil_core.ports`
- preserve `fossil_core.contracts.Reranker` object identity and exact historical `contracts.py` implicit namespace
- freeze the existing `rerank(query, candidates, *, limit)` Protocol surface
- add public API declaration, architecture enforcement, compatibility tests, and migration guidance

## Explicit non-goals
- no reranking algorithm/model/provider changes
- no candidate score/order/truncation/filtering policy changes
- no retrieval/context/model/verification behavior changes
- no ModelService or VerificationService migration
- no event/schema/stable-ID/canonical-hash changes
- no storage/provider/projection changes
- no acceptance weakening

## Verification
- canonical/legacy/ports object identity
- exact `rerank(self, query, candidates, *, limit)` signature regression
- exact legacy `fossil_core.contracts` namespace regression
- public API contract tests
- architecture-boundary tests
- full deterministic DKG suite
- Dependency Integrity
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `e87676f120ac5427383aaf1ca15339196e6c4eab`