### PR TITLE
[ARCH-P4] Move ModelService contract behind canonical port

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -35,7 +35,8 @@
         "Retriever",
         "ContextProvider",
         "EmbeddingProvider",
-        "Reranker"
+        "Reranker",
+        "ModelService"
       ]
     },
     "projection_port": {
@@ -79,6 +80,13 @@
       "status": "supported",
       "symbols": [
         "Reranker"
+      ]
+    },
+    "model_service_port": {
+      "module": "fossil_core.ports.model_service",
+      "status": "supported",
+      "symbols": [
+        "ModelService"
       ]
     },
     "filesystem_adapter": {
@@ -323,6 +331,10 @@
     {
       "source": "fossil_core.contracts.Reranker",
       "target": "fossil_core.ports.reranker.Reranker"
+    },
+    {
+      "source": "fossil_core.contracts.ModelService",
+      "target": "fossil_core.ports.model_service.ModelService"
     }
   ]
 }

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -149,7 +149,17 @@ from fossil_core.ports.reranker import Reranker
 
 `Reranker.rerank` retains the existing `query`, `candidates`, and keyword-only `limit` contract. Moving the Protocol does not select a reranking provider/model or change candidate scoring, ordering, truncation, filtering, retrieval, or context-construction behavior.
 
-`fossil_core.contracts.ProjectionAdapter`, `fossil_core.contracts.ProjectionReceipt`, `fossil_core.contracts.VersionedCognitiveService`, `fossil_core.contracts.Retriever`, `fossil_core.contracts.ContextProvider`, `fossil_core.contracts.EmbeddingProvider`, and `fossil_core.contracts.Reranker` remain identity-preserving aliases during migration. The entire `fossil_core.contracts` module is **not** classified as compatibility-only yet because it still owns `ModelService` and `VerificationService`. Those interfaces require separate bounded migrations rather than one broad package move.
+Model-execution capability code should depend on the canonical ModelService port:
+
+```python
+from fossil_core.ports import ModelService
+# equivalent canonical module:
+from fossil_core.ports.model_service import ModelService
+```
+
+`ModelService.run` retains the existing `run(task) -> dict[str, Any]` contract. Moving the Protocol does not select a model/provider, change routing or prompting policy, alter task/output semantics, or change verification behavior.
+
+`fossil_core.contracts.ProjectionAdapter`, `fossil_core.contracts.ProjectionReceipt`, `fossil_core.contracts.VersionedCognitiveService`, `fossil_core.contracts.Retriever`, `fossil_core.contracts.ContextProvider`, `fossil_core.contracts.EmbeddingProvider`, `fossil_core.contracts.Reranker`, and `fossil_core.contracts.ModelService` remain identity-preserving aliases during migration. The entire `fossil_core.contracts` module is **not** classified as compatibility-only yet because it still owns `VerificationService`. That final interface requires its own bounded migration rather than a broad package move.
 
 ## Canonical concrete adapters
 
@@ -185,7 +195,7 @@ The following flat paths remain valid only to prevent migration breakage:
 
 They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `annotations`, `hashlib`, and `uuid` names as well as the two identity functions. The promotion shim preserves its historical `Any`, `Iterable`, `annotations`, and `build_promotion_event` names. None of these compatibility-only modules gains a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
 
-`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. Likewise, `fossil_core.contracts` remains a mixed active module while migrated projection, cognitive-metadata, Retriever, ContextProvider, EmbeddingProvider, and Reranker types forward to canonical ports.
+`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. Likewise, `fossil_core.contracts` remains a mixed active module while migrated projection, cognitive-metadata, Retriever, ContextProvider, EmbeddingProvider, Reranker, and ModelService types forward to canonical ports.
 
 Removal is not authorized by this document. Compatibility modules may be removed only in an explicit cleanup phase after first-party consumers, clean-install tests, cross-repository contracts, and required hosted gates demonstrate that the old paths are no longer needed.
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -21,6 +21,7 @@ CANONICAL_MODULES = {
     "fossil_core.ports.context_provider",
     "fossil_core.ports.embedding_provider",
     "fossil_core.ports.event_store",
+    "fossil_core.ports.model_service",
     "fossil_core.ports.projection",
     "fossil_core.ports.reranker",
     "fossil_core.ports.retriever",

--- a/src/fossil_core/contracts.py
+++ b/src/fossil_core/contracts.py
@@ -7,13 +7,10 @@ from typing import Any, Protocol
 from .ports.cognitive_service import VersionedCognitiveService
 from .ports.context_provider import ContextProvider
 from .ports.embedding_provider import EmbeddingProvider
+from .ports.model_service import ModelService
 from .ports.projection import ProjectionAdapter, ProjectionReceipt
 from .ports.reranker import Reranker
 from .ports.retriever import Retriever
-
-
-class ModelService(VersionedCognitiveService, Protocol):
-    def run(self, task: dict[str, Any]) -> dict[str, Any]: ...
 
 
 class VerificationService(VersionedCognitiveService, Protocol):

--- a/src/fossil_core/ports/__init__.py
+++ b/src/fossil_core/ports/__init__.py
@@ -5,6 +5,7 @@ from .cognitive_service import VersionedCognitiveService
 from .context_provider import ContextProvider
 from .embedding_provider import EmbeddingProvider
 from .event_store import EventStorePort
+from .model_service import ModelService
 from .projection import ProjectionAdapter, ProjectionReceipt
 from .reranker import Reranker
 from .retriever import Retriever
@@ -19,4 +20,5 @@ __all__ = [
     "ContextProvider",
     "EmbeddingProvider",
     "Reranker",
+    "ModelService",
 ]

--- a/src/fossil_core/ports/model_service.py
+++ b/src/fossil_core/ports/model_service.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from .cognitive_service import VersionedCognitiveService
+
+
+class ModelService(VersionedCognitiveService, Protocol):
+    def run(self, task: dict[str, Any]) -> dict[str, Any]: ...
+
+
+__all__ = ["ModelService"]

--- a/tests/test_model_service_port_compatibility.py
+++ b/tests/test_model_service_port_compatibility.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import inspect
+
+import fossil_core.contracts as legacy_contracts
+import fossil_core.ports as ports
+from fossil_core.ports.cognitive_service import VersionedCognitiveService
+from fossil_core.ports.model_service import ModelService
+
+
+def test_model_service_port_is_canonical_and_legacy_contract_preserves_identity():
+    assert legacy_contracts.ModelService is ModelService
+    assert ports.ModelService is ModelService
+    assert VersionedCognitiveService in ModelService.__mro__
+
+
+def test_model_service_contract_is_unchanged():
+    signature = inspect.signature(ModelService.run)
+    parameters = list(signature.parameters.values())
+    assert [parameter.name for parameter in parameters] == ["self", "task"]
+    assert parameters[1].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+
+
+def test_legacy_contracts_namespace_remains_frozen_after_model_service_extraction():
+    assert not hasattr(legacy_contracts, "__all__")
+    public_names = sorted(
+        name for name in vars(legacy_contracts) if not name.startswith("_")
+    )
+    assert public_names == [
+        "Any",
+        "ContextProvider",
+        "EmbeddingProvider",
+        "ModelService",
+        "Path",
+        "ProjectionAdapter",
+        "ProjectionReceipt",
+        "Protocol",
+        "Reranker",
+        "Retriever",
+        "VerificationService",
+        "VersionedCognitiveService",
+        "annotations",
+        "dataclass",
+    ]


### PR DESCRIPTION
Advances #82 Phase 4 with one bounded provider-neutral ModelService port seam.

## Scope
- move `ModelService` from flat `fossil_core.contracts` to canonical `fossil_core.ports.model_service`
- inherit canonical `VersionedCognitiveService`
- export `ModelService` from `fossil_core.ports`
- preserve `fossil_core.contracts.ModelService` object identity and exact historical `contracts.py` implicit namespace
- freeze the existing `run(task) -> dict[str, Any]` Protocol surface
- add public API declaration, architecture enforcement, compatibility tests, and migration guidance

## Explicit non-goals
- no model provider/routing/prompt/task execution/output behavior changes
- no retrieval/context/reranking/verification behavior changes
- no VerificationService migration
- no event/schema/stable-ID/canonical-hash changes
- no storage/provider/projection changes
- no acceptance weakening

## Verification
- canonical/legacy/ports object identity
- exact `run(self, task)` signature regression
- exact legacy `fossil_core.contracts` namespace regression
- public API contract tests
- architecture-boundary tests
- full deterministic DKG suite
- Dependency Integrity
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `ccfe616f13cc0634114a0e5ddb367906f8d8c12d`