### PR TITLE
[ARCH-P4] Move VerificationService contract behind canonical port

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -36,7 +36,8 @@
         "ContextProvider",
         "EmbeddingProvider",
         "Reranker",
-        "ModelService"
+        "ModelService",
+        "VerificationService"
       ]
     },
     "projection_port": {
@@ -87,6 +88,13 @@
       "status": "supported",
       "symbols": [
         "ModelService"
+      ]
+    },
+    "verification_service_port": {
+      "module": "fossil_core.ports.verification_service",
+      "status": "supported",
+      "symbols": [
+        "VerificationService"
       ]
     },
     "filesystem_adapter": {
@@ -335,6 +343,10 @@
     {
       "source": "fossil_core.contracts.ModelService",
       "target": "fossil_core.ports.model_service.ModelService"
+    },
+    {
+      "source": "fossil_core.contracts.VerificationService",
+      "target": "fossil_core.ports.verification_service.VerificationService"
     }
   ]
 }

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -159,7 +159,17 @@ from fossil_core.ports.model_service import ModelService
 
 `ModelService.run` retains the existing `run(task) -> dict[str, Any]` contract. Moving the Protocol does not select a model/provider, change routing or prompting policy, alter task/output semantics, or change verification behavior.
 
-`fossil_core.contracts.ProjectionAdapter`, `fossil_core.contracts.ProjectionReceipt`, `fossil_core.contracts.VersionedCognitiveService`, `fossil_core.contracts.Retriever`, `fossil_core.contracts.ContextProvider`, `fossil_core.contracts.EmbeddingProvider`, `fossil_core.contracts.Reranker`, and `fossil_core.contracts.ModelService` remain identity-preserving aliases during migration. The entire `fossil_core.contracts` module is **not** classified as compatibility-only yet because it still owns `VerificationService`. That final interface requires its own bounded migration rather than a broad package move.
+Verification capability code should depend on the canonical VerificationService port:
+
+```python
+from fossil_core.ports import VerificationService
+# equivalent canonical module:
+from fossil_core.ports.verification_service import VerificationService
+```
+
+`VerificationService.verify` retains the existing `verify(proposal) -> dict[str, Any]` contract. Moving the Protocol does not change verification rules, scoring, evidence requirements, proposal semantics, model/provider selection, or any acceptance policy.
+
+All projection/cognitive types historically exposed by `fossil_core.contracts` now forward to canonical port modules with object identity preserved. `fossil_core.contracts` remains available as the historical aggregate and keeps its exact implicit namespace and absence of `__all__`; this structural move does not authorize deleting, warning on, or reclassifying that module. Any compatibility cleanup is a separate Phase 6 decision after first-party and cross-repository consumers are migrated and verified.
 
 ## Canonical concrete adapters
 
@@ -195,7 +205,7 @@ The following flat paths remain valid only to prevent migration breakage:
 
 They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `annotations`, `hashlib`, and `uuid` names as well as the two identity functions. The promotion shim preserves its historical `Any`, `Iterable`, `annotations`, and `build_promotion_event` names. None of these compatibility-only modules gains a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
 
-`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. Likewise, `fossil_core.contracts` remains a mixed active module while migrated projection, cognitive-metadata, Retriever, ContextProvider, EmbeddingProvider, Reranker, and ModelService types forward to canonical ports.
+`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. `fossil_core.contracts` is also intentionally not reclassified here: it is now a forwarding aggregate for canonical projection/cognitive ports, and its cleanup status remains a separate migration decision.
 
 Removal is not authorized by this document. Compatibility modules may be removed only in an explicit cleanup phase after first-party consumers, clean-install tests, cross-repository contracts, and required hosted gates demonstrate that the old paths are no longer needed.
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -25,6 +25,7 @@ CANONICAL_MODULES = {
     "fossil_core.ports.projection",
     "fossil_core.ports.reranker",
     "fossil_core.ports.retriever",
+    "fossil_core.ports.verification_service",
     "fossil_core.adapters",
     "fossil_core.adapters.filesystem",
     "fossil_core.adapters.filesystem.artifact_store",

--- a/src/fossil_core/contracts.py
+++ b/src/fossil_core/contracts.py
@@ -11,7 +11,4 @@ from .ports.model_service import ModelService
 from .ports.projection import ProjectionAdapter, ProjectionReceipt
 from .ports.reranker import Reranker
 from .ports.retriever import Retriever
-
-
-class VerificationService(VersionedCognitiveService, Protocol):
-    def verify(self, proposal: dict[str, Any]) -> dict[str, Any]: ...
+from .ports.verification_service import VerificationService

--- a/src/fossil_core/ports/__init__.py
+++ b/src/fossil_core/ports/__init__.py
@@ -9,6 +9,7 @@ from .model_service import ModelService
 from .projection import ProjectionAdapter, ProjectionReceipt
 from .reranker import Reranker
 from .retriever import Retriever
+from .verification_service import VerificationService
 
 __all__ = [
     "ArtifactStorePort",
@@ -21,4 +22,5 @@ __all__ = [
     "EmbeddingProvider",
     "Reranker",
     "ModelService",
+    "VerificationService",
 ]

--- a/src/fossil_core/ports/verification_service.py
+++ b/src/fossil_core/ports/verification_service.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from .cognitive_service import VersionedCognitiveService
+
+
+class VerificationService(VersionedCognitiveService, Protocol):
+    def verify(self, proposal: dict[str, Any]) -> dict[str, Any]: ...
+
+
+__all__ = ["VerificationService"]

--- a/tests/test_verification_service_port_compatibility.py
+++ b/tests/test_verification_service_port_compatibility.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import inspect
+
+import fossil_core.contracts as legacy_contracts
+import fossil_core.ports as ports
+from fossil_core.ports.cognitive_service import VersionedCognitiveService
+from fossil_core.ports.verification_service import VerificationService
+
+
+def test_verification_service_port_is_canonical_and_legacy_contract_preserves_identity():
+    assert legacy_contracts.VerificationService is VerificationService
+    assert ports.VerificationService is VerificationService
+    assert VersionedCognitiveService in VerificationService.__mro__
+
+
+def test_verification_service_contract_is_unchanged():
+    signature = inspect.signature(VerificationService.verify)
+    parameters = list(signature.parameters.values())
+    assert [parameter.name for parameter in parameters] == ["self", "proposal"]
+    assert parameters[1].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+
+
+def test_legacy_contracts_namespace_remains_frozen_after_verification_service_extraction():
+    assert not hasattr(legacy_contracts, "__all__")
+    public_names = sorted(
+        name for name in vars(legacy_contracts) if not name.startswith("_")
+    )
+    assert public_names == [
+        "Any",
+        "ContextProvider",
+        "EmbeddingProvider",
+        "ModelService",
+        "Path",
+        "ProjectionAdapter",
+        "ProjectionReceipt",
+        "Protocol",
+        "Reranker",
+        "Retriever",
+        "VerificationService",
+        "VersionedCognitiveService",
+        "annotations",
+        "dataclass",
+    ]


### PR DESCRIPTION
Advances #82 Phase 4 with the final bounded cognitive Protocol seam.

## Scope
- move `VerificationService` from flat `fossil_core.contracts` to canonical `fossil_core.ports.verification_service`
- inherit canonical `VersionedCognitiveService`
- export `VerificationService` from `fossil_core.ports`
- preserve `fossil_core.contracts.VerificationService` object identity and exact historical `contracts.py` implicit namespace
- freeze the existing `verify(proposal) -> dict[str, Any]` Protocol surface
- keep `fossil_core.contracts` as a forwarding aggregate; defer cleanup/reclassification/removal to Phase 6
- add public API declaration, architecture enforcement, compatibility tests, and migration guidance

## Explicit non-goals
- no verification policy/rules/scoring/evidence/model/provider changes
- no proposal semantics changes
- no retrieval/context/reranking/model behavior changes
- no event/schema/stable-ID/canonical-hash changes
- no storage/provider/projection changes
- no compatibility cleanup or acceptance weakening

## Verification
- canonical/legacy/ports object identity
- exact `verify(self, proposal)` signature regression
- exact legacy `fossil_core.contracts` namespace regression
- public API contract tests
- architecture-boundary tests
- full deterministic DKG suite
- Dependency Integrity
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `e8ad6a1da43d7a35680d4637e6c5b02ee46b5b7a`