### PR TITLE
[ARCH-P4] Move source lifecycle provenance into pure domain

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -154,6 +154,15 @@
       "symbols": [
         "build_promotion_event"
       ]
+    },
+    "provenance_domain": {
+      "module": "fossil_core.domain.provenance",
+      "status": "supported_domain_model",
+      "symbols": [
+        "SourceStatus",
+        "SourceLifecycleState",
+        "build_source_state_event"
+      ]
     }
   },
   "compatibility_modules": {
@@ -311,6 +320,18 @@
     {
       "source": "fossil_core.build_promotion_event",
       "target": "fossil_core.domain.promotion.build_promotion_event"
+    },
+    {
+      "source": "fossil_core.source.SourceStatus",
+      "target": "fossil_core.domain.provenance.SourceStatus"
+    },
+    {
+      "source": "fossil_core.source.SourceLifecycleState",
+      "target": "fossil_core.domain.provenance.SourceLifecycleState"
+    },
+    {
+      "source": "fossil_core.source.build_source_state_event",
+      "target": "fossil_core.domain.provenance.build_source_state_event"
     },
     {
       "source": "fossil_core.contracts.ProjectionReceipt",

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -79,6 +79,22 @@ This is a pure domain event factory. It enforces that promotion has at least one
 
 Promotion is append-only: the source pack is not mutated. The target records a new durable event whose payload points to the source pack and whose evidence/provenance fields preserve why the promotion was accepted. The existing event type, schema version, payload keys, provenance method, and validation messages are compatibility-sensitive and are not changed by package movement.
 
+## Canonical source lifecycle provenance domain
+
+Replayable source lifecycle state is canonical under:
+
+```python
+from fossil_core.domain.provenance import (
+    SourceLifecycleState,
+    SourceStatus,
+    build_source_state_event,
+)
+```
+
+This pure domain slice owns only the semantics of `source.stale`, `source.retracted`, and `source.restored`, their deterministic replay ordering, and the existing `dkg.event.v1` source-lifecycle event factory. Moving it does not change event type names, payload keys, provenance method, ordering, or default-active behavior.
+
+`fossil_core.source` remains the active mixed source-evidence module. `SourceSnapshotStore`, citation/schema validation, artifact-backed source bytes, `RedactionPolicy`, and `build_redaction_event` intentionally remain there because they depend on storage, filesystem, schema, or visibility concerns. `fossil_core.source.SourceStatus`, `SourceLifecycleState`, and `build_source_state_event` remain identity-preserving aliases to the canonical domain definitions.
+
 ## Canonical provider-neutral ports
 
 New code that depends on storage capabilities rather than a concrete implementation should use:
@@ -205,7 +221,7 @@ The following flat paths remain valid only to prevent migration breakage:
 
 They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `annotations`, `hashlib`, and `uuid` names as well as the two identity functions. The promotion shim preserves its historical `Any`, `Iterable`, `annotations`, and `build_promotion_event` names. None of these compatibility-only modules gains a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
 
-`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. `fossil_core.contracts` is also intentionally not reclassified here: it is now a forwarding aggregate for canonical projection/cognitive ports, and its cleanup status remains a separate migration decision.
+`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. `fossil_core.source` likewise remains an active mixed module while its pure source lifecycle types/event factory forward to `fossil_core.domain.provenance`. `fossil_core.contracts` is also intentionally not reclassified here: it is now a forwarding aggregate for canonical projection/cognitive ports, and its cleanup status remains a separate migration decision.
 
 Removal is not authorized by this document. Compatibility modules may be removed only in an explicit cleanup phase after first-party consumers, clean-install tests, cross-repository contracts, and required hosted gates demonstrate that the old paths are no longer needed.
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -15,6 +15,7 @@ CANONICAL_MODULES = {
     "fossil_core.domain.lifecycle",
     "fossil_core.domain.pack",
     "fossil_core.domain.promotion",
+    "fossil_core.domain.provenance",
     "fossil_core.ports",
     "fossil_core.ports.artifact_store",
     "fossil_core.ports.cognitive_service",

--- a/src/fossil_core/domain/provenance.py
+++ b/src/fossil_core/domain/provenance.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+
+@dataclass(frozen=True)
+class SourceStatus:
+    snapshot_id: str
+    state: str
+    reason: str | None
+    last_event_id: str
+
+
+class SourceLifecycleState:
+    """Replay explicit source staleness/retraction/restoration events."""
+
+    VALID = {"source.stale", "source.retracted", "source.restored"}
+
+    def __init__(self) -> None:
+        self.statuses: dict[str, SourceStatus] = {}
+
+    @classmethod
+    def replay(cls, events: Iterable[Mapping[str, Any]]) -> "SourceLifecycleState":
+        state = cls()
+        for event in sorted(
+            (event for event in events if event.get("event_type") in cls.VALID),
+            key=lambda event: (str(event["recorded_at"]), str(event["event_id"])),
+        ):
+            snapshot_id = str(event["payload"]["snapshot_id"])
+            event_type = str(event["event_type"])
+            new_state = {
+                "source.stale": "stale",
+                "source.retracted": "retracted",
+                "source.restored": "active",
+            }[event_type]
+            state.statuses[snapshot_id] = SourceStatus(
+                snapshot_id=snapshot_id,
+                state=new_state,
+                reason=event["payload"].get("reason"),
+                last_event_id=str(event["event_id"]),
+            )
+        return state
+
+    def status(self, snapshot_id: str) -> str:
+        return self.statuses.get(
+            snapshot_id, SourceStatus(snapshot_id, "active", None, "")
+        ).state
+
+
+def build_source_state_event(
+    *,
+    event_type: str,
+    snapshot_id: str,
+    source_id: str,
+    pack_id: str,
+    actor: Mapping[str, Any],
+    occurred_at: str,
+    recorded_at: str,
+    idempotency_key: str,
+    reason: str,
+) -> dict[str, Any]:
+    if event_type not in SourceLifecycleState.VALID:
+        raise ValueError(f"unsupported source lifecycle event: {event_type}")
+    return {
+        "schema_version": "dkg.event.v1",
+        "event_type": event_type,
+        "occurred_at": occurred_at,
+        "recorded_at": recorded_at,
+        "pack_id": pack_id,
+        "actor": dict(actor),
+        "subject_refs": [snapshot_id, source_id],
+        "idempotency_key": idempotency_key,
+        "source_snapshot_refs": [snapshot_id],
+        "payload": {
+            "snapshot_id": snapshot_id,
+            "source_id": source_id,
+            "reason": reason,
+        },
+        "provenance": {"method": "source_lifecycle"},
+    }
+
+
+__all__ = ["SourceStatus", "SourceLifecycleState", "build_source_state_event"]

--- a/src/fossil_core/source.py
+++ b/src/fossil_core/source.py
@@ -10,6 +10,11 @@ from typing import Any, Iterable, Mapping
 from jsonschema import Draft202012Validator, FormatChecker
 
 from fossil_core.artifact_store import ArtifactStore
+from fossil_core.domain.provenance import (
+    SourceLifecycleState,
+    SourceStatus,
+    build_source_state_event,
+)
 from fossil_core.io import publish_immutable
 
 
@@ -270,83 +275,6 @@ class SourceSnapshotStore:
             "redacted": False,
             "redaction": None,
         }
-
-
-@dataclass(frozen=True)
-class SourceStatus:
-    snapshot_id: str
-    state: str
-    reason: str | None
-    last_event_id: str
-
-
-class SourceLifecycleState:
-    """Replay explicit source staleness/retraction/restoration events."""
-
-    VALID = {"source.stale", "source.retracted", "source.restored"}
-
-    def __init__(self) -> None:
-        self.statuses: dict[str, SourceStatus] = {}
-
-    @classmethod
-    def replay(cls, events: Iterable[Mapping[str, Any]]) -> "SourceLifecycleState":
-        state = cls()
-        for event in sorted(
-            (event for event in events if event.get("event_type") in cls.VALID),
-            key=lambda event: (str(event["recorded_at"]), str(event["event_id"])),
-        ):
-            snapshot_id = str(event["payload"]["snapshot_id"])
-            event_type = str(event["event_type"])
-            new_state = {
-                "source.stale": "stale",
-                "source.retracted": "retracted",
-                "source.restored": "active",
-            }[event_type]
-            state.statuses[snapshot_id] = SourceStatus(
-                snapshot_id=snapshot_id,
-                state=new_state,
-                reason=event["payload"].get("reason"),
-                last_event_id=str(event["event_id"]),
-            )
-        return state
-
-    def status(self, snapshot_id: str) -> str:
-        return self.statuses.get(
-            snapshot_id, SourceStatus(snapshot_id, "active", None, "")
-        ).state
-
-
-def build_source_state_event(
-    *,
-    event_type: str,
-    snapshot_id: str,
-    source_id: str,
-    pack_id: str,
-    actor: Mapping[str, Any],
-    occurred_at: str,
-    recorded_at: str,
-    idempotency_key: str,
-    reason: str,
-) -> dict[str, Any]:
-    if event_type not in SourceLifecycleState.VALID:
-        raise ValueError(f"unsupported source lifecycle event: {event_type}")
-    return {
-        "schema_version": "dkg.event.v1",
-        "event_type": event_type,
-        "occurred_at": occurred_at,
-        "recorded_at": recorded_at,
-        "pack_id": pack_id,
-        "actor": dict(actor),
-        "subject_refs": [snapshot_id, source_id],
-        "idempotency_key": idempotency_key,
-        "source_snapshot_refs": [snapshot_id],
-        "payload": {
-            "snapshot_id": snapshot_id,
-            "source_id": source_id,
-            "reason": reason,
-        },
-        "provenance": {"method": "source_lifecycle"},
-    }
 
 
 class RedactionPolicy:

--- a/tests/test_source_lifecycle_domain_compatibility.py
+++ b/tests/test_source_lifecycle_domain_compatibility.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import fossil_core.source as legacy_source
+from fossil_core.domain.provenance import (
+    SourceLifecycleState,
+    SourceStatus,
+    build_source_state_event,
+)
+
+
+def _event(event_type: str, recorded_at: str, event_id: str) -> dict:
+    return {
+        **build_source_state_event(
+            event_type=event_type,
+            snapshot_id="snap_fixture",
+            source_id="source_fixture",
+            pack_id="pack_fixture",
+            actor={"actor_type": "system", "actor_id": "fixture"},
+            occurred_at=recorded_at,
+            recorded_at=recorded_at,
+            idempotency_key=f"fixture:{event_type}",
+            reason=event_type,
+        ),
+        "event_id": event_id,
+    }
+
+
+def test_source_lifecycle_domain_preserves_legacy_identity():
+    assert legacy_source.SourceStatus is SourceStatus
+    assert legacy_source.SourceLifecycleState is SourceLifecycleState
+    assert legacy_source.build_source_state_event is build_source_state_event
+
+
+def test_source_state_event_shape_is_unchanged():
+    event = build_source_state_event(
+        event_type="source.retracted",
+        snapshot_id="snap_123",
+        source_id="source_456",
+        pack_id="pack_789",
+        actor={"actor_type": "system", "actor_id": "source-fixture"},
+        occurred_at="2026-08-09T23:42:00Z",
+        recorded_at="2026-08-09T23:43:00Z",
+        idempotency_key="source-lifecycle-2",
+        reason="upstream retraction",
+    )
+    assert event == {
+        "schema_version": "dkg.event.v1",
+        "event_type": "source.retracted",
+        "occurred_at": "2026-08-09T23:42:00Z",
+        "recorded_at": "2026-08-09T23:43:00Z",
+        "pack_id": "pack_789",
+        "actor": {"actor_type": "system", "actor_id": "source-fixture"},
+        "subject_refs": ["snap_123", "source_456"],
+        "idempotency_key": "source-lifecycle-2",
+        "source_snapshot_refs": ["snap_123"],
+        "payload": {
+            "snapshot_id": "snap_123",
+            "source_id": "source_456",
+            "reason": "upstream retraction",
+        },
+        "provenance": {"method": "source_lifecycle"},
+    }
+
+
+def test_source_lifecycle_replay_order_and_default_active_are_unchanged():
+    stale = _event("source.stale", "2026-08-09T23:41:00Z", "evt_1")
+    retracted = _event("source.retracted", "2026-08-09T23:42:00Z", "evt_2")
+    restored = _event("source.restored", "2026-08-09T23:43:00Z", "evt_3")
+
+    state = SourceLifecycleState.replay([restored, stale, retracted])
+    assert state.status("snap_fixture") == "active"
+    assert state.statuses["snap_fixture"] == SourceStatus(
+        snapshot_id="snap_fixture",
+        state="active",
+        reason="source.restored",
+        last_event_id="evt_3",
+    )
+    assert state.status("snap_unknown") == "active"
+
+
+def test_legacy_source_namespace_remains_frozen_after_domain_extraction():
+    assert not hasattr(legacy_source, "__all__")
+    public_names = sorted(
+        name for name in vars(legacy_source) if not name.startswith("_")
+    )
+    assert public_names == [
+        "Any",
+        "ArtifactStore",
+        "CitationIntegrityError",
+        "CitationLaunderingError",
+        "Draft202012Validator",
+        "FormatChecker",
+        "Iterable",
+        "Mapping",
+        "Path",
+        "RedactionPolicy",
+        "SourceLifecycleState",
+        "SourceSnapshotConflict",
+        "SourceSnapshotStore",
+        "SourceStatus",
+        "annotations",
+        "build_redaction_event",
+        "build_source_state_event",
+        "copy",
+        "dataclass",
+        "hashlib",
+        "json",
+        "publish_immutable",
+    ]


### PR DESCRIPTION
Advances #82 Phase 4 with one pure source-provenance lifecycle domain slice.

## Scope
- move `SourceStatus`, `SourceLifecycleState`, and `build_source_state_event` from flat `fossil_core.source` to canonical `fossil_core.domain.provenance`
- preserve `fossil_core.source` object identity and exact historical implicit namespace for those names
- freeze source lifecycle replay ordering/default-active semantics and the exact existing `dkg.event.v1` source lifecycle event dictionary
- add public API declaration, architecture enforcement, compatibility tests, and migration guidance

## Explicit non-goals
- no `SourceSnapshotStore` move
- no citation/schema validation move
- no `RedactionPolicy` or `build_redaction_event` move
- no source snapshot ID/hash, event schema/payload/order, citation/redaction/storage/projection/provider changes
- no compatibility cleanup or acceptance weakening

## Verification
- canonical/legacy object identity
- exact source lifecycle event dictionary regression
- replay ordering/default-active regression
- exact historical `fossil_core.source` implicit namespace regression
- public API contract tests
- domain architecture-boundary tests
- full deterministic DKG suite
- Dependency Integrity
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `cbef3e5931d555f240e6e2e72e025bc1826a8571`