### PR TITLE
[ARCH-P4] Move evidence redaction event into pure domain

### DIFF
--- a/contracts/python-public-api-v1.json
+++ b/contracts/python-public-api-v1.json
@@ -163,6 +163,13 @@
         "SourceLifecycleState",
         "build_source_state_event"
       ]
+    },
+    "evidence_domain": {
+      "module": "fossil_core.domain.evidence",
+      "status": "supported_domain_model",
+      "symbols": [
+        "build_redaction_event"
+      ]
     }
   },
   "compatibility_modules": {
@@ -332,6 +339,10 @@
     {
       "source": "fossil_core.source.build_source_state_event",
       "target": "fossil_core.domain.provenance.build_source_state_event"
+    },
+    {
+      "source": "fossil_core.source.build_redaction_event",
+      "target": "fossil_core.domain.evidence.build_redaction_event"
     },
     {
       "source": "fossil_core.contracts.ProjectionReceipt",

--- a/docs/architecture/public-api.md
+++ b/docs/architecture/public-api.md
@@ -93,7 +93,19 @@ from fossil_core.domain.provenance import (
 
 This pure domain slice owns only the semantics of `source.stale`, `source.retracted`, and `source.restored`, their deterministic replay ordering, and the existing `dkg.event.v1` source-lifecycle event factory. Moving it does not change event type names, payload keys, provenance method, ordering, or default-active behavior.
 
-`fossil_core.source` remains the active mixed source-evidence module. `SourceSnapshotStore`, citation/schema validation, artifact-backed source bytes, `RedactionPolicy`, and `build_redaction_event` intentionally remain there because they depend on storage, filesystem, schema, or visibility concerns. `fossil_core.source.SourceStatus`, `SourceLifecycleState`, and `build_source_state_event` remain identity-preserving aliases to the canonical domain definitions.
+`fossil_core.source.SourceStatus`, `SourceLifecycleState`, and `build_source_state_event` remain identity-preserving aliases to the canonical domain definitions.
+
+## Canonical evidence redaction event domain
+
+The deterministic evidence-redaction event factory is canonical under:
+
+```python
+from fossil_core.domain.evidence import build_redaction_event
+```
+
+`build_redaction_event` retains the exact existing `dkg.event.v1` `evidence.redacted` dictionary: artifact and snapshot subject references, tombstone reason/authority/request/redaction time, and provenance method `artifact_redaction_tombstone`. Moving this constructor does not create or persist a tombstone, delete bytes, change redaction ordering, or select storage/provider behavior.
+
+`fossil_core.source` remains the active mixed source-evidence module. `SourceSnapshotStore`, citation/schema validation, artifact-backed source bytes, and `RedactionPolicy` intentionally remain there because they depend on storage, filesystem, schema, or visibility concerns. `fossil_core.source.build_redaction_event` remains an identity-preserving alias to the canonical evidence-domain factory.
 
 ## Canonical provider-neutral ports
 
@@ -221,7 +233,7 @@ The following flat paths remain valid only to prevent migration breakage:
 
 They intentionally preserve object identity with canonical classes/protocols/functions. The lifecycle shim preserves its historical implicit star-import names rather than adding a new `__all__`. The `ids` shim likewise preserves its historical implicit `annotations`, `hashlib`, and `uuid` names as well as the two identity functions. The promotion shim preserves its historical `Any`, `Iterable`, `annotations`, and `build_promotion_event` names. None of these compatibility-only modules gains a new `__all__`. No runtime deprecation warning is added to these `fossil_core` compatibility paths because that would mix behavior changes into structural migration.
 
-`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. `fossil_core.source` likewise remains an active mixed module while its pure source lifecycle types/event factory forward to `fossil_core.domain.provenance`. `fossil_core.contracts` is also intentionally not reclassified here: it is now a forwarding aggregate for canonical projection/cognitive ports, and its cleanup status remains a separate migration decision.
+`fossil_core.pack` is not listed as compatibility-only: it remains the active home of `KnowledgePackValidator` while `PackAccess` and `PackBoundaryError` are identity aliases to the pure domain boundary. `fossil_core.source` likewise remains an active mixed module while its pure source-lifecycle and evidence-redaction factories/types forward to canonical domain modules. `fossil_core.contracts` is also intentionally not reclassified here: it is now a forwarding aggregate for canonical projection/cognitive ports, and its cleanup status remains a separate migration decision.
 
 Removal is not authorized by this document. Compatibility modules may be removed only in an explicit cleanup phase after first-party consumers, clean-install tests, cross-repository contracts, and required hosted gates demonstrate that the old paths are no longer needed.
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -11,6 +11,7 @@ from architecture_inventory import inventory
 PACKAGE = "fossil_core"
 CANONICAL_MODULES = {
     "fossil_core.domain",
+    "fossil_core.domain.evidence",
     "fossil_core.domain.identity",
     "fossil_core.domain.lifecycle",
     "fossil_core.domain.pack",

--- a/src/fossil_core/domain/evidence.py
+++ b/src/fossil_core/domain/evidence.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+
+def build_redaction_event(
+    *,
+    tombstone: Mapping[str, Any],
+    pack_id: str,
+    actor: Mapping[str, Any],
+    occurred_at: str,
+    recorded_at: str,
+    idempotency_key: str,
+    snapshot_ids: Iterable[str] = (),
+) -> dict[str, Any]:
+    return {
+        "schema_version": "dkg.event.v1",
+        "event_type": "evidence.redacted",
+        "occurred_at": occurred_at,
+        "recorded_at": recorded_at,
+        "pack_id": pack_id,
+        "actor": dict(actor),
+        "subject_refs": [str(tombstone["artifact_id"]), *list(snapshot_ids)],
+        "idempotency_key": idempotency_key,
+        "payload": {
+            "artifact_id": tombstone["artifact_id"],
+            "snapshot_ids": list(snapshot_ids),
+            "reason": tombstone["reason"],
+            "authority": tombstone["authority"],
+            "request_ref": tombstone.get("request_ref"),
+            "redacted_at": tombstone["redacted_at"],
+        },
+        "provenance": {"method": "artifact_redaction_tombstone"},
+    }
+
+
+__all__ = ["build_redaction_event"]

--- a/src/fossil_core/source.py
+++ b/src/fossil_core/source.py
@@ -10,6 +10,7 @@ from typing import Any, Iterable, Mapping
 from jsonschema import Draft202012Validator, FormatChecker
 
 from fossil_core.artifact_store import ArtifactStore
+from fossil_core.domain.evidence import build_redaction_event
 from fossil_core.domain.provenance import (
     SourceLifecycleState,
     SourceStatus,
@@ -302,34 +303,3 @@ class RedactionPolicy:
 
     def export_event(self, event: Mapping[str, Any]) -> dict[str, Any] | None:
         return copy.deepcopy(dict(event)) if self.event_visible(event) else None
-
-
-def build_redaction_event(
-    *,
-    tombstone: Mapping[str, Any],
-    pack_id: str,
-    actor: Mapping[str, Any],
-    occurred_at: str,
-    recorded_at: str,
-    idempotency_key: str,
-    snapshot_ids: Iterable[str] = (),
-) -> dict[str, Any]:
-    return {
-        "schema_version": "dkg.event.v1",
-        "event_type": "evidence.redacted",
-        "occurred_at": occurred_at,
-        "recorded_at": recorded_at,
-        "pack_id": pack_id,
-        "actor": dict(actor),
-        "subject_refs": [str(tombstone["artifact_id"]), *list(snapshot_ids)],
-        "idempotency_key": idempotency_key,
-        "payload": {
-            "artifact_id": tombstone["artifact_id"],
-            "snapshot_ids": list(snapshot_ids),
-            "reason": tombstone["reason"],
-            "authority": tombstone["authority"],
-            "request_ref": tombstone.get("request_ref"),
-            "redacted_at": tombstone["redacted_at"],
-        },
-        "provenance": {"method": "artifact_redaction_tombstone"},
-    }

--- a/tests/test_evidence_redaction_domain_compatibility.py
+++ b/tests/test_evidence_redaction_domain_compatibility.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import fossil_core.source as legacy_source
+from fossil_core.domain.evidence import build_redaction_event
+
+
+def test_redaction_event_factory_preserves_legacy_identity():
+    assert legacy_source.build_redaction_event is build_redaction_event
+
+
+def test_redaction_event_shape_is_unchanged():
+    event = build_redaction_event(
+        tombstone={
+            "artifact_id": "artifact_123",
+            "reason": "legal request",
+            "authority": "owner",
+            "request_ref": "request_456",
+            "redacted_at": "2026-08-09T23:50:00Z",
+        },
+        pack_id="pack_789",
+        actor={"actor_type": "system", "actor_id": "redaction-fixture"},
+        occurred_at="2026-08-09T23:51:00Z",
+        recorded_at="2026-08-09T23:52:00Z",
+        idempotency_key="redaction-1",
+        snapshot_ids=("snap_1", "snap_2"),
+    )
+    assert event == {
+        "schema_version": "dkg.event.v1",
+        "event_type": "evidence.redacted",
+        "occurred_at": "2026-08-09T23:51:00Z",
+        "recorded_at": "2026-08-09T23:52:00Z",
+        "pack_id": "pack_789",
+        "actor": {"actor_type": "system", "actor_id": "redaction-fixture"},
+        "subject_refs": ["artifact_123", "snap_1", "snap_2"],
+        "idempotency_key": "redaction-1",
+        "payload": {
+            "artifact_id": "artifact_123",
+            "snapshot_ids": ["snap_1", "snap_2"],
+            "reason": "legal request",
+            "authority": "owner",
+            "request_ref": "request_456",
+            "redacted_at": "2026-08-09T23:50:00Z",
+        },
+        "provenance": {"method": "artifact_redaction_tombstone"},
+    }
+
+
+def test_redaction_event_preserves_optional_request_ref_default():
+    event = build_redaction_event(
+        tombstone={
+            "artifact_id": "artifact_123",
+            "reason": "policy",
+            "authority": "owner",
+            "redacted_at": "2026-08-09T23:50:00Z",
+        },
+        pack_id="pack_789",
+        actor={"actor_type": "system", "actor_id": "redaction-fixture"},
+        occurred_at="2026-08-09T23:51:00Z",
+        recorded_at="2026-08-09T23:52:00Z",
+        idempotency_key="redaction-2",
+    )
+    assert event["payload"]["request_ref"] is None
+    assert event["payload"]["snapshot_ids"] == []
+    assert event["subject_refs"] == ["artifact_123"]


### PR DESCRIPTION
Advances #82 Phase 4 with one pure evidence-event domain slice.

## Scope
- move `build_redaction_event` from mixed `fossil_core.source` to canonical `fossil_core.domain.evidence`
- preserve `fossil_core.source.build_redaction_event` object identity and the existing historical `source.py` implicit namespace
- freeze the exact existing `dkg.event.v1` `evidence.redacted` dictionary, including subject refs, payload fields, optional request_ref behavior, and provenance method
- add public API declaration, architecture enforcement, compatibility tests, and migration guidance

## Explicit non-goals
- no `RedactionPolicy` move
- no tombstone creation/persistence or artifact deletion behavior changes
- no `SourceSnapshotStore`/citation/schema changes
- no source lifecycle, storage/provider/projection, event ordering, or acceptance changes
- no compatibility cleanup

## Verification
- canonical/legacy object identity
- exact evidence.redacted event dictionary regression
- optional request_ref / empty snapshot default regression
- existing historical `fossil_core.source` namespace regression remains green
- public API contract tests
- domain architecture-boundary tests
- full deterministic DKG suite
- Dependency Integrity
- SHA-fenced merge + exact-main post-merge gates

Parent: #82
Architecture: #81, #86
Base: `7e1d85db6584954dec5dc7b9d5c5e110ca784a07`