### PR TITLE
[ARCH-P4] Move immutable IO behind filesystem adapter boundary

### DIFF
--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -35,6 +35,7 @@ CANONICAL_MODULES = {
     "fossil_core.adapters.filesystem",
     "fossil_core.adapters.filesystem.artifact_store",
     "fossil_core.adapters.filesystem.event_store",
+    "fossil_core.adapters.filesystem.io",
     "fossil_core.adapters.s3",
     "fossil_core.adapters.s3.storage",
 }
@@ -42,6 +43,7 @@ CANONICAL_MODULES = {
 COMPATIBILITY_IMPORTS = {
     "fossil_core.answer_pipeline": {"fossil_core.application.query"},
     "fossil_core.ids": {"fossil_core.domain.identity"},
+    "fossil_core.io": {"fossil_core.adapters.filesystem.io"},
     "fossil_core.lifecycle": {"fossil_core.domain.lifecycle"},
     "fossil_core.promotion": {"fossil_core.domain.promotion"},
     "fossil_core.storage_ports": {"fossil_core.ports"},

--- a/src/fossil_core/adapters/filesystem/artifact_store.py
+++ b/src/fossil_core/adapters/filesystem/artifact_store.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from ...io import publish_immutable
+from .io import publish_immutable
 
 
 class ArtifactIntegrityError(RuntimeError):

--- a/src/fossil_core/adapters/filesystem/event_store.py
+++ b/src/fossil_core/adapters/filesystem/event_store.py
@@ -9,7 +9,7 @@ from typing import Any, Iterator
 from jsonschema import Draft202012Validator, FormatChecker
 
 from ...ids import deterministic_event_id, new_id
-from ...io import publish_immutable
+from .io import publish_immutable
 
 
 class IdempotencyConflict(RuntimeError):

--- a/src/fossil_core/adapters/filesystem/io.py
+++ b/src/fossil_core/adapters/filesystem/io.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+
+def fsync_directory(path: Path) -> None:
+    """Best-effort directory fsync after publishing a durable file."""
+    flags = getattr(os, "O_DIRECTORY", 0) | os.O_RDONLY
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def publish_immutable(path: Path, data: bytes) -> bool:
+    """Atomically publish bytes without replacing an existing path.
+
+    Returns True when this call published the file, False when another writer
+    already published the target. The caller decides whether the existing
+    content is an idempotent retry or a conflict.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.parent / f".{path.name}.{uuid.uuid4().hex}.tmp"
+    try:
+        fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except Exception:
+            temp.unlink(missing_ok=True)
+            raise
+
+        try:
+            os.link(temp, path)
+            published = True
+        except FileExistsError:
+            published = False
+        if published:
+            fsync_directory(path.parent)
+        return published
+    finally:
+        temp.unlink(missing_ok=True)

--- a/src/fossil_core/io.py
+++ b/src/fossil_core/io.py
@@ -4,48 +4,4 @@ import os
 import uuid
 from pathlib import Path
 
-
-def fsync_directory(path: Path) -> None:
-    """Best-effort directory fsync after publishing a durable file."""
-    flags = getattr(os, "O_DIRECTORY", 0) | os.O_RDONLY
-    try:
-        fd = os.open(path, flags)
-    except OSError:
-        return
-    try:
-        os.fsync(fd)
-    finally:
-        os.close(fd)
-
-
-def publish_immutable(path: Path, data: bytes) -> bool:
-    """Atomically publish bytes without replacing an existing path.
-
-    Returns True when this call published the file, False when another writer
-    already published the target. The caller decides whether the existing
-    content is an idempotent retry or a conflict.
-    """
-    path = Path(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temp = path.parent / f".{path.name}.{uuid.uuid4().hex}.tmp"
-    try:
-        fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
-        try:
-            with os.fdopen(fd, "wb") as handle:
-                handle.write(data)
-                handle.flush()
-                os.fsync(handle.fileno())
-        except Exception:
-            temp.unlink(missing_ok=True)
-            raise
-
-        try:
-            os.link(temp, path)
-            published = True
-        except FileExistsError:
-            published = False
-        if published:
-            fsync_directory(path.parent)
-        return published
-    finally:
-        temp.unlink(missing_ok=True)
+from .adapters.filesystem.io import fsync_directory, publish_immutable

--- a/tests/test_io_filesystem_compatibility.py
+++ b/tests/test_io_filesystem_compatibility.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import inspect
+
+import fossil_core.adapters.filesystem.io as canonical_io
+import fossil_core.io as legacy_io
+
+
+def test_io_legacy_namespace_and_object_identity_are_frozen():
+    assert not hasattr(legacy_io, "__all__")
+    assert {name for name in vars(legacy_io) if not name.startswith("_")} == {
+        "Path",
+        "annotations",
+        "fsync_directory",
+        "os",
+        "publish_immutable",
+        "uuid",
+    }
+    assert legacy_io.fsync_directory is canonical_io.fsync_directory
+    assert legacy_io.publish_immutable is canonical_io.publish_immutable
+
+
+def test_io_signatures_are_unchanged():
+    fsync_signature = inspect.signature(canonical_io.fsync_directory)
+    assert list(fsync_signature.parameters) == ["path"]
+    assert fsync_signature.return_annotation == "None"
+
+    publish_signature = inspect.signature(canonical_io.publish_immutable)
+    assert list(publish_signature.parameters) == ["path", "data"]
+    assert publish_signature.return_annotation == "bool"
+
+
+def test_canonical_and_legacy_immutable_publish_behavior_match(tmp_path):
+    canonical_path = tmp_path / "canonical" / "item.bin"
+    legacy_path = tmp_path / "legacy" / "item.bin"
+
+    for publish, path in (
+        (canonical_io.publish_immutable, canonical_path),
+        (legacy_io.publish_immutable, legacy_path),
+    ):
+        assert publish(path, b"first") is True
+        assert path.read_bytes() == b"first"
+        assert publish(path, b"first") is False
+        assert publish(path, b"different") is False
+        assert path.read_bytes() == b"first"


### PR DESCRIPTION
## Scope

Phase 4 bounded filesystem-adapter modularization under #82.

- move the existing immutable filesystem publication implementation verbatim to `fossil_core.adapters.filesystem.io`
- retain `fossil_core.io` as a thin identity-preserving compatibility shim
- update canonical filesystem artifact/event stores to import the canonical sibling IO helper instead of the historical flat module
- freeze legacy implicit namespace, object identity, signatures, and immutable-publish behavior
- make the compatibility boundary mechanically enforced by architecture CI

## Boundary decision

`io.py` is concrete POSIX/filesystem adapter behavior (`os.open`, hard-link publication, fsync, filesystem paths), so its canonical ownership is `adapters.filesystem`, not the flat package root. The canonical file reuses the exact historical implementation blob `0bfdf1d008fa5718f69c86e3e4c8cb0898c1e7f0`.

Historical flat `source.py` / `conversation.py` consumers intentionally remain on the compatibility path until their owning responsibilities are modularized; canonical filesystem adapters no longer depend on the legacy shim.

This module is not a supported public surface in `contracts/python-public-api-v1.json`, so this is not a public API promotion.

## Semantic-drift audit

No filesystem publication logic was edited. Artifact/event store changes are import-path-only. Stable IDs, event/schema/hash, redaction, storage semantics, provider behavior, projection behavior, LiteLLM/V5 runtime, and acceptance criteria are unchanged.

## Exact-head verification

Head `2c12179b32367a89390e00cd67332fbc578517b8`:

- DKG contract tests `32041609214`: SUCCESS — `367 passed, 1 skipped, 1 warning`
- Dependency Integrity `32041609210`: SUCCESS — architecture-boundaries, vulnerability-scan, and pyproject-consistency all passed
- canonical filesystem IO blob is exactly the historical `fossil_core.io` implementation blob `0bfdf1d008fa5718f69c86e3e4c8cb0898c1e7f0`
- architecture CI now requires the canonical module and freezes `fossil_core.io` as a thin compatibility import
- submitted reviews: 0
- review threads: pending final re-fetch before merge