### PR TITLE
[ARCH-P4] Move pack validation behind application/ingest

### DIFF
--- a/docs/architecture/modularization-phase4-application-ingest-pack-validation.md
+++ b/docs/architecture/modularization-phase4-application-ingest-pack-validation.md
@@ -1,0 +1,27 @@
+# Phase 4: pack validation application boundary
+
+Status: bounded behavior-preserving modularization slice under #82.
+
+`KnowledgePackValidator` is canonical under `fossil_core.application.ingest`. It is not pure domain logic: construction reads a JSON Schema from the filesystem and validation delegates structural checks to `jsonschema` before applying the existing pure pack-boundary invariants.
+
+The pure capability model remains in `fossil_core.domain.pack`:
+
+```python
+from fossil_core.domain.pack import PackAccess, PackBoundaryError
+```
+
+The ingestion validation service is:
+
+```python
+from fossil_core.application.ingest import KnowledgePackValidator
+```
+
+The supported package-root import remains unchanged and aliases the canonical application object:
+
+```python
+from fossil_core import KnowledgePackValidator
+```
+
+`fossil_core.pack` remains an import-compatible mixed legacy path during the migration. Its historical implicit namespace is preserved, while `KnowledgePackValidator` forwards to the application boundary and `PackAccess` / `PackBoundaryError` forward to the pure domain boundary.
+
+This move does not change the knowledge-pack schema, manifest fields, dependency/read/write validation rules, validation messages, storage/provider behavior, stable identities, hashes, projection behavior, LiteLLM/Cortex V5 runtime, or any acceptance threshold. Cleanup or removal of the legacy path requires a separate compatibility decision.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -11,6 +11,8 @@ from architecture_inventory import inventory
 PACKAGE = "fossil_core"
 CANONICAL_MODULES = {
     "fossil_core.application",
+    "fossil_core.application.ingest",
+    "fossil_core.application.ingest.pack_validation",
     "fossil_core.application.query",
     "fossil_core.application.query.lineage",
     "fossil_core.domain",

--- a/src/fossil_core/__init__.py
+++ b/src/fossil_core/__init__.py
@@ -1,10 +1,11 @@
 """Durable Knowledge Graph core contracts."""
 
-from .adapters.filesystem import ArtifactIntegrityError, ArtifactStore, DurableEventStore, IdempotencyConflict
+from .artifact_store import ArtifactIntegrityError, ArtifactStore
 from .application.ingest import KnowledgePackValidator
-from .domain.lifecycle import KnowledgeState, LifecycleError, RelationRecord
-from .domain.pack import PackAccess, PackBoundaryError
-from .domain.promotion import build_promotion_event
+from .event_store import DurableEventStore, IdempotencyConflict
+from .lifecycle import KnowledgeState, LifecycleError, RelationRecord
+from .pack import PackAccess, PackBoundaryError
+from .promotion import build_promotion_event
 
 __all__ = [
     "ArtifactIntegrityError",

--- a/src/fossil_core/__init__.py
+++ b/src/fossil_core/__init__.py
@@ -1,10 +1,10 @@
 """Durable Knowledge Graph core contracts."""
 
-from .artifact_store import ArtifactIntegrityError, ArtifactStore
-from .event_store import DurableEventStore, IdempotencyConflict
-from .lifecycle import KnowledgeState, LifecycleError, RelationRecord
-from .pack import KnowledgePackValidator, PackAccess, PackBoundaryError
-from .promotion import build_promotion_event
+from .adapters.filesystem import ArtifactIntegrityError, ArtifactStore, DurableEventStore, IdempotencyConflict
+from .application.ingest import KnowledgePackValidator
+from .domain.lifecycle import KnowledgeState, LifecycleError, RelationRecord
+from .domain.pack import PackAccess, PackBoundaryError
+from .domain.promotion import build_promotion_event
 
 __all__ = [
     "ArtifactIntegrityError",

--- a/src/fossil_core/application/ingest/__init__.py
+++ b/src/fossil_core/application/ingest/__init__.py
@@ -1,0 +1,5 @@
+"""Provider-neutral ingestion validation/application services."""
+
+from .pack_validation import KnowledgePackValidator
+
+__all__ = ["KnowledgePackValidator"]

--- a/src/fossil_core/application/ingest/pack_validation.py
+++ b/src/fossil_core/application/ingest/pack_validation.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+from ...domain.pack import PackAccess, PackBoundaryError
+
+
+class KnowledgePackValidator:
+    def __init__(self, schema_path: Path):
+        self.schema_path = Path(schema_path)
+        self.schema = json.loads(self.schema_path.read_text(encoding="utf-8"))
+        self.validator = Draft202012Validator(self.schema, format_checker=FormatChecker())
+
+    def validate(self, manifest: dict[str, Any]) -> None:
+        self.validator.validate(manifest)
+        pack_id = manifest["pack_id"]
+        if pack_id not in manifest["read_mounts"]:
+            raise PackBoundaryError("a pack must be able to read itself")
+        for target in manifest["write_targets"]:
+            if target not in manifest["read_mounts"]:
+                raise PackBoundaryError("every write target must also be readable")
+        for dependency in manifest.get("dependencies", []):
+            if dependency["required"] and dependency["pack_id"] not in manifest["read_mounts"]:
+                raise PackBoundaryError("every required dependency must be in read_mounts")
+
+    def validate_set(self, manifests: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        by_id: dict[str, dict[str, Any]] = {}
+        for manifest in manifests:
+            self.validate(manifest)
+            pack_id = manifest["pack_id"]
+            if pack_id in by_id:
+                raise PackBoundaryError(f"duplicate pack_id: {pack_id}")
+            by_id[pack_id] = manifest
+        for manifest in by_id.values():
+            for dependency in manifest.get("dependencies", []):
+                if dependency["required"] and dependency["pack_id"] not in by_id:
+                    raise PackBoundaryError(
+                        f"required dependency {dependency['pack_id']} is unavailable"
+                    )
+        return by_id
+
+    def load_and_validate(self, path: Path) -> dict[str, Any]:
+        manifest = json.loads(Path(path).read_text(encoding="utf-8"))
+        self.validate(manifest)
+        return manifest

--- a/src/fossil_core/pack.py
+++ b/src/fossil_core/pack.py
@@ -7,44 +7,5 @@ from typing import Any, Iterable
 
 from jsonschema import Draft202012Validator, FormatChecker
 
+from .application.ingest import KnowledgePackValidator
 from .domain.pack import PackAccess, PackBoundaryError
-
-
-class KnowledgePackValidator:
-    def __init__(self, schema_path: Path):
-        self.schema_path = Path(schema_path)
-        self.schema = json.loads(self.schema_path.read_text(encoding="utf-8"))
-        self.validator = Draft202012Validator(self.schema, format_checker=FormatChecker())
-
-    def validate(self, manifest: dict[str, Any]) -> None:
-        self.validator.validate(manifest)
-        pack_id = manifest["pack_id"]
-        if pack_id not in manifest["read_mounts"]:
-            raise PackBoundaryError("a pack must be able to read itself")
-        for target in manifest["write_targets"]:
-            if target not in manifest["read_mounts"]:
-                raise PackBoundaryError("every write target must also be readable")
-        for dependency in manifest.get("dependencies", []):
-            if dependency["required"] and dependency["pack_id"] not in manifest["read_mounts"]:
-                raise PackBoundaryError("every required dependency must be in read_mounts")
-
-    def validate_set(self, manifests: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:
-        by_id: dict[str, dict[str, Any]] = {}
-        for manifest in manifests:
-            self.validate(manifest)
-            pack_id = manifest["pack_id"]
-            if pack_id in by_id:
-                raise PackBoundaryError(f"duplicate pack_id: {pack_id}")
-            by_id[pack_id] = manifest
-        for manifest in by_id.values():
-            for dependency in manifest.get("dependencies", []):
-                if dependency["required"] and dependency["pack_id"] not in by_id:
-                    raise PackBoundaryError(
-                        f"required dependency {dependency['pack_id']} is unavailable"
-                    )
-        return by_id
-
-    def load_and_validate(self, path: Path) -> dict[str, Any]:
-        manifest = json.loads(Path(path).read_text(encoding="utf-8"))
-        self.validate(manifest)
-        return manifest

--- a/tests/test_pack_domain_compatibility.py
+++ b/tests/test_pack_domain_compatibility.py
@@ -4,6 +4,7 @@ import importlib
 
 import fossil_core
 import fossil_core.pack as legacy_pack
+from fossil_core.application.ingest import KnowledgePackValidator
 from fossil_core.domain.pack import PackAccess, PackBoundaryError
 
 
@@ -26,5 +27,7 @@ def test_legacy_dkg_pack_boundary_exports_alias_canonical_domain_objects():
 
 
 def test_json_schema_validator_stays_outside_pure_domain_boundary():
-    assert legacy_pack.KnowledgePackValidator.__module__ == "fossil_core.pack"
+    assert legacy_pack.KnowledgePackValidator is KnowledgePackValidator
+    assert fossil_core.KnowledgePackValidator is KnowledgePackValidator
+    assert KnowledgePackValidator.__module__ == "fossil_core.application.ingest.pack_validation"
     assert not hasattr(importlib.import_module("fossil_core.domain.pack"), "KnowledgePackValidator")

--- a/tests/test_pack_validation_application_compatibility.py
+++ b/tests/test_pack_validation_application_compatibility.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import fossil_core
+import fossil_core.application.ingest as canonical_ingest
+import fossil_core.domain.pack as canonical_pack
+import fossil_core.pack as legacy_pack
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_pack_legacy_namespace_and_object_identity_are_frozen():
+    assert not hasattr(legacy_pack, "__all__")
+    assert {name for name in vars(legacy_pack) if not name.startswith("_")} == {
+        "Any",
+        "Draft202012Validator",
+        "FormatChecker",
+        "Iterable",
+        "KnowledgePackValidator",
+        "PackAccess",
+        "PackBoundaryError",
+        "Path",
+        "annotations",
+        "dataclass",
+        "json",
+    }
+
+    assert legacy_pack.KnowledgePackValidator is canonical_ingest.KnowledgePackValidator
+    assert fossil_core.KnowledgePackValidator is canonical_ingest.KnowledgePackValidator
+    assert legacy_pack.PackAccess is canonical_pack.PackAccess
+    assert legacy_pack.PackBoundaryError is canonical_pack.PackBoundaryError
+
+
+def test_pack_validator_call_signatures_are_unchanged():
+    validator = canonical_ingest.KnowledgePackValidator
+
+    init_parameters = list(inspect.signature(validator.__init__).parameters.values())
+    assert [parameter.name for parameter in init_parameters] == ["self", "schema_path"]
+
+    validate_parameters = list(inspect.signature(validator.validate).parameters.values())
+    assert [parameter.name for parameter in validate_parameters] == ["self", "manifest"]
+
+    set_parameters = list(inspect.signature(validator.validate_set).parameters.values())
+    assert [parameter.name for parameter in set_parameters] == ["self", "manifests"]
+
+    load_parameters = list(inspect.signature(validator.load_and_validate).parameters.values())
+    assert [parameter.name for parameter in load_parameters] == ["self", "path"]
+
+
+def test_canonical_and_legacy_pack_validation_behavior_match():
+    schema = ROOT / "schemas/knowledge-pack/v1.schema.json"
+    common_path = ROOT / "examples/packs/common/manifest.json"
+    project_path = ROOT / "examples/packs/plugin-harness/manifest.json"
+
+    canonical = canonical_ingest.KnowledgePackValidator(schema)
+    legacy = legacy_pack.KnowledgePackValidator(schema)
+
+    canonical_common = canonical.load_and_validate(common_path)
+    canonical_project = canonical.load_and_validate(project_path)
+    legacy_common = legacy.load_and_validate(common_path)
+    legacy_project = legacy.load_and_validate(project_path)
+
+    assert canonical_common == legacy_common
+    assert canonical_project == legacy_project
+    assert canonical.validate_set([canonical_common, canonical_project]) == legacy.validate_set(
+        [legacy_common, legacy_project]
+    )


### PR DESCRIPTION
## Scope

Phase 4 bounded application/ingest modularization under #82.

- move `KnowledgePackValidator` behind `fossil_core.application.ingest`
- retain `fossil_core.pack` as a mixed import-compatible legacy path with its historical implicit namespace
- keep `PackAccess` / `PackBoundaryError` canonical in the pure `fossil_core.domain.pack` boundary
- point the supported package-root `KnowledgePackValidator` directly at the canonical application object
- freeze legacy namespace, object identity, public call signatures, and representative schema/dependency validation behavior
- require the new application modules in architecture CI

## Boundary decision

`KnowledgePackValidator` is not pure domain logic: construction reads a JSON Schema from a filesystem path and uses `jsonschema` before applying the existing pure pack-boundary invariants. Canonical ownership is therefore `application.ingest`, while the capability model remains in `domain.pack`.

The implementation body is unchanged from the historical `pack.py`; the only implementation-path edit is the package-relative import needed to reach `domain.pack` after relocation.

The supported package-root API remains unchanged. No new public contract surface is promoted by this PR; `application.ingest` is internal-by-default under the existing API policy.

## Semantic-drift audit

No knowledge-pack schema, manifest field, required-dependency, read/write boundary, validation-message, storage/provider, stable-ID/hash, projection, LiteLLM/V5 runtime, or acceptance behavior changes.

The first exact-head DKG run `32042242706` failed only because an existing architecture test explicitly asserted `KnowledgePackValidator.__module__ == "fossil_core.pack"`. The test was updated to preserve its actual invariant — validator stays outside the pure domain boundary — while now asserting canonical application ownership and legacy/root object identity. No validation rule or acceptance threshold was weakened.

## Exact-head verification

Head `048d25ddfe14cbde143bac2f94046f05499a6ec0`:

- DKG contract tests `32042297154`: SUCCESS — `370 passed, 1 skipped, 1 warning`
- Dependency Integrity `32042297153`: SUCCESS — architecture-boundaries, vulnerability-scan, and pyproject-consistency all passed
- legacy `fossil_core.pack` namespace and object identity are frozen; root `KnowledgePackValidator` aliases the canonical application object
- submitted reviews: 0
- review threads: 0