### PR TITLE
[WORKSTREAM-D] Add bounded hosted reranker adapter

### DIFF
--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -38,6 +38,8 @@ CANONICAL_MODULES = {
     "fossil_core.adapters.filesystem.artifact_store",
     "fossil_core.adapters.filesystem.event_store",
     "fossil_core.adapters.filesystem.io",
+    "fossil_core.adapters.litellm",
+    "fossil_core.adapters.litellm.reranker",
     "fossil_core.adapters.s3",
     "fossil_core.adapters.s3.storage",
 }

--- a/src/fossil_core/adapters/litellm/__init__.py
+++ b/src/fossil_core/adapters/litellm/__init__.py
@@ -1,0 +1,15 @@
+"""Narrow LiteLLM cognitive-service adapters."""
+
+from .reranker import (
+    LiteLLMReranker,
+    LiteLLMRerankerIdentityError,
+    LiteLLMRerankerProtocolError,
+    LiteLLMRerankerTransportError,
+)
+
+__all__ = [
+    "LiteLLMReranker",
+    "LiteLLMRerankerIdentityError",
+    "LiteLLMRerankerProtocolError",
+    "LiteLLMRerankerTransportError",
+]

--- a/src/fossil_core/adapters/litellm/reranker.py
+++ b/src/fossil_core/adapters/litellm/reranker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import socket
 from collections.abc import Callable, Iterable, Mapping
@@ -287,7 +288,7 @@ class LiteLLMReranker:
             retrieval = candidate.get("retrieval")
             retrieval_mapping = dict(retrieval) if isinstance(retrieval, Mapping) else {}
             base_rank = int(retrieval_mapping.get("rank", index + 1))
-            result = json.loads(json.dumps(candidate))
+            result = copy.deepcopy(candidate)
             result["rerank"] = {
                 "base_rank": base_rank,
                 "score": score,

--- a/src/fossil_core/adapters/litellm/reranker.py
+++ b/src/fossil_core/adapters/litellm/reranker.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import json
+import socket
+from collections.abc import Callable, Iterable, Mapping
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from ...services import ServiceMetadata
+
+
+JsonTransport = Callable[
+    [str, Mapping[str, str], Mapping[str, Any], float],
+    Mapping[str, Any],
+]
+
+
+class LiteLLMRerankerTransportError(RuntimeError):
+    """Raised when the bounded rerank request cannot be completed."""
+
+
+class LiteLLMRerankerProtocolError(RuntimeError):
+    """Raised when the rerank response cannot be mapped to candidate ordering."""
+
+
+class LiteLLMRerankerIdentityError(LiteLLMRerankerProtocolError):
+    """Raised when a reported actual model contradicts the requested route identity."""
+
+
+def _post_json(
+    url: str,
+    headers: Mapping[str, str],
+    payload: Mapping[str, Any],
+    timeout_seconds: float,
+) -> Mapping[str, Any]:
+    request = Request(
+        url,
+        data=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+        headers=dict(headers),
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            raw = response.read(2_000_001)
+    except HTTPError as exc:
+        raise LiteLLMRerankerTransportError(
+            f"LiteLLM rerank request failed with HTTP status {exc.code}"
+        ) from None
+    except (URLError, TimeoutError, socket.timeout):
+        raise LiteLLMRerankerTransportError("LiteLLM rerank request failed") from None
+
+    if len(raw) > 2_000_000:
+        raise LiteLLMRerankerProtocolError("LiteLLM rerank response exceeded the 2 MB bound")
+    try:
+        decoded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise LiteLLMRerankerProtocolError("LiteLLM rerank response was not valid JSON") from None
+    if not isinstance(decoded, Mapping):
+        raise LiteLLMRerankerProtocolError("LiteLLM rerank response must be a JSON object")
+    return decoded
+
+
+def _reported_model(payload: Mapping[str, Any]) -> str | None:
+    metadata = payload.get("metadata")
+    meta = payload.get("meta")
+    values = [
+        payload.get("model"),
+        metadata.get("bridge_actual_model") if isinstance(metadata, Mapping) else None,
+        metadata.get("actual_model") if isinstance(metadata, Mapping) else None,
+        meta.get("model") if isinstance(meta, Mapping) else None,
+        meta.get("actual_model") if isinstance(meta, Mapping) else None,
+    ]
+    for value in values:
+        if value is not None and str(value).strip():
+            return str(value)
+    return None
+
+
+def _reported_provider(payload: Mapping[str, Any]) -> str | None:
+    metadata = payload.get("metadata")
+    meta = payload.get("meta")
+    values = [
+        payload.get("provider"),
+        metadata.get("bridge_actual_provider") if isinstance(metadata, Mapping) else None,
+        metadata.get("actual_provider") if isinstance(metadata, Mapping) else None,
+        meta.get("provider") if isinstance(meta, Mapping) else None,
+    ]
+    for value in values:
+        if value is not None and str(value).strip():
+            return str(value)
+    return None
+
+
+class LiteLLMReranker:
+    """One-request, bounded adapter for LiteLLM's non-streaming ``/v1/rerank`` lane.
+
+    Rerank scores are candidate-ordering evidence only. The adapter performs no
+    retries, fallback, model substitution, truth mutation, or tool execution.
+    The rerank endpoint used by the currently verified gateway is a buffered
+    JSON API rather than a streaming model surface; that is recorded explicitly
+    in service metadata instead of being left as an implicit transport default.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        model: str,
+        gateway_id: str,
+        provider_version: str,
+        timeout_seconds: float,
+        max_candidates: int,
+        accepted_actual_models: Iterable[str] = (),
+        require_reported_actual_model: bool = False,
+        transport: JsonTransport | None = None,
+        implementation_version: str = "1",
+    ) -> None:
+        values = {
+            "base_url": base_url,
+            "api_key": api_key,
+            "model": model,
+            "gateway_id": gateway_id,
+            "provider_version": provider_version,
+            "implementation_version": implementation_version,
+        }
+        if any(not str(value).strip() for value in values.values()):
+            raise ValueError("LiteLLM reranker requires non-empty connection and identity values")
+        if timeout_seconds <= 0 or timeout_seconds > 120:
+            raise ValueError("LiteLLM reranker timeout_seconds must be in (0, 120]")
+        if max_candidates < 1 or max_candidates > 256:
+            raise ValueError("LiteLLM reranker max_candidates must be in [1, 256]")
+
+        self.base_url = str(base_url).rstrip("/")
+        self.api_key = str(api_key)
+        self.model = str(model)
+        self.gateway_id = str(gateway_id)
+        self.provider_version = str(provider_version)
+        self.timeout_seconds = float(timeout_seconds)
+        self.max_candidates = int(max_candidates)
+        self.require_reported_actual_model = bool(require_reported_actual_model)
+        self.implementation_version = str(implementation_version)
+        self.transport = transport or _post_json
+        self.accepted_actual_models = {self.model, *[str(item) for item in accepted_actual_models]}
+        self._last_actual_model: str | None = None
+        self._last_actual_provider: str | None = None
+
+    @property
+    def identity_verified(self) -> bool:
+        return self._last_actual_model is not None
+
+    def metadata(self) -> dict[str, Any]:
+        return ServiceMetadata(
+            kind="reranker",
+            provider="litellm",
+            provider_version=self.provider_version,
+            implementation="litellm-rerank-api",
+            implementation_version=self.implementation_version,
+            model_id=self._last_actual_model,
+            local=False,
+            estimated_cost_per_call_usd=0.0,
+            runtime={
+                "gateway_id": self.gateway_id,
+                "requested_model_id": self.model,
+                "actual_model_id": self._last_actual_model or "unreported",
+                "actual_provider": self._last_actual_provider or "unreported",
+                "actual_model_verified": str(self.identity_verified).lower(),
+                "require_reported_actual_model": str(
+                    self.require_reported_actual_model
+                ).lower(),
+                "timeout_seconds": str(self.timeout_seconds),
+                "max_candidates": str(self.max_candidates),
+                "automatic_retries": "0",
+                "fallback": "disabled",
+                "request_granularity": "one-bounded-rerank-request-per-call",
+                "streaming_supported": "false",
+                "streaming_required": "false",
+                "response_mode": "buffered-json",
+                "score_authority": "candidate-ordering-only",
+            },
+        ).as_dict()
+
+    def _response_identity(self, payload: Mapping[str, Any]) -> None:
+        actual_model = _reported_model(payload)
+        actual_provider = _reported_provider(payload)
+        if actual_model is None:
+            self._last_actual_model = None
+            self._last_actual_provider = actual_provider
+            if self.require_reported_actual_model:
+                raise LiteLLMRerankerIdentityError(
+                    "LiteLLM rerank response did not report actual model identity"
+                )
+            return
+        if actual_model not in self.accepted_actual_models:
+            raise LiteLLMRerankerIdentityError(
+                "LiteLLM rerank response reported an unaccepted actual model identity"
+            )
+        self._last_actual_model = actual_model
+        self._last_actual_provider = actual_provider
+
+    def rerank(
+        self,
+        query: str,
+        candidates: list[dict[str, Any]],
+        *,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        if limit < 1:
+            raise ValueError("limit must be positive")
+        if not str(query).strip():
+            raise ValueError("rerank query must be non-empty")
+        if not candidates:
+            return []
+        if len(candidates) > self.max_candidates:
+            raise ValueError(
+                "rerank candidate count exceeds the explicit max_candidates request bound"
+            )
+
+        documents: list[str] = []
+        for candidate in candidates:
+            if not candidate.get("id"):
+                raise ValueError("rerank candidates require stable id")
+            if not isinstance(candidate.get("text"), str):
+                raise ValueError("rerank candidates require string text")
+            documents.append(str(candidate["text"]))
+
+        top_n = min(int(limit), len(candidates))
+        payload = {
+            "model": self.model,
+            "query": str(query),
+            "documents": documents,
+            "top_n": top_n,
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        try:
+            response = self.transport(
+                f"{self.base_url}/rerank",
+                headers,
+                payload,
+                self.timeout_seconds,
+            )
+        except (LiteLLMRerankerTransportError, LiteLLMRerankerProtocolError):
+            raise
+        except Exception:
+            raise LiteLLMRerankerTransportError("LiteLLM rerank transport failed") from None
+        if not isinstance(response, Mapping):
+            raise LiteLLMRerankerProtocolError("LiteLLM rerank response must be a mapping")
+
+        self._response_identity(response)
+        rows = response.get("results") or response.get("data")
+        if not isinstance(rows, list) or not rows:
+            raise LiteLLMRerankerProtocolError("LiteLLM rerank response contained no ranking rows")
+        if len(rows) > top_n:
+            raise LiteLLMRerankerProtocolError(
+                "LiteLLM rerank response exceeded the requested top_n bound"
+            )
+
+        seen_indices: set[int] = set()
+        parsed: list[tuple[int, float]] = []
+        for row in rows:
+            if not isinstance(row, Mapping):
+                raise LiteLLMRerankerProtocolError("LiteLLM rerank row must be a mapping")
+            index = row.get("index")
+            if isinstance(index, bool) or not isinstance(index, int):
+                raise LiteLLMRerankerProtocolError("LiteLLM rerank row index must be an integer")
+            if index < 0 or index >= len(candidates) or index in seen_indices:
+                raise LiteLLMRerankerProtocolError(
+                    "LiteLLM rerank row index was duplicate or outside candidate bounds"
+                )
+            raw_score = row.get("relevance_score", row.get("score"))
+            if isinstance(raw_score, bool) or not isinstance(raw_score, (int, float)):
+                raise LiteLLMRerankerProtocolError(
+                    "LiteLLM rerank row requires numeric relevance_score or score"
+                )
+            seen_indices.add(index)
+            parsed.append((index, float(raw_score)))
+
+        service = self.metadata()
+        reranked: list[dict[str, Any]] = []
+        for api_rank, (index, score) in enumerate(parsed, start=1):
+            candidate = candidates[index]
+            retrieval = candidate.get("retrieval")
+            retrieval_mapping = dict(retrieval) if isinstance(retrieval, Mapping) else {}
+            base_rank = int(retrieval_mapping.get("rank", index + 1))
+            result = json.loads(json.dumps(candidate))
+            result["rerank"] = {
+                "base_rank": base_rank,
+                "score": score,
+                "api_rank": api_rank,
+                "service": service,
+            }
+            reranked.append(result)
+        return reranked
+
+
+__all__ = [
+    "LiteLLMReranker",
+    "LiteLLMRerankerIdentityError",
+    "LiteLLMRerankerProtocolError",
+    "LiteLLMRerankerTransportError",
+]

--- a/tests/test_litellm_reranker.py
+++ b/tests/test_litellm_reranker.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+import pytest
+
+from fossil_core.adapters.litellm import (
+    LiteLLMReranker,
+    LiteLLMRerankerIdentityError,
+    LiteLLMRerankerProtocolError,
+    LiteLLMRerankerTransportError,
+)
+
+
+class RecordingTransport:
+    def __init__(
+        self,
+        response: Mapping[str, Any] | None = None,
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        self.response = dict(response or {})
+        self.error = error
+        self.calls: list[tuple[str, dict[str, str], dict[str, Any], float]] = []
+
+    def __call__(
+        self,
+        url: str,
+        headers: Mapping[str, str],
+        payload: Mapping[str, Any],
+        timeout_seconds: float,
+    ) -> Mapping[str, Any]:
+        self.calls.append(
+            (
+                str(url),
+                dict(headers),
+                copy.deepcopy(dict(payload)),
+                float(timeout_seconds),
+            )
+        )
+        if self.error is not None:
+            raise self.error
+        return copy.deepcopy(self.response)
+
+
+def _reranker(
+    transport: RecordingTransport,
+    *,
+    accepted_actual_models: tuple[str, ...] = (),
+    require_reported_actual_model: bool = False,
+    timeout_seconds: float = 7.5,
+    max_candidates: int = 8,
+) -> LiteLLMReranker:
+    return LiteLLMReranker(
+        base_url="https://gateway.example/v1/",
+        api_key="unit-test-secret",
+        model="rerank-v4-pro",
+        gateway_id="ckff-production",
+        provider_version="proxy-contract-v1",
+        timeout_seconds=timeout_seconds,
+        max_candidates=max_candidates,
+        accepted_actual_models=accepted_actual_models,
+        require_reported_actual_model=require_reported_actual_model,
+        transport=transport,
+        implementation_version="workstream-d",
+    )
+
+
+def _candidates() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "claim_alpha",
+            "pack_id": "pack_test",
+            "text": "alpha evidence",
+            "retrieval": {"rank": 1, "score": 0.7},
+            "extra": ("preserve", "tuple"),
+        },
+        {
+            "id": "claim_beta",
+            "pack_id": "pack_test",
+            "text": "beta evidence",
+            "retrieval": {"rank": 2, "score": 0.6},
+        },
+        {
+            "id": "claim_gamma",
+            "pack_id": "pack_test",
+            "text": "gamma evidence",
+            "retrieval": {"rank": 3, "score": 0.5},
+        },
+    ]
+
+
+def test_hosted_reranker_makes_one_bounded_non_streaming_request_and_preserves_candidates():
+    transport = RecordingTransport(
+        {
+            "model": "rerank-v4-pro",
+            "provider": "cohere",
+            "results": [
+                {"index": 1, "relevance_score": 0.99},
+                {"index": 0, "relevance_score": 0.75},
+            ],
+        }
+    )
+    reranker = _reranker(transport)
+    candidates = _candidates()
+    original = copy.deepcopy(candidates)
+
+    results = reranker.rerank("which evidence is strongest?", candidates, limit=2)
+
+    assert [item["id"] for item in results] == ["claim_beta", "claim_alpha"]
+    assert results[0]["rerank"]["base_rank"] == 2
+    assert results[0]["rerank"]["api_rank"] == 1
+    assert results[0]["rerank"]["score"] == 0.99
+    assert results[1]["extra"] == ("preserve", "tuple")
+    assert candidates == original
+
+    assert len(transport.calls) == 1
+    url, headers, payload, timeout_seconds = transport.calls[0]
+    assert url == "https://gateway.example/v1/rerank"
+    assert headers == {
+        "Authorization": "Bearer unit-test-secret",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    assert payload == {
+        "model": "rerank-v4-pro",
+        "query": "which evidence is strongest?",
+        "documents": ["alpha evidence", "beta evidence", "gamma evidence"],
+        "top_n": 2,
+    }
+    assert "stream" not in payload
+    assert timeout_seconds == 7.5
+
+    metadata = results[0]["rerank"]["service"]
+    assert metadata["kind"] == "reranker"
+    assert metadata["provider"] == "litellm"
+    assert metadata["provider_version"] == "proxy-contract-v1"
+    assert metadata["implementation"] == "litellm-rerank-api"
+    assert metadata["implementation_version"] == "workstream-d"
+    assert metadata["model_id"] == "rerank-v4-pro"
+    assert metadata["local"] is False
+    assert metadata["runtime"]["gateway_id"] == "ckff-production"
+    assert metadata["runtime"]["requested_model_id"] == "rerank-v4-pro"
+    assert metadata["runtime"]["actual_model_id"] == "rerank-v4-pro"
+    assert metadata["runtime"]["actual_provider"] == "cohere"
+    assert metadata["runtime"]["actual_model_verified"] == "true"
+    assert metadata["runtime"]["timeout_seconds"] == "7.5"
+    assert metadata["runtime"]["max_candidates"] == "8"
+    assert metadata["runtime"]["automatic_retries"] == "0"
+    assert metadata["runtime"]["fallback"] == "disabled"
+    assert metadata["runtime"]["request_granularity"] == (
+        "one-bounded-rerank-request-per-call"
+    )
+    assert metadata["runtime"]["streaming_supported"] == "false"
+    assert metadata["runtime"]["streaming_required"] == "false"
+    assert metadata["runtime"]["response_mode"] == "buffered-json"
+    assert metadata["runtime"]["score_authority"] == "candidate-ordering-only"
+    assert "unit-test-secret" not in repr(metadata)
+
+
+def test_hosted_reranker_records_unreported_actual_identity_without_inventing_it():
+    transport = RecordingTransport(
+        {
+            "results": [
+                {"index": 0, "relevance_score": 0.9},
+            ]
+        }
+    )
+    reranker = _reranker(transport)
+
+    results = reranker.rerank("alpha?", _candidates(), limit=1)
+    metadata = results[0]["rerank"]["service"]
+
+    assert metadata["model_id"] is None
+    assert metadata["runtime"]["requested_model_id"] == "rerank-v4-pro"
+    assert metadata["runtime"]["actual_model_id"] == "unreported"
+    assert metadata["runtime"]["actual_provider"] == "unreported"
+    assert metadata["runtime"]["actual_model_verified"] == "false"
+
+
+def test_hosted_reranker_can_require_reported_actual_identity_for_promotion_grade_runs():
+    transport = RecordingTransport(
+        {
+            "results": [
+                {"index": 0, "relevance_score": 0.9},
+            ]
+        }
+    )
+    reranker = _reranker(transport, require_reported_actual_model=True)
+
+    with pytest.raises(
+        LiteLLMRerankerIdentityError,
+        match="did not report actual model identity",
+    ):
+        reranker.rerank("alpha?", _candidates(), limit=1)
+
+    assert len(transport.calls) == 1
+
+
+def test_hosted_reranker_accepts_only_explicitly_allowlisted_actual_model_aliases():
+    accepted = RecordingTransport(
+        {
+            "metadata": {
+                "bridge_actual_model": "cohere/rerank-v4-pro",
+                "bridge_actual_provider": "cohere",
+            },
+            "results": [
+                {"index": 2, "relevance_score": 0.93},
+            ],
+        }
+    )
+    reranker = _reranker(
+        accepted,
+        accepted_actual_models=("cohere/rerank-v4-pro",),
+        require_reported_actual_model=True,
+    )
+
+    result = reranker.rerank("gamma?", _candidates(), limit=1)[0]
+
+    assert result["id"] == "claim_gamma"
+    assert result["rerank"]["service"]["model_id"] == "cohere/rerank-v4-pro"
+    assert result["rerank"]["service"]["runtime"]["actual_provider"] == "cohere"
+
+    rejected = RecordingTransport(
+        {
+            "model": "unexpected-reranker",
+            "results": [
+                {"index": 0, "relevance_score": 0.8},
+            ],
+        }
+    )
+    reranker = _reranker(rejected)
+    with pytest.raises(
+        LiteLLMRerankerIdentityError,
+        match="unaccepted actual model identity",
+    ):
+        reranker.rerank("alpha?", _candidates(), limit=1)
+    assert len(rejected.calls) == 1
+
+
+def test_hosted_reranker_has_no_hidden_retry_or_fallback_on_transport_failure():
+    transport = RecordingTransport(error=TimeoutError("simulated"))
+    reranker = _reranker(transport, timeout_seconds=3.0)
+
+    with pytest.raises(LiteLLMRerankerTransportError, match="transport failed"):
+        reranker.rerank("alpha?", _candidates(), limit=1)
+
+    assert len(transport.calls) == 1
+    assert transport.calls[0][3] == 3.0
+
+
+def test_hosted_reranker_enforces_candidate_and_timeout_bounds_before_execution():
+    transport = RecordingTransport(
+        {"results": [{"index": 0, "relevance_score": 1.0}]}
+    )
+    reranker = _reranker(transport, max_candidates=2)
+
+    with pytest.raises(ValueError, match="max_candidates"):
+        reranker.rerank("query", _candidates(), limit=1)
+    assert transport.calls == []
+
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        _reranker(transport, timeout_seconds=0.0)
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        _reranker(transport, timeout_seconds=121.0)
+
+
+def test_hosted_reranker_rejects_malformed_or_overbroad_ranking_rows():
+    duplicate = RecordingTransport(
+        {
+            "results": [
+                {"index": 0, "relevance_score": 0.9},
+                {"index": 0, "relevance_score": 0.8},
+            ]
+        }
+    )
+    with pytest.raises(LiteLLMRerankerProtocolError, match="duplicate or outside"):
+        _reranker(duplicate).rerank("query", _candidates(), limit=2)
+
+    non_numeric = RecordingTransport(
+        {
+            "results": [
+                {"index": 0, "relevance_score": "high"},
+            ]
+        }
+    )
+    with pytest.raises(LiteLLMRerankerProtocolError, match="numeric"):
+        _reranker(non_numeric).rerank("query", _candidates(), limit=1)
+
+    too_many = RecordingTransport(
+        {
+            "results": [
+                {"index": 0, "relevance_score": 0.9},
+                {"index": 1, "relevance_score": 0.8},
+            ]
+        }
+    )
+    with pytest.raises(LiteLLMRerankerProtocolError, match="top_n"):
+        _reranker(too_many).rerank("query", _candidates(), limit=1)


### PR DESCRIPTION
## Scope

Granular Workstream-D reranker task under #47. This PR adds only the provider adapter contract; it does **not** change LiteLLM gateway configuration, Cortex V5, D021, retrieval policy, model policy, schemas, stable IDs, storage, or benchmark promotion decisions.

- add `fossil_core.adapters.litellm.LiteLLMReranker` behind the existing provider-neutral `Reranker` shape
- one bounded `/v1/rerank` request per call; no retries, fallback, substitution, tools, or truth mutation
- require explicit `timeout_seconds` and `max_candidates`
- record requested model, reported actual model/provider, identity-verification state, timeout, request granularity, and retry/fallback state in service metadata
- record the verified rerank lane as buffered/non-streaming (`streaming_supported=false`, `streaming_required=false`) instead of silently treating absence of streaming as an implicit default
- fail closed on malformed ranking rows, over-broad responses, and unaccepted reported model identity
- preserve candidate values by deep copy and treat rerank scores as candidate-ordering evidence only
- register the adapter modules in architecture-boundary CI
- add deterministic injected-transport tests; no secrets or live provider calls in this adapter PR

## Owner execution constraints

This task implements the Issue #47 execution note: model streaming requirements must be explicit; timeout values must be bounded and recorded; LiteLLM-backed work must stay granular and independently checkable. The live reranker proof/benchmark is intentionally a separate follow-on task after this adapter lands.

## Identity rule

The historical live probe showed `/v1/rerank` can return a valid ranking without reporting model identity. This adapter therefore never invents an actual model. By default it records `actual_model_id=unreported` and `actual_model_verified=false`; promotion-grade callers can set `require_reported_actual_model=True` to fail closed. Explicit alternate actual IDs must be allowlisted.

## Exact-head verification

Head `0e47bb31c516fcdafebbda78c5d62326abcc4f38`:

- DKG contract tests `32049060990`: SUCCESS — `377 passed, 1 skipped, 1 warning`
- Dependency Integrity `32049061113`: SUCCESS
- architecture-boundary registry includes `fossil_core.adapters.litellm` and `.reranker`
- deterministic tests verify one request only, explicit timeout propagation/bounds, no streaming parameter, `streaming_supported=false`, `streaming_required=false`, no retry/fallback, requested-vs-reported identity handling, candidate immutability, and malformed-response fail-closed behavior
- submitted reviews: 0
- review threads: 0
- base/main remained `c32ba7521bda205fb989c5c0704aa7d91f7e1a4a` at verification time