### PR TITLE
[WORKSTREAM-D] Add projection-bound Gemini Embedding 2 adapter

### DIFF
--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -39,6 +39,7 @@ CANONICAL_MODULES = {
     "fossil_core.adapters.filesystem.event_store",
     "fossil_core.adapters.filesystem.io",
     "fossil_core.adapters.litellm",
+    "fossil_core.adapters.litellm.embedding",
     "fossil_core.adapters.litellm.reranker",
     "fossil_core.adapters.s3",
     "fossil_core.adapters.s3.storage",

--- a/src/fossil_core/adapters/litellm/__init__.py
+++ b/src/fossil_core/adapters/litellm/__init__.py
@@ -1,5 +1,15 @@
 """Narrow LiteLLM cognitive-service adapters."""
 
+from .embedding import (
+    GEMINI_EMBEDDING_2_ACCEPTED_ACTUAL_MODELS,
+    GEMINI_EMBEDDING_2_CANONICAL_MODEL,
+    GEMINI_EMBEDDING_2_DIMENSION,
+    GEMINI_EMBEDDING_2_REQUESTED_MODEL,
+    GeminiEmbedding2IdentityError,
+    GeminiEmbedding2ProtocolError,
+    GeminiEmbedding2Provider,
+    GeminiEmbedding2TransportError,
+)
 from .reranker import (
     LiteLLMReranker,
     LiteLLMRerankerIdentityError,
@@ -8,6 +18,14 @@ from .reranker import (
 )
 
 __all__ = [
+    "GEMINI_EMBEDDING_2_ACCEPTED_ACTUAL_MODELS",
+    "GEMINI_EMBEDDING_2_CANONICAL_MODEL",
+    "GEMINI_EMBEDDING_2_DIMENSION",
+    "GEMINI_EMBEDDING_2_REQUESTED_MODEL",
+    "GeminiEmbedding2IdentityError",
+    "GeminiEmbedding2ProtocolError",
+    "GeminiEmbedding2Provider",
+    "GeminiEmbedding2TransportError",
     "LiteLLMReranker",
     "LiteLLMRerankerIdentityError",
     "LiteLLMRerankerProtocolError",

--- a/src/fossil_core/adapters/litellm/embedding.py
+++ b/src/fossil_core/adapters/litellm/embedding.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+import json
+import math
+import socket
+from collections.abc import Callable, Mapping
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from ...services import ServiceMetadata
+
+
+GEMINI_EMBEDDING_2_REQUESTED_MODEL = "gemini-embedding-2"
+GEMINI_EMBEDDING_2_CANONICAL_MODEL = "google/gemini-embedding-2"
+GEMINI_EMBEDDING_2_DIMENSION = 3072
+GEMINI_EMBEDDING_2_ACCEPTED_ACTUAL_MODELS = frozenset(
+    {
+        GEMINI_EMBEDDING_2_REQUESTED_MODEL,
+        GEMINI_EMBEDDING_2_CANONICAL_MODEL,
+    }
+)
+
+JsonTransport = Callable[
+    [str, Mapping[str, str], Mapping[str, Any], float],
+    Mapping[str, Any],
+]
+
+
+class GeminiEmbedding2TransportError(RuntimeError):
+    """Raised when the bounded embedding request cannot be completed."""
+
+
+class GeminiEmbedding2ProtocolError(RuntimeError):
+    """Raised when the embedding response violates the expected response contract."""
+
+
+class GeminiEmbedding2IdentityError(GeminiEmbedding2ProtocolError):
+    """Raised when reported model identity is missing or contradicts Gemini Embedding 2."""
+
+
+def _post_json(
+    url: str,
+    headers: Mapping[str, str],
+    payload: Mapping[str, Any],
+    timeout_seconds: float,
+) -> Mapping[str, Any]:
+    request = Request(
+        url,
+        data=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+        headers=dict(headers),
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            raw = response.read(16_000_001)
+    except HTTPError as exc:
+        raise GeminiEmbedding2TransportError(
+            f"Gemini Embedding 2 request failed with HTTP status {exc.code}"
+        ) from None
+    except (URLError, TimeoutError, socket.timeout):
+        raise GeminiEmbedding2TransportError("Gemini Embedding 2 request failed") from None
+
+    if len(raw) > 16_000_000:
+        raise GeminiEmbedding2ProtocolError(
+            "Gemini Embedding 2 response exceeded the 16 MB bound"
+        )
+    try:
+        decoded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise GeminiEmbedding2ProtocolError(
+            "Gemini Embedding 2 response was not valid JSON"
+        ) from None
+    if not isinstance(decoded, Mapping):
+        raise GeminiEmbedding2ProtocolError(
+            "Gemini Embedding 2 response must be a JSON object"
+        )
+    return decoded
+
+
+def _reported_model(payload: Mapping[str, Any]) -> str | None:
+    metadata = payload.get("metadata")
+    values = [
+        payload.get("model"),
+        metadata.get("bridge_actual_model") if isinstance(metadata, Mapping) else None,
+        metadata.get("actual_model") if isinstance(metadata, Mapping) else None,
+    ]
+    for value in values:
+        if value is not None and str(value).strip():
+            return str(value)
+    return None
+
+
+def _reported_provider(payload: Mapping[str, Any]) -> str | None:
+    metadata = payload.get("metadata")
+    values = [
+        payload.get("provider"),
+        metadata.get("bridge_actual_provider") if isinstance(metadata, Mapping) else None,
+        metadata.get("actual_provider") if isinstance(metadata, Mapping) else None,
+    ]
+    for value in values:
+        if value is not None and str(value).strip():
+            return str(value)
+    return None
+
+
+def _canonical_model(model: str) -> str:
+    if model in GEMINI_EMBEDDING_2_ACCEPTED_ACTUAL_MODELS:
+        return GEMINI_EMBEDDING_2_CANONICAL_MODEL
+    return model
+
+
+class GeminiEmbedding2Provider:
+    """Bounded LiteLLM adapter for the approved Gemini Embedding 2 candidate lane.
+
+    Each :meth:`embed` call is exactly one buffered `/v1/embeddings` request.
+    The adapter never splits batches, retries, falls back, or switches models.
+    An embedding-space identity must be tied to a caller-supplied projection ID,
+    so a promoted model cannot silently reuse an incompatible vector projection.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        gateway_id: str,
+        provider_version: str,
+        projection_id: str,
+        timeout_seconds: float,
+        max_batch_size: int,
+        max_chars_per_text: int,
+        max_total_chars: int,
+        transport: JsonTransport | None = None,
+        implementation_version: str = "1",
+        require_reported_actual_model: bool = True,
+        estimated_cost_per_call_usd: float = 0.0,
+    ) -> None:
+        values = {
+            "base_url": base_url,
+            "api_key": api_key,
+            "gateway_id": gateway_id,
+            "provider_version": provider_version,
+            "projection_id": projection_id,
+            "implementation_version": implementation_version,
+        }
+        if any(not str(value).strip() for value in values.values()):
+            raise ValueError(
+                "Gemini Embedding 2 requires non-empty connection, identity, and projection values"
+            )
+        if timeout_seconds <= 0 or timeout_seconds > 120:
+            raise ValueError("Gemini Embedding 2 timeout_seconds must be in (0, 120]")
+        if max_batch_size < 1 or max_batch_size > 64:
+            raise ValueError("Gemini Embedding 2 max_batch_size must be in [1, 64]")
+        if max_chars_per_text < 1 or max_chars_per_text > 100_000:
+            raise ValueError(
+                "Gemini Embedding 2 max_chars_per_text must be in [1, 100000]"
+            )
+        if max_total_chars < max_chars_per_text or max_total_chars > 1_000_000:
+            raise ValueError(
+                "Gemini Embedding 2 max_total_chars must be >= max_chars_per_text and <= 1000000"
+            )
+        if estimated_cost_per_call_usd < 0:
+            raise ValueError("estimated_cost_per_call_usd must be non-negative")
+
+        self.base_url = str(base_url).rstrip("/")
+        self.api_key = str(api_key)
+        self.gateway_id = str(gateway_id)
+        self.provider_version = str(provider_version)
+        self.projection_id = str(projection_id)
+        self.timeout_seconds = float(timeout_seconds)
+        self.max_batch_size = int(max_batch_size)
+        self.max_chars_per_text = int(max_chars_per_text)
+        self.max_total_chars = int(max_total_chars)
+        self.transport = transport or _post_json
+        self.implementation_version = str(implementation_version)
+        self.require_reported_actual_model = bool(require_reported_actual_model)
+        self.estimated_cost_per_call_usd = float(estimated_cost_per_call_usd)
+        self._last_actual_model: str | None = None
+        self._last_actual_provider: str | None = None
+        self._last_usage: Mapping[str, Any] = {}
+
+    @property
+    def model_id(self) -> str:
+        """Pinned requested model identity used to define the embedding space."""
+        return GEMINI_EMBEDDING_2_REQUESTED_MODEL
+
+    @property
+    def embedding_space_id(self) -> str:
+        return (
+            f"{self.projection_id}:{GEMINI_EMBEDDING_2_CANONICAL_MODEL}:"
+            f"{GEMINI_EMBEDDING_2_DIMENSION}"
+        )
+
+    @property
+    def identity_verified(self) -> bool:
+        return self._last_actual_model is not None
+
+    def metadata(self) -> dict[str, Any]:
+        return ServiceMetadata(
+            kind="embedding",
+            provider="litellm",
+            provider_version=self.provider_version,
+            implementation="litellm-gemini-embedding-2",
+            implementation_version=self.implementation_version,
+            model_id=self._last_actual_model or self.model_id,
+            local=False,
+            estimated_cost_per_call_usd=self.estimated_cost_per_call_usd,
+            runtime={
+                "gateway_id": self.gateway_id,
+                "requested_model_id": self.model_id,
+                "actual_model_id": self._last_actual_model or "unreported",
+                "actual_provider": self._last_actual_provider or "unreported",
+                "actual_model_verified": str(self.identity_verified).lower(),
+                "require_reported_actual_model": str(
+                    self.require_reported_actual_model
+                ).lower(),
+                "projection_id": self.projection_id,
+                "embedding_space_id": self.embedding_space_id,
+                "output_dimension": str(GEMINI_EMBEDDING_2_DIMENSION),
+                "timeout_seconds": str(self.timeout_seconds),
+                "max_batch_size": str(self.max_batch_size),
+                "max_chars_per_text": str(self.max_chars_per_text),
+                "max_total_chars": str(self.max_total_chars),
+                "automatic_retries": "0",
+                "fallback": "disabled",
+                "dynamic_model_switching": "disabled",
+                "projection_switching": "disabled",
+                "request_granularity": "one-bounded-embedding-request-per-call",
+                "batching_mode": "single-request-explicit-batch",
+                "streaming_supported": "false",
+                "streaming_required": "false",
+                "response_mode": "buffered-json",
+                "task_type": "not-exposed-by-openai-compatible-route",
+                "last_usage": json.dumps(
+                    dict(self._last_usage), sort_keys=True, separators=(",", ":")
+                ),
+            },
+        ).as_dict()
+
+    def _verify_identity(self, payload: Mapping[str, Any]) -> None:
+        actual_model = _reported_model(payload)
+        actual_provider = _reported_provider(payload)
+        if actual_model is None:
+            self._last_actual_model = None
+            self._last_actual_provider = actual_provider
+            if self.require_reported_actual_model:
+                raise GeminiEmbedding2IdentityError(
+                    "Gemini Embedding 2 response did not report actual model identity"
+                )
+            return
+        if actual_model not in GEMINI_EMBEDDING_2_ACCEPTED_ACTUAL_MODELS:
+            raise GeminiEmbedding2IdentityError(
+                "Gemini Embedding 2 response reported an unaccepted actual model identity"
+            )
+        if (
+            self._last_actual_model is not None
+            and _canonical_model(self._last_actual_model) != _canonical_model(actual_model)
+        ):
+            raise GeminiEmbedding2IdentityError(
+                "Gemini Embedding 2 actual model changed within one projection-bound provider"
+            )
+        self._last_actual_model = actual_model
+        self._last_actual_provider = actual_provider
+
+    def _validate_inputs(self, texts: list[str]) -> None:
+        if len(texts) > self.max_batch_size:
+            raise ValueError(
+                "Gemini Embedding 2 batch exceeds the explicit max_batch_size request bound"
+            )
+        total_chars = 0
+        for text in texts:
+            if not isinstance(text, str) or not text:
+                raise ValueError("Gemini Embedding 2 inputs must be non-empty strings")
+            if len(text) > self.max_chars_per_text:
+                raise ValueError(
+                    "Gemini Embedding 2 input exceeds the explicit max_chars_per_text bound"
+                )
+            total_chars += len(text)
+        if total_chars > self.max_total_chars:
+            raise ValueError(
+                "Gemini Embedding 2 batch exceeds the explicit max_total_chars bound"
+            )
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        self._validate_inputs(texts)
+        payload = {
+            "model": self.model_id,
+            "input": list(texts),
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        try:
+            response = self.transport(
+                f"{self.base_url}/embeddings",
+                headers,
+                payload,
+                self.timeout_seconds,
+            )
+        except (GeminiEmbedding2TransportError, GeminiEmbedding2ProtocolError):
+            raise
+        except Exception:
+            raise GeminiEmbedding2TransportError(
+                "Gemini Embedding 2 transport failed"
+            ) from None
+        if not isinstance(response, Mapping):
+            raise GeminiEmbedding2ProtocolError(
+                "Gemini Embedding 2 response must be a mapping"
+            )
+
+        self._verify_identity(response)
+        raw_data = response.get("data")
+        if not isinstance(raw_data, list) or len(raw_data) != len(texts):
+            raise GeminiEmbedding2ProtocolError(
+                "Gemini Embedding 2 response count did not match the input count"
+            )
+
+        indexed: dict[int, list[float]] = {}
+        for item in raw_data:
+            if not isinstance(item, Mapping):
+                raise GeminiEmbedding2ProtocolError(
+                    "Gemini Embedding 2 response item must be a mapping"
+                )
+            index = item.get("index")
+            if isinstance(index, bool) or not isinstance(index, int):
+                raise GeminiEmbedding2ProtocolError(
+                    "Gemini Embedding 2 response item index must be an integer"
+                )
+            if index < 0 or index >= len(texts) or index in indexed:
+                raise GeminiEmbedding2ProtocolError(
+                    "Gemini Embedding 2 response index was duplicate or outside input bounds"
+                )
+            raw_vector = item.get("embedding")
+            if not isinstance(raw_vector, list) or len(raw_vector) != GEMINI_EMBEDDING_2_DIMENSION:
+                raise GeminiEmbedding2ProtocolError(
+                    "Gemini Embedding 2 response vector dimension was not 3072"
+                )
+            vector: list[float] = []
+            for value in raw_vector:
+                if isinstance(value, bool) or not isinstance(value, (int, float)):
+                    raise GeminiEmbedding2ProtocolError(
+                        "Gemini Embedding 2 response vector contained a non-numeric value"
+                    )
+                converted = float(value)
+                if not math.isfinite(converted):
+                    raise GeminiEmbedding2ProtocolError(
+                        "Gemini Embedding 2 response vector contained a non-finite value"
+                    )
+                vector.append(converted)
+            indexed[index] = vector
+
+        if set(indexed) != set(range(len(texts))):
+            raise GeminiEmbedding2ProtocolError(
+                "Gemini Embedding 2 response did not cover every input index exactly once"
+            )
+
+        usage = response.get("usage")
+        self._last_usage = dict(usage) if isinstance(usage, Mapping) else {}
+        return [indexed[index] for index in range(len(texts))]
+
+
+__all__ = [
+    "GEMINI_EMBEDDING_2_ACCEPTED_ACTUAL_MODELS",
+    "GEMINI_EMBEDDING_2_CANONICAL_MODEL",
+    "GEMINI_EMBEDDING_2_DIMENSION",
+    "GEMINI_EMBEDDING_2_REQUESTED_MODEL",
+    "GeminiEmbedding2IdentityError",
+    "GeminiEmbedding2ProtocolError",
+    "GeminiEmbedding2Provider",
+    "GeminiEmbedding2TransportError",
+]

--- a/tests/test_gemini_embedding2_adapter.py
+++ b/tests/test_gemini_embedding2_adapter.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+import pytest
+
+from fossil_core.adapters.litellm import (
+    GEMINI_EMBEDDING_2_CANONICAL_MODEL,
+    GEMINI_EMBEDDING_2_DIMENSION,
+    GEMINI_EMBEDDING_2_REQUESTED_MODEL,
+    GeminiEmbedding2IdentityError,
+    GeminiEmbedding2ProtocolError,
+    GeminiEmbedding2Provider,
+    GeminiEmbedding2TransportError,
+)
+
+
+class RecordingTransport:
+    def __init__(
+        self,
+        response: Mapping[str, Any] | None = None,
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        self.response = dict(response or {})
+        self.error = error
+        self.calls: list[tuple[str, dict[str, str], dict[str, Any], float]] = []
+
+    def __call__(
+        self,
+        url: str,
+        headers: Mapping[str, str],
+        payload: Mapping[str, Any],
+        timeout_seconds: float,
+    ) -> Mapping[str, Any]:
+        self.calls.append(
+            (
+                str(url),
+                dict(headers),
+                copy.deepcopy(dict(payload)),
+                float(timeout_seconds),
+            )
+        )
+        if self.error is not None:
+            raise self.error
+        return copy.deepcopy(self.response)
+
+
+def _vector(seed: float = 0.0) -> list[float]:
+    return [seed + (index / 10_000.0) for index in range(GEMINI_EMBEDDING_2_DIMENSION)]
+
+
+def _provider(
+    transport: RecordingTransport,
+    *,
+    require_reported_actual_model: bool = True,
+    timeout_seconds: float = 12.0,
+    max_batch_size: int = 8,
+    max_chars_per_text: int = 100,
+    max_total_chars: int = 400,
+) -> GeminiEmbedding2Provider:
+    return GeminiEmbedding2Provider(
+        base_url="https://gateway.example/v1/",
+        api_key="unit-test-secret",
+        gateway_id="ckff-production",
+        provider_version="proxy-contract-v1",
+        projection_id="projection_gemini2_test_v1",
+        timeout_seconds=timeout_seconds,
+        max_batch_size=max_batch_size,
+        max_chars_per_text=max_chars_per_text,
+        max_total_chars=max_total_chars,
+        transport=transport,
+        implementation_version="workstream-d",
+        require_reported_actual_model=require_reported_actual_model,
+        estimated_cost_per_call_usd=0.001,
+    )
+
+
+def test_gemini_embedding2_makes_one_bounded_non_streaming_request_and_pins_projection_space():
+    first = _vector(1.0)
+    second = _vector(2.0)
+    transport = RecordingTransport(
+        {
+            "model": GEMINI_EMBEDDING_2_CANONICAL_MODEL,
+            "provider": "google",
+            "data": [
+                {"index": 1, "embedding": second},
+                {"index": 0, "embedding": first},
+            ],
+            "usage": {"prompt_tokens": 7, "total_tokens": 7},
+        }
+    )
+    provider = _provider(transport)
+
+    vectors = provider.embed(["alpha", "beta"])
+
+    assert vectors == [first, second]
+    assert len(transport.calls) == 1
+    url, headers, payload, timeout_seconds = transport.calls[0]
+    assert url == "https://gateway.example/v1/embeddings"
+    assert headers == {
+        "Authorization": "Bearer unit-test-secret",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    assert payload == {
+        "model": GEMINI_EMBEDDING_2_REQUESTED_MODEL,
+        "input": ["alpha", "beta"],
+    }
+    assert "stream" not in payload
+    assert timeout_seconds == 12.0
+
+    assert provider.model_id == GEMINI_EMBEDDING_2_REQUESTED_MODEL
+    assert provider.embedding_space_id == (
+        "projection_gemini2_test_v1:google/gemini-embedding-2:3072"
+    )
+
+    metadata = provider.metadata()
+    assert metadata["kind"] == "embedding"
+    assert metadata["provider"] == "litellm"
+    assert metadata["provider_version"] == "proxy-contract-v1"
+    assert metadata["implementation"] == "litellm-gemini-embedding-2"
+    assert metadata["implementation_version"] == "workstream-d"
+    assert metadata["model_id"] == GEMINI_EMBEDDING_2_CANONICAL_MODEL
+    assert metadata["local"] is False
+    assert metadata["estimated_cost_per_call_usd"] == 0.001
+    runtime = metadata["runtime"]
+    assert runtime["gateway_id"] == "ckff-production"
+    assert runtime["requested_model_id"] == GEMINI_EMBEDDING_2_REQUESTED_MODEL
+    assert runtime["actual_model_id"] == GEMINI_EMBEDDING_2_CANONICAL_MODEL
+    assert runtime["actual_provider"] == "google"
+    assert runtime["actual_model_verified"] == "true"
+    assert runtime["projection_id"] == "projection_gemini2_test_v1"
+    assert runtime["embedding_space_id"] == provider.embedding_space_id
+    assert runtime["output_dimension"] == "3072"
+    assert runtime["timeout_seconds"] == "12.0"
+    assert runtime["max_batch_size"] == "8"
+    assert runtime["max_chars_per_text"] == "100"
+    assert runtime["max_total_chars"] == "400"
+    assert runtime["automatic_retries"] == "0"
+    assert runtime["fallback"] == "disabled"
+    assert runtime["dynamic_model_switching"] == "disabled"
+    assert runtime["projection_switching"] == "disabled"
+    assert runtime["request_granularity"] == "one-bounded-embedding-request-per-call"
+    assert runtime["batching_mode"] == "single-request-explicit-batch"
+    assert runtime["streaming_supported"] == "false"
+    assert runtime["streaming_required"] == "false"
+    assert runtime["response_mode"] == "buffered-json"
+    assert runtime["task_type"] == "not-exposed-by-openai-compatible-route"
+    assert runtime["last_usage"] == '{"prompt_tokens":7,"total_tokens":7}'
+    assert "unit-test-secret" not in repr(metadata)
+
+
+def test_gemini_embedding2_requires_reported_actual_identity_by_default():
+    transport = RecordingTransport(
+        {"data": [{"index": 0, "embedding": _vector()}]}
+    )
+    provider = _provider(transport)
+
+    with pytest.raises(
+        GeminiEmbedding2IdentityError,
+        match="did not report actual model identity",
+    ):
+        provider.embed(["alpha"])
+
+    assert len(transport.calls) == 1
+
+
+def test_gemini_embedding2_rejects_unaccepted_model_identity_without_fallback():
+    transport = RecordingTransport(
+        {
+            "model": "some-other-embedding-model",
+            "data": [{"index": 0, "embedding": _vector()}],
+        }
+    )
+    provider = _provider(transport)
+
+    with pytest.raises(
+        GeminiEmbedding2IdentityError,
+        match="unaccepted actual model identity",
+    ):
+        provider.embed(["alpha"])
+
+    assert len(transport.calls) == 1
+
+
+def test_gemini_embedding2_accepts_only_known_aliases_for_the_same_canonical_space():
+    responses = [
+        {
+            "model": GEMINI_EMBEDDING_2_REQUESTED_MODEL,
+            "data": [{"index": 0, "embedding": _vector(1.0)}],
+        },
+        {
+            "model": GEMINI_EMBEDDING_2_CANONICAL_MODEL,
+            "data": [{"index": 0, "embedding": _vector(2.0)}],
+        },
+    ]
+
+    class SequenceTransport(RecordingTransport):
+        def __call__(self, url, headers, payload, timeout_seconds):
+            self.response = responses[len(self.calls)]
+            return super().__call__(url, headers, payload, timeout_seconds)
+
+    transport = SequenceTransport()
+    provider = _provider(transport)
+
+    provider.embed(["document"])
+    provider.embed(["query"])
+
+    assert len(transport.calls) == 2
+    assert provider.metadata()["runtime"]["actual_model_id"] == (
+        GEMINI_EMBEDDING_2_CANONICAL_MODEL
+    )
+
+
+def test_gemini_embedding2_has_no_hidden_retry_on_transport_failure():
+    transport = RecordingTransport(error=TimeoutError("simulated"))
+    provider = _provider(transport, timeout_seconds=4.0)
+
+    with pytest.raises(GeminiEmbedding2TransportError, match="transport failed"):
+        provider.embed(["alpha"])
+
+    assert len(transport.calls) == 1
+    assert transport.calls[0][3] == 4.0
+
+
+def test_gemini_embedding2_enforces_batch_and_input_bounds_before_execution():
+    transport = RecordingTransport(
+        {
+            "model": GEMINI_EMBEDDING_2_CANONICAL_MODEL,
+            "data": [{"index": 0, "embedding": _vector()}],
+        }
+    )
+    provider = _provider(
+        transport,
+        max_batch_size=2,
+        max_chars_per_text=5,
+        max_total_chars=8,
+    )
+
+    with pytest.raises(ValueError, match="max_batch_size"):
+        provider.embed(["a", "b", "c"])
+    with pytest.raises(ValueError, match="max_chars_per_text"):
+        provider.embed(["123456"])
+    with pytest.raises(ValueError, match="max_total_chars"):
+        provider.embed(["12345", "6789"])
+    assert transport.calls == []
+
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        _provider(transport, timeout_seconds=0.0)
+    with pytest.raises(ValueError, match="max_batch_size"):
+        _provider(transport, max_batch_size=65)
+
+
+def test_gemini_embedding2_rejects_wrong_dimension_duplicate_index_and_nonfinite_values():
+    wrong_dimension = RecordingTransport(
+        {
+            "model": GEMINI_EMBEDDING_2_CANONICAL_MODEL,
+            "data": [{"index": 0, "embedding": [0.0, 1.0]}],
+        }
+    )
+    with pytest.raises(GeminiEmbedding2ProtocolError, match="dimension"):
+        _provider(wrong_dimension).embed(["alpha"])
+
+    duplicate = RecordingTransport(
+        {
+            "model": GEMINI_EMBEDDING_2_CANONICAL_MODEL,
+            "data": [
+                {"index": 0, "embedding": _vector()},
+                {"index": 0, "embedding": _vector(1.0)},
+            ],
+        }
+    )
+    with pytest.raises(GeminiEmbedding2ProtocolError, match="duplicate or outside"):
+        _provider(duplicate).embed(["alpha", "beta"])
+
+    nonfinite = _vector()
+    nonfinite[42] = float("nan")
+    invalid = RecordingTransport(
+        {
+            "model": GEMINI_EMBEDDING_2_CANONICAL_MODEL,
+            "data": [{"index": 0, "embedding": nonfinite}],
+        }
+    )
+    with pytest.raises(GeminiEmbedding2ProtocolError, match="non-finite"):
+        _provider(invalid).embed(["alpha"])
+
+
+def test_gemini_embedding2_empty_batch_is_local_noop_with_no_network_request():
+    transport = RecordingTransport()
+    provider = _provider(transport)
+
+    assert provider.embed([]) == []
+    assert transport.calls == []


### PR DESCRIPTION
## Scope

Granular Workstream-D Gemini Embedding 2 adapter task under #47. This PR is limited to the explicitly authorized hosted `gemini-embedding-2` lane. It does **not** modify LiteLLM gateway configuration, other LiteLLM model routes, Cortex V5, D021, retrieval policy, schemas, stable IDs, storage, or promotion decisions.

- add `GeminiEmbedding2Provider` behind the existing provider-neutral `EmbeddingProvider` shape
- fixed requested route `gemini-embedding-2`; accepted reported identities limited to that alias and `google/gemini-embedding-2`
- require reported actual model identity by default and fail closed on a different model
- require caller-supplied `projection_id`; expose a stable embedding-space identity coupling projection + canonical model + 3072 dimensions
- one bounded `/v1/embeddings` request per `embed()` call; no automatic batch splitting, retries, fallback, or dynamic model/projection switching
- require explicit `timeout_seconds`, `max_batch_size`, `max_chars_per_text`, and `max_total_chars`
- record batching, projection, requested/actual identity, output dimension, usage, and execution constraints in service metadata
- explicitly record this OpenAI-compatible embeddings route as buffered/non-streaming (`streaming_supported=false`, `streaming_required=false`); task type is recorded as not exposed by this route rather than inferred
- validate exact result count/index coverage, 3072-dimensional finite numeric vectors, and response model identity
- register the adapter module in architecture CI and add deterministic injected-transport tests

## Owner execution constraints

This task preserves the Issue #47 owner note: streaming capability is explicit, request timeout/size bounds are explicit and recorded, and the work remains a granular adapter-only task. The live Gemini Embedding 2 proof is intentionally a separate follow-on execution task.

## Projection rule

Embedding model identity is coupled to the vector projection/index identity. This adapter therefore requires `projection_id` and reports `embedding_space_id=<projection>:google/gemini-embedding-2:3072`; it does not permit silent model fallback or projection switching. A different promoted embedder requires a distinct projection/rebuild lane.

## Exact-head verification

Head `e917d1b107fd1f337575dcd0a3d226a5962a3ee6`:

- DKG contract tests `32050019446`: SUCCESS — `385 passed, 1 skipped, 1 warning`
- Dependency Integrity `32050019850`: SUCCESS
- deterministic tests verify one request per non-empty embed call, no `stream` parameter, explicit timeout/batch/input bounds, no retry/fallback, strict actual-model verification, only known Gemini Embedding 2 aliases, projection-bound embedding-space identity, exact 3072-dimensional finite vectors, response index coverage, usage capture, and empty-batch local no-op
- architecture CI requires `fossil_core.adapters.litellm.embedding`
- submitted reviews: 0
- review threads: 0
- base/main remained `e1c3bb0a829a65fddff233de2319430d0d1238b3` at verification time