### PR TITLE
[ARCH-P4] Move pack corpus rebuild behind application/rebuild

### DIFF
--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -15,6 +15,8 @@ CANONICAL_MODULES = {
     "fossil_core.application.ingest.pack_validation",
     "fossil_core.application.query",
     "fossil_core.application.query.lineage",
+    "fossil_core.application.rebuild",
+    "fossil_core.application.rebuild.pack_corpus",
     "fossil_core.domain",
     "fossil_core.domain.evidence",
     "fossil_core.domain.identity",
@@ -50,6 +52,7 @@ COMPATIBILITY_IMPORTS = {
     "fossil_core.ids": {"fossil_core.domain.identity"},
     "fossil_core.io": {"fossil_core.adapters.filesystem.io"},
     "fossil_core.lifecycle": {"fossil_core.domain.lifecycle"},
+    "fossil_core.pack_corpus": {"fossil_core.application.rebuild.pack_corpus"},
     "fossil_core.promotion": {"fossil_core.domain.promotion"},
     "fossil_core.storage_ports": {"fossil_core.ports"},
     "fossil_core.artifact_store": {

--- a/scripts/run_gate2_comparative_bakeoff.py
+++ b/scripts/run_gate2_comparative_bakeoff.py
@@ -4,10 +4,10 @@ import argparse
 import json
 from pathlib import Path
 
+from fossil_core.application.rebuild import retrieval_documents_from_pack_fixtures
 from fossil_core.benchmark import BenchmarkValidator, RetrievalBenchmark
 from fossil_core.benchmark_cases import load_benchmark_case_set, retrieval_cases_from_case_set
 from fossil_core.benchmark_compare import comparative_summary
-from fossil_core.pack_corpus import retrieval_documents_from_pack_fixtures
 from fossil_core.real_retrieval import (
     LifecycleIntentReranker,
     ReciprocalRankFusionRetriever,

--- a/scripts/run_gate2_real_retrieval_candidates.py
+++ b/scripts/run_gate2_real_retrieval_candidates.py
@@ -4,9 +4,9 @@ import argparse
 import json
 from pathlib import Path
 
+from fossil_core.application.rebuild import retrieval_documents_from_pack_fixtures
 from fossil_core.benchmark import BenchmarkValidator, RetrievalBenchmark
 from fossil_core.benchmark_cases import load_benchmark_case_set, retrieval_cases_from_case_set
-from fossil_core.pack_corpus import retrieval_documents_from_pack_fixtures
 from fossil_core.real_retrieval import (
     LifecycleIntentReranker,
     ReciprocalRankFusionRetriever,

--- a/scripts/run_gate2_real_retrieval_controls.py
+++ b/scripts/run_gate2_real_retrieval_controls.py
@@ -4,9 +4,9 @@ import argparse
 import json
 from pathlib import Path
 
+from fossil_core.application.rebuild import retrieval_documents_from_pack_fixtures
 from fossil_core.benchmark import BenchmarkValidator, RetrievalBenchmark
 from fossil_core.benchmark_cases import load_benchmark_case_set, retrieval_cases_from_case_set
-from fossil_core.pack_corpus import retrieval_documents_from_pack_fixtures
 from fossil_core.services import BM25Retriever, EmbeddingRetriever, HashEmbeddingProvider
 
 

--- a/scripts/run_post_gate2_answer_reliability.py
+++ b/scripts/run_post_gate2_answer_reliability.py
@@ -11,7 +11,7 @@ from fossil_core.answer_eval import (
     run_answer_reliability_benchmark,
 )
 from fossil_core.answer_pipeline import LineageResolvedModelService
-from fossil_core.pack_corpus import retrieval_documents_from_pack_fixtures
+from fossil_core.application.rebuild import retrieval_documents_from_pack_fixtures
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PLAN = ROOT / "benchmarks" / "post-gate2" / "answer-reliability-v1.json"

--- a/scripts/run_post_gate2_retrieval_poisoning.py
+++ b/scripts/run_post_gate2_retrieval_poisoning.py
@@ -12,7 +12,7 @@ from fossil_core.application.query.poisoning_eval import (
     RetrievalPoisoningCase,
     run_retrieval_poisoning_benchmark,
 )
-from fossil_core.pack_corpus import retrieval_documents_from_pack_fixtures
+from fossil_core.application.rebuild import retrieval_documents_from_pack_fixtures
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PLAN = ROOT / "benchmarks" / "post-gate2" / "retrieval-poisoning-v1.json"

--- a/src/fossil_core/application/rebuild/__init__.py
+++ b/src/fossil_core/application/rebuild/__init__.py
@@ -1,0 +1,5 @@
+"""Rebuildable application projections derived from durable FOSSIL state."""
+
+from .pack_corpus import retrieval_documents_from_pack_fixtures
+
+__all__ = ["retrieval_documents_from_pack_fixtures"]

--- a/src/fossil_core/application/rebuild/pack_corpus.py
+++ b/src/fossil_core/application/rebuild/pack_corpus.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from ...domain.lifecycle import KnowledgeState
+from ...pack_fixture import validate_pack_fixtures
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def _events_for_pack(
+    root: Path,
+    manifest: dict[str, Any],
+    *,
+    as_of_recorded_at: str | None = None,
+) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for relative in manifest["event_roots"]:
+        event_root = root / str(relative)
+        for path in sorted(event_root.glob("*/*.json")):
+            event = _load_json(path)
+            if as_of_recorded_at is not None and str(event["recorded_at"]) > as_of_recorded_at:
+                continue
+            events.append(event)
+    return sorted(events, key=lambda event: (str(event["recorded_at"]), str(event["event_id"])))
+
+
+def retrieval_documents_from_pack_fixtures(
+    pack_roots: Iterable[Path],
+    *,
+    schemas_root: Path,
+    as_of_recorded_at: str | None = None,
+) -> list[dict[str, Any]]:
+    """Build deterministic retrieval documents from validated durable packs.
+
+    This is a rebuildable benchmark/search projection. Claim and relation IDs remain
+    the durable corpus identities; generated document text is never canonical truth.
+
+    When ``as_of_recorded_at`` is supplied, the projection replays only events whose
+    durable ``recorded_at`` timestamp is at or before that cutoff. The complete pack is
+    still validated first, so historical reconstruction never bypasses fixture integrity.
+    """
+
+    roots = [Path(root) for root in pack_roots]
+    validate_pack_fixtures(roots, schemas_root=schemas_root)
+
+    manifests: dict[str, dict[str, Any]] = {}
+    events_by_pack: dict[str, list[dict[str, Any]]] = {}
+    state_by_pack: dict[str, KnowledgeState] = {}
+    claim_text: dict[str, str] = {}
+    claim_event: dict[str, dict[str, Any]] = {}
+    relation_event: dict[str, dict[str, Any]] = {}
+
+    for root in roots:
+        manifest = _load_json(root / "manifest.json")
+        pack_id = str(manifest["pack_id"])
+        manifests[pack_id] = manifest
+        events = _events_for_pack(
+            root,
+            manifest,
+            as_of_recorded_at=as_of_recorded_at,
+        )
+        events_by_pack[pack_id] = events
+        state_by_pack[pack_id] = KnowledgeState.replay(events)
+        for event in events:
+            if event["event_type"] == "claim.proposed":
+                claim_id = str(event["subject_refs"][0])
+                claim_text[claim_id] = str(event["payload"]["claim_text"])
+                claim_event[claim_id] = event
+            elif event["event_type"] == "relation.proposed":
+                relation_event[str(event["payload"]["relation_id"])] = event
+
+    documents: list[dict[str, Any]] = []
+    for pack_id in sorted(events_by_pack):
+        state = state_by_pack[pack_id]
+        for claim_id in sorted(state.claims):
+            event = claim_event[claim_id]
+            document = {
+                "id": claim_id,
+                "pack_id": pack_id,
+                "text": claim_text[claim_id],
+                "document_type": "claim",
+                "current_state": state.claims[claim_id],
+                "state_history": list(state.claim_history[claim_id]),
+                "proposed_event_id": str(event["event_id"]),
+                "evidence_refs": [str(item) for item in event.get("evidence_refs", [])],
+                "source_snapshot_refs": [
+                    str(item) for item in event.get("source_snapshot_refs", [])
+                ],
+            }
+            citation = event.get("payload", {}).get("citation")
+            if isinstance(citation, dict):
+                document["citation"] = copy.deepcopy(citation)
+            documents.append(document)
+
+        for relation_id in sorted(state.relations):
+            relation = state.relations[relation_id]
+            event = relation_event[relation_id]
+            source_text = claim_text.get(relation.source_ref, relation.source_ref)
+            target_text = claim_text.get(relation.target_ref, relation.target_ref)
+            documents.append(
+                {
+                    "id": relation_id,
+                    "pack_id": pack_id,
+                    "text": (
+                        f"{source_text}\n"
+                        f"Relation: {relation.relation_type}\n"
+                        f"{target_text}"
+                    ),
+                    "document_type": "relation",
+                    "relation_type": relation.relation_type,
+                    "source_ref": relation.source_ref,
+                    "target_ref": relation.target_ref,
+                    "current_state": relation.state,
+                    "state_history": list(state.relation_history[relation_id]),
+                    "proposed_event_id": str(event["event_id"]),
+                    "evidence_refs": [str(item) for item in event.get("evidence_refs", [])],
+                    "source_snapshot_refs": [
+                        str(item) for item in event.get("source_snapshot_refs", [])
+                    ],
+                }
+            )
+
+    documents.sort(key=lambda document: (str(document["pack_id"]), str(document["id"])))
+    return documents

--- a/src/fossil_core/pack_corpus.py
+++ b/src/fossil_core/pack_corpus.py
@@ -1,133 +1,14 @@
 from __future__ import annotations
 
-import copy
-import json
-from pathlib import Path
-from typing import Any, Iterable
-
-from .lifecycle import KnowledgeState
-from .pack_fixture import validate_pack_fixtures
-
-
-def _load_json(path: Path) -> dict[str, Any]:
-    value = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(value, dict):
-        raise ValueError(f"expected JSON object: {path}")
-    return value
-
-
-def _events_for_pack(
-    root: Path,
-    manifest: dict[str, Any],
-    *,
-    as_of_recorded_at: str | None = None,
-) -> list[dict[str, Any]]:
-    events: list[dict[str, Any]] = []
-    for relative in manifest["event_roots"]:
-        event_root = root / str(relative)
-        for path in sorted(event_root.glob("*/*.json")):
-            event = _load_json(path)
-            if as_of_recorded_at is not None and str(event["recorded_at"]) > as_of_recorded_at:
-                continue
-            events.append(event)
-    return sorted(events, key=lambda event: (str(event["recorded_at"]), str(event["event_id"])))
-
-
-def retrieval_documents_from_pack_fixtures(
-    pack_roots: Iterable[Path],
-    *,
-    schemas_root: Path,
-    as_of_recorded_at: str | None = None,
-) -> list[dict[str, Any]]:
-    """Build deterministic retrieval documents from validated durable packs.
-
-    This is a rebuildable benchmark/search projection. Claim and relation IDs remain
-    the durable corpus identities; generated document text is never canonical truth.
-
-    When ``as_of_recorded_at`` is supplied, the projection replays only events whose
-    durable ``recorded_at`` timestamp is at or before that cutoff. The complete pack is
-    still validated first, so historical reconstruction never bypasses fixture integrity.
-    """
-
-    roots = [Path(root) for root in pack_roots]
-    validate_pack_fixtures(roots, schemas_root=schemas_root)
-
-    manifests: dict[str, dict[str, Any]] = {}
-    events_by_pack: dict[str, list[dict[str, Any]]] = {}
-    state_by_pack: dict[str, KnowledgeState] = {}
-    claim_text: dict[str, str] = {}
-    claim_event: dict[str, dict[str, Any]] = {}
-    relation_event: dict[str, dict[str, Any]] = {}
-
-    for root in roots:
-        manifest = _load_json(root / "manifest.json")
-        pack_id = str(manifest["pack_id"])
-        manifests[pack_id] = manifest
-        events = _events_for_pack(
-            root,
-            manifest,
-            as_of_recorded_at=as_of_recorded_at,
-        )
-        events_by_pack[pack_id] = events
-        state_by_pack[pack_id] = KnowledgeState.replay(events)
-        for event in events:
-            if event["event_type"] == "claim.proposed":
-                claim_id = str(event["subject_refs"][0])
-                claim_text[claim_id] = str(event["payload"]["claim_text"])
-                claim_event[claim_id] = event
-            elif event["event_type"] == "relation.proposed":
-                relation_event[str(event["payload"]["relation_id"])] = event
-
-    documents: list[dict[str, Any]] = []
-    for pack_id in sorted(events_by_pack):
-        state = state_by_pack[pack_id]
-        for claim_id in sorted(state.claims):
-            event = claim_event[claim_id]
-            document = {
-                "id": claim_id,
-                "pack_id": pack_id,
-                "text": claim_text[claim_id],
-                "document_type": "claim",
-                "current_state": state.claims[claim_id],
-                "state_history": list(state.claim_history[claim_id]),
-                "proposed_event_id": str(event["event_id"]),
-                "evidence_refs": [str(item) for item in event.get("evidence_refs", [])],
-                "source_snapshot_refs": [
-                    str(item) for item in event.get("source_snapshot_refs", [])
-                ],
-            }
-            citation = event.get("payload", {}).get("citation")
-            if isinstance(citation, dict):
-                document["citation"] = copy.deepcopy(citation)
-            documents.append(document)
-
-        for relation_id in sorted(state.relations):
-            relation = state.relations[relation_id]
-            event = relation_event[relation_id]
-            source_text = claim_text.get(relation.source_ref, relation.source_ref)
-            target_text = claim_text.get(relation.target_ref, relation.target_ref)
-            documents.append(
-                {
-                    "id": relation_id,
-                    "pack_id": pack_id,
-                    "text": (
-                        f"{source_text}\n"
-                        f"Relation: {relation.relation_type}\n"
-                        f"{target_text}"
-                    ),
-                    "document_type": "relation",
-                    "relation_type": relation.relation_type,
-                    "source_ref": relation.source_ref,
-                    "target_ref": relation.target_ref,
-                    "current_state": relation.state,
-                    "state_history": list(state.relation_history[relation_id]),
-                    "proposed_event_id": str(event["event_id"]),
-                    "evidence_refs": [str(item) for item in event.get("evidence_refs", [])],
-                    "source_snapshot_refs": [
-                        str(item) for item in event.get("source_snapshot_refs", [])
-                    ],
-                }
-            )
-
-    documents.sort(key=lambda document: (str(document["pack_id"]), str(document["id"])))
-    return documents
+from .application.rebuild.pack_corpus import (
+    Any,
+    Iterable,
+    KnowledgeState,
+    Path,
+    _events_for_pack,
+    _load_json,
+    copy,
+    json,
+    retrieval_documents_from_pack_fixtures,
+    validate_pack_fixtures,
+)

--- a/tests/test_pack_corpus.py
+++ b/tests/test_pack_corpus.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from fossil_core.pack_corpus import retrieval_documents_from_pack_fixtures
+from fossil_core.application.rebuild import retrieval_documents_from_pack_fixtures
 
 
 COMMON = "pack_269099f7b2ba43b7a99b9427d64092de"
@@ -156,7 +156,10 @@ def _fixture(tmp_path: Path) -> tuple[Path, Path]:
 
 def test_pack_projection_preserves_claim_state_history_and_citation(tmp_path, monkeypatch):
     common, ai = _fixture(tmp_path)
-    monkeypatch.setattr("fossil_core.pack_corpus.validate_pack_fixtures", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "fossil_core.application.rebuild.pack_corpus.validate_pack_fixtures",
+        lambda *args, **kwargs: None,
+    )
 
     documents = retrieval_documents_from_pack_fixtures(
         [common, ai],
@@ -178,7 +181,10 @@ def test_pack_projection_preserves_claim_state_history_and_citation(tmp_path, mo
 
 def test_pack_projection_materializes_cross_pack_relation_with_durable_identity(tmp_path, monkeypatch):
     common, ai = _fixture(tmp_path)
-    monkeypatch.setattr("fossil_core.pack_corpus.validate_pack_fixtures", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "fossil_core.application.rebuild.pack_corpus.validate_pack_fixtures",
+        lambda *args, **kwargs: None,
+    )
 
     documents = retrieval_documents_from_pack_fixtures(
         [ai, common],

--- a/tests/test_pack_corpus_application_compatibility.py
+++ b/tests/test_pack_corpus_application_compatibility.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import inspect
+
+import fossil_core.application.rebuild.pack_corpus as canonical_pack_corpus
+import fossil_core.pack_corpus as legacy_pack_corpus
+from fossil_core.domain.lifecycle import KnowledgeState
+
+
+def test_pack_corpus_legacy_namespace_and_object_identity_are_frozen():
+    assert not hasattr(legacy_pack_corpus, "__all__")
+    assert {
+        name for name in vars(legacy_pack_corpus) if not name.startswith("_")
+    } == {
+        "Any",
+        "Iterable",
+        "KnowledgeState",
+        "Path",
+        "annotations",
+        "copy",
+        "json",
+        "retrieval_documents_from_pack_fixtures",
+        "validate_pack_fixtures",
+    }
+
+    assert legacy_pack_corpus.KnowledgeState is KnowledgeState
+    assert legacy_pack_corpus.validate_pack_fixtures is canonical_pack_corpus.validate_pack_fixtures
+    assert (
+        legacy_pack_corpus.retrieval_documents_from_pack_fixtures
+        is canonical_pack_corpus.retrieval_documents_from_pack_fixtures
+    )
+    assert legacy_pack_corpus._load_json is canonical_pack_corpus._load_json
+    assert legacy_pack_corpus._events_for_pack is canonical_pack_corpus._events_for_pack
+
+
+def test_pack_corpus_rebuild_signature_is_unchanged():
+    signature = inspect.signature(
+        canonical_pack_corpus.retrieval_documents_from_pack_fixtures
+    )
+    parameters = list(signature.parameters.values())
+
+    assert [parameter.name for parameter in parameters] == [
+        "pack_roots",
+        "schemas_root",
+        "as_of_recorded_at",
+    ]
+    assert parameters[0].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert parameters[0].default is inspect.Parameter.empty
+    assert parameters[1].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters[1].default is inspect.Parameter.empty
+    assert parameters[2].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters[2].default is None

--- a/tests/test_temporal_benchmark.py
+++ b/tests/test_temporal_benchmark.py
@@ -154,7 +154,10 @@ def _fixture(tmp_path: Path) -> Path:
 
 def test_temporal_benchmark_replays_current_and_historical_truth(tmp_path, monkeypatch):
     root = _fixture(tmp_path)
-    monkeypatch.setattr("fossil_core.pack_corpus.validate_pack_fixtures", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "fossil_core.application.rebuild.pack_corpus.validate_pack_fixtures",
+        lambda *args, **kwargs: None,
+    )
 
     current_new = TemporalQueryCase(
         case_id="current-durable-core",
@@ -231,7 +234,10 @@ def test_temporal_benchmark_replays_current_and_historical_truth(tmp_path, monke
 
 def test_temporal_benchmark_rejects_wrong_expected_state(tmp_path, monkeypatch):
     root = _fixture(tmp_path)
-    monkeypatch.setattr("fossil_core.pack_corpus.validate_pack_fixtures", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "fossil_core.application.rebuild.pack_corpus.validate_pack_fixtures",
+        lambda *args, **kwargs: None,
+    )
 
     report = run_temporal_evolution_benchmark(
         [root],


### PR DESCRIPTION
## Scope

Phase 4 bounded application/rebuild modularization under #82.

- move the existing deterministic `retrieval_documents_from_pack_fixtures` rebuild/projection responsibility to `fossil_core.application.rebuild.pack_corpus`
- expose the canonical application-internal entrypoint from `fossil_core.application.rebuild`
- retain `fossil_core.pack_corpus` as an identity-preserving thin compatibility path with its historical implicit namespace
- switch the moved implementation to the already-canonical `fossil_core.domain.lifecycle.KnowledgeState` identity
- migrate focused Gate-2 / post-Gate-2 first-party entrypoints touched by this responsibility to the canonical rebuild import
- freeze the legacy namespace, function/helper object identity, public signature, claim lifecycle/citation materialization, and cross-pack relation materialization
- require the new rebuild modules and thin compatibility path in architecture CI

## Boundary decision

This function is a deterministic rebuildable search/benchmark projection from already-validated durable pack fixtures: it replays durable events into `KnowledgeState`, materializes claim/relation documents, and never becomes canonical truth. That is the existing Phase-4 `rebuild` application responsibility rather than domain semantics or a concrete retrieval backend.

The existing `pack_fixture.validate_pack_fixtures` dependency remains where it is for now; this PR does not broaden into the much larger pack-fixture integrity/storage surface. The canonical rebuild module has no direct dependency on filesystem/S3/Graphiti/Neo4j/vector adapters. A later bounded slice can classify/move pack-fixture validation separately.

## Semantic-drift audit

The implementation body is unchanged apart from import-path relocation to canonical lifecycle and the still-existing pack-fixture validator. No document IDs/text, event ordering/cutoff behavior, lifecycle replay, relation construction, citation copying, retrieval ranking, context/model policy, event/schema/ID/hash, storage/provider, projection backend, LiteLLM, Cortex V5, or acceptance behavior changes.

The legacy flat module remains available and aliases the canonical function/helpers, while focused first-party benchmark scripts now use the canonical rebuild path.

The first exact-head DKG run `32051436282` failed only because two existing temporal benchmark tests monkeypatched `fossil_core.pack_corpus.validate_pack_fixtures`; after relocation, the function's global validator lives in `fossil_core.application.rebuild.pack_corpus`. Those tests were updated to patch the canonical implementation global. No lifecycle, retrieval, fixture-validation, or acceptance rule was changed.

## Exact-head verification

Head `4f4f183b140a302fef3d15fe5bebafd4eecd05a6`:

- DKG contract tests `32051625786`: SUCCESS — `387 passed, 1 skipped, 1 warning`
- Dependency Integrity `32051625779`: SUCCESS
- legacy `fossil_core.pack_corpus` namespace/function/helper identity and public signature are frozen
- claim lifecycle/citation materialization and cross-pack relation materialization remain covered by focused tests
- architecture CI requires `fossil_core.application.rebuild`, `.pack_corpus`, and the thin legacy compatibility import
- no LiteLLM or Cortex V5 changes