### PR TITLE
[ARCH-P4] Move semantic retriever behind adapters/vector

### DIFF
--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -45,6 +45,8 @@ CANONICAL_MODULES = {
     "fossil_core.adapters.litellm.reranker",
     "fossil_core.adapters.s3",
     "fossil_core.adapters.s3.storage",
+    "fossil_core.adapters.vector",
+    "fossil_core.adapters.vector.semantic_retriever",
 }
 
 COMPATIBILITY_IMPORTS = {
@@ -54,6 +56,7 @@ COMPATIBILITY_IMPORTS = {
     "fossil_core.lifecycle": {"fossil_core.domain.lifecycle"},
     "fossil_core.pack_corpus": {"fossil_core.application.rebuild.pack_corpus"},
     "fossil_core.promotion": {"fossil_core.domain.promotion"},
+    "fossil_core.semantic_retriever": {"fossil_core.adapters.vector.semantic_retriever"},
     "fossil_core.storage_ports": {"fossil_core.ports"},
     "fossil_core.artifact_store": {
         "fossil_core.adapters.filesystem.artifact_store"

--- a/scripts/run_gate2_comparative_bakeoff.py
+++ b/scripts/run_gate2_comparative_bakeoff.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
+from fossil_core.adapters.vector import SemanticEmbeddingRetriever
 from fossil_core.application.rebuild import retrieval_documents_from_pack_fixtures
 from fossil_core.benchmark import BenchmarkValidator, RetrievalBenchmark
 from fossil_core.benchmark_cases import load_benchmark_case_set, retrieval_cases_from_case_set
@@ -14,7 +15,6 @@ from fossil_core.real_retrieval import (
     RerankedRetriever,
     SentenceTransformerEmbeddingProvider,
 )
-from fossil_core.semantic_retriever import SemanticEmbeddingRetriever
 from fossil_core.services import (
     BM25Retriever,
     BudgetedContextProvider,

--- a/scripts/run_gate2_real_retrieval_candidates.py
+++ b/scripts/run_gate2_real_retrieval_candidates.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
+from fossil_core.adapters.vector import SemanticEmbeddingRetriever
 from fossil_core.application.rebuild import retrieval_documents_from_pack_fixtures
 from fossil_core.benchmark import BenchmarkValidator, RetrievalBenchmark
 from fossil_core.benchmark_cases import load_benchmark_case_set, retrieval_cases_from_case_set
@@ -13,7 +14,6 @@ from fossil_core.real_retrieval import (
     RerankedRetriever,
     SentenceTransformerEmbeddingProvider,
 )
-from fossil_core.semantic_retriever import SemanticEmbeddingRetriever
 from fossil_core.services import BM25Retriever, BudgetedContextProvider
 
 

--- a/src/fossil_core/adapters/vector/__init__.py
+++ b/src/fossil_core/adapters/vector/__init__.py
@@ -1,0 +1,5 @@
+"""Vector/search adapters for rebuildable retrieval projections."""
+
+from .semantic_retriever import SemanticEmbeddingRetriever
+
+__all__ = ["SemanticEmbeddingRetriever"]

--- a/src/fossil_core/adapters/vector/semantic_retriever.py
+++ b/src/fossil_core/adapters/vector/semantic_retriever.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable, Mapping
+
+from ...services import EmbeddingRetriever, ServiceMetadata
+
+
+class SemanticEmbeddingRetriever(EmbeddingRetriever):
+    """EmbeddingRetriever with full embedding-runtime provenance in benchmark metadata."""
+
+    def __init__(
+        self,
+        documents: Iterable[Mapping[str, Any]],
+        embedder: Any,
+        *,
+        version: str = "1",
+    ) -> None:
+        super().__init__(documents, embedder, version=version)
+
+    def metadata(self) -> dict[str, Any]:
+        embedder = dict(self.embedder.metadata())
+        embedder_runtime = dict(embedder.get("runtime", {}))
+        return ServiceMetadata(
+            kind="retriever",
+            provider=str(embedder.get("provider", "unknown")),
+            provider_version=str(embedder.get("provider_version", "unknown")),
+            implementation="semantic-in-memory-cosine",
+            implementation_version=self.version,
+            model_id=str(embedder.get("model_id")) if embedder.get("model_id") else None,
+            local=bool(embedder.get("local", True)),
+            estimated_cost_per_call_usd=float(
+                embedder.get("estimated_cost_per_call_usd", 0.0)
+            ),
+            runtime={
+                "embedding_implementation": str(embedder.get("implementation", "unknown")),
+                "embedding_implementation_version": str(
+                    embedder.get("implementation_version", "unknown")
+                ),
+                "embedding_runtime": json.dumps(
+                    embedder_runtime,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+            },
+        ).as_dict()

--- a/src/fossil_core/semantic_retriever.py
+++ b/src/fossil_core/semantic_retriever.py
@@ -1,46 +1,11 @@
 from __future__ import annotations
 
-import json
-from typing import Any, Iterable, Mapping
-
-from .services import EmbeddingRetriever, ServiceMetadata
-
-
-class SemanticEmbeddingRetriever(EmbeddingRetriever):
-    """EmbeddingRetriever with full embedding-runtime provenance in benchmark metadata."""
-
-    def __init__(
-        self,
-        documents: Iterable[Mapping[str, Any]],
-        embedder: Any,
-        *,
-        version: str = "1",
-    ) -> None:
-        super().__init__(documents, embedder, version=version)
-
-    def metadata(self) -> dict[str, Any]:
-        embedder = dict(self.embedder.metadata())
-        embedder_runtime = dict(embedder.get("runtime", {}))
-        return ServiceMetadata(
-            kind="retriever",
-            provider=str(embedder.get("provider", "unknown")),
-            provider_version=str(embedder.get("provider_version", "unknown")),
-            implementation="semantic-in-memory-cosine",
-            implementation_version=self.version,
-            model_id=str(embedder.get("model_id")) if embedder.get("model_id") else None,
-            local=bool(embedder.get("local", True)),
-            estimated_cost_per_call_usd=float(
-                embedder.get("estimated_cost_per_call_usd", 0.0)
-            ),
-            runtime={
-                "embedding_implementation": str(embedder.get("implementation", "unknown")),
-                "embedding_implementation_version": str(
-                    embedder.get("implementation_version", "unknown")
-                ),
-                "embedding_runtime": json.dumps(
-                    embedder_runtime,
-                    sort_keys=True,
-                    separators=(",", ":"),
-                ),
-            },
-        ).as_dict()
+from .adapters.vector.semantic_retriever import (
+    Any,
+    EmbeddingRetriever,
+    Iterable,
+    Mapping,
+    SemanticEmbeddingRetriever,
+    ServiceMetadata,
+    json,
+)

--- a/tests/test_semantic_retriever_adapter_compatibility.py
+++ b/tests/test_semantic_retriever_adapter_compatibility.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import inspect
+
+import fossil_core.adapters.vector.semantic_retriever as canonical_semantic
+import fossil_core.semantic_retriever as legacy_semantic
+
+
+def test_semantic_retriever_legacy_namespace_and_identity_are_frozen():
+    assert not hasattr(legacy_semantic, "__all__")
+    assert {
+        name for name in vars(legacy_semantic) if not name.startswith("_")
+    } == {
+        "Any",
+        "EmbeddingRetriever",
+        "Iterable",
+        "Mapping",
+        "SemanticEmbeddingRetriever",
+        "ServiceMetadata",
+        "annotations",
+        "json",
+    }
+
+    assert (
+        legacy_semantic.SemanticEmbeddingRetriever
+        is canonical_semantic.SemanticEmbeddingRetriever
+    )
+    assert legacy_semantic.EmbeddingRetriever is canonical_semantic.EmbeddingRetriever
+    assert legacy_semantic.ServiceMetadata is canonical_semantic.ServiceMetadata
+
+
+def test_semantic_retriever_constructor_signature_is_unchanged():
+    signature = inspect.signature(canonical_semantic.SemanticEmbeddingRetriever)
+    parameters = list(signature.parameters.values())
+
+    assert [parameter.name for parameter in parameters] == [
+        "documents",
+        "embedder",
+        "version",
+    ]
+    assert parameters[0].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert parameters[0].default is inspect.Parameter.empty
+    assert parameters[1].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert parameters[1].default is inspect.Parameter.empty
+    assert parameters[2].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters[2].default == "1"


### PR DESCRIPTION
## Scope

Phase 4 bounded adapter/vector modularization under #82.

- move the small `SemanticEmbeddingRetriever` provider-provenance wrapper to `fossil_core.adapters.vector.semantic_retriever`
- expose the canonical internal adapter entrypoint from `fossil_core.adapters.vector`
- retain `fossil_core.semantic_retriever` as a thin identity-preserving compatibility path with its historical implicit namespace
- migrate the focused Gate-2 semantic candidate/comparison entrypoints to the canonical vector adapter import
- freeze legacy namespace, object identity, constructor signature, and the existing metadata behavior
- require the new vector adapter modules and thin compatibility import in architecture CI

## Boundary decision

`SemanticEmbeddingRetriever` is a concrete in-memory semantic retrieval adapter that decorates the existing embedding retriever with provider/runtime provenance. It does not own durable truth, retrieval policy, or embedding-provider selection. Canonical ownership therefore fits the incremental `adapters/vector` target in #82.

This PR deliberately does **not** extract the larger mixed `services.py` module or move the base `EmbeddingRetriever`; the new adapter continues to depend on that existing implementation seam. A later bounded slice can classify/extract the base vector retriever without widening this PR.

## Semantic-drift audit

The class implementation is unchanged apart from the relative import needed after relocation. No cosine scoring, ranking/tie-break behavior, pack filtering, embedding calls, model/provider identity, context policy, reranking, LiteLLM gateway/model behavior, Cortex V5, event/schema/ID/hash, storage/provider, projection identity, or acceptance behavior changes.

The legacy module aliases the canonical class and its historical imported symbols. Existing larger post-Gate-2 callers may continue through the compatibility path; focused Gate-2 entrypoints now demonstrate canonical usage.

## Exact-head verification

Head `3fe368ec15c41baf550c2243675adec9e921d640`:

- DKG contract tests `32052466274`: SUCCESS — `389 passed, 1 skipped, 1 warning`
- Dependency Integrity `32052466323`: SUCCESS
- legacy `fossil_core.semantic_retriever` namespace, semantic class/base/metadata identity, and constructor signature are frozen
- architecture CI requires `fossil_core.adapters.vector`, `.semantic_retriever`, and the thin legacy compatibility path
- focused Gate-2 semantic candidate/comparison entrypoints import the canonical vector adapter
- submitted reviews: 0
- review threads: 0
- base/main remained `b77004498b9f719c9e786ef0752bf59915fb8f6c` at verification time