### PR TITLE
[ARCH-P4] Extract evaluation context-probe classifier

### DIFF
--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -14,6 +14,7 @@ CANONICAL_MODULES = {
     "fossil_core.application.evaluation",
     "fossil_core.application.evaluation.benchmark",
     "fossil_core.application.evaluation.cases",
+    "fossil_core.application.evaluation.context_probe",
     "fossil_core.application.ingest",
     "fossil_core.application.ingest.pack_validation",
     "fossil_core.application.query",

--- a/src/fossil_core/application/evaluation/context_probe.py
+++ b/src/fossil_core/application/evaluation/context_probe.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def classify_context_probe(probe: Mapping[str, Any]) -> dict[str, Any]:
+    items = [dict(item) for item in probe.get("items", [])]
+    truncated_ids = [
+        str(item.get("id"))
+        for item in items
+        if bool(item.get("context_truncated", False))
+    ]
+    chars_used = int(probe.get("chars_used", 0))
+    max_chars = int(probe.get("max_chars", 0))
+    return {
+        "chars_used": chars_used,
+        "max_chars": max_chars,
+        "item_ids": [str(item.get("id")) for item in items],
+        "truncated_ids": truncated_ids,
+        "context_truncation_or_overload": bool(truncated_ids) or (
+            max_chars > 0 and chars_used >= max_chars
+        ),
+    }

--- a/src/fossil_core/benchmark_compare.py
+++ b/src/fossil_core/benchmark_compare.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Any
 
+from .application.evaluation.context_probe import classify_context_probe
 from .benchmark import RetrievalBenchmarkCase
 from .real_retrieval import LifecycleIntentReranker
 
@@ -149,26 +150,6 @@ def classify_retrieval_result(
                 "candidate truth authority or truth-changing claims"
             ),
         },
-    }
-
-
-def classify_context_probe(probe: Mapping[str, Any]) -> dict[str, Any]:
-    items = [dict(item) for item in probe.get("items", [])]
-    truncated_ids = [
-        str(item.get("id"))
-        for item in items
-        if bool(item.get("context_truncated", False))
-    ]
-    chars_used = int(probe.get("chars_used", 0))
-    max_chars = int(probe.get("max_chars", 0))
-    return {
-        "chars_used": chars_used,
-        "max_chars": max_chars,
-        "item_ids": [str(item.get("id")) for item in items],
-        "truncated_ids": truncated_ids,
-        "context_truncation_or_overload": bool(truncated_ids) or (
-            max_chars > 0 and chars_used >= max_chars
-        ),
     }
 
 

--- a/tests/test_context_probe_application_compatibility.py
+++ b/tests/test_context_probe_application_compatibility.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import inspect
+
+from fossil_core.application.evaluation.context_probe import classify_context_probe as canonical_classify_context_probe
+from fossil_core.benchmark_compare import classify_context_probe as legacy_classify_context_probe
+
+
+def test_context_probe_legacy_symbol_is_canonical_function():
+    assert legacy_classify_context_probe is canonical_classify_context_probe
+    parameters = list(inspect.signature(canonical_classify_context_probe).parameters.values())
+    assert [parameter.name for parameter in parameters] == ["probe"]
+    assert parameters[0].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert parameters[0].default is inspect.Parameter.empty
+
+
+def test_context_probe_classification_behavior_is_frozen():
+    clean = {
+        "chars_used": 120,
+        "max_chars": 4000,
+        "items": [
+            {"id": "former", "context_truncated": False},
+            {"id": "stale", "context_truncated": False},
+        ],
+    }
+    saturated = {
+        "chars_used": 4000,
+        "max_chars": 4000,
+        "items": [{"id": "current", "context_truncated": False}],
+    }
+    truncated = {
+        "chars_used": 100,
+        "max_chars": 4000,
+        "items": [{"id": "current", "context_truncated": True}],
+    }
+
+    assert canonical_classify_context_probe(clean) == {
+        "chars_used": 120,
+        "max_chars": 4000,
+        "item_ids": ["former", "stale"],
+        "truncated_ids": [],
+        "context_truncation_or_overload": False,
+    }
+    assert canonical_classify_context_probe(saturated) == {
+        "chars_used": 4000,
+        "max_chars": 4000,
+        "item_ids": ["current"],
+        "truncated_ids": [],
+        "context_truncation_or_overload": True,
+    }
+    assert canonical_classify_context_probe(truncated) == {
+        "chars_used": 100,
+        "max_chars": 4000,
+        "item_ids": ["current"],
+        "truncated_ids": ["current"],
+        "context_truncation_or_overload": True,
+    }
+
+    assert legacy_classify_context_probe(clean) == canonical_classify_context_probe(clean)


### PR DESCRIPTION
Issue #82 Phase 4 bounded slice.

Extracts only the pure benchmark context-probe classification responsibility from `fossil_core.benchmark_compare` into `fossil_core.application.evaluation.context_probe`.

Behavior/compatibility:
- the classifier body is moved unchanged: item IDs/order, truncation detection, saturation (`chars_used >= max_chars` when bounded), integer coercion, and output shape remain identical
- `fossil_core.benchmark_compare.classify_context_probe` remains available and is now the same function object as the canonical application evaluator
- `comparative_summary` therefore uses the canonical classifier without changing comparison evidence or selection behavior
- compatibility tests freeze function identity, signature, clean/saturated/truncated representative outputs, and the legacy path
- architecture CI requires the canonical context-probe module
- internal-by-default: no public API contract promotion or package re-export

Deliberate boundary: the rest of `benchmark_compare` stays flat because retrieval failure taxonomy still depends on `LifecycleIntentReranker`; moving that wholesale into application would entrench retrieval-policy coupling. This PR does not touch it.

Exact-head evidence on `ee6fb8c65bf3bd601d42d85c2d338718361d59b6`:
- DKG contract tests `32060813141`: SUCCESS — 397 passed, 1 skipped, 1 existing legacy-`dkg` deprecation warning
- Dependency integrity `32060813225`: SUCCESS

Non-goals: no ContextProvider/compression policy, retrieval/ranking/model behavior, LiteLLM gateway/model work, Cortex V5 work, event/schema/ID/hash, storage/provider/projection, or acceptance changes.