### PR TITLE
[ARCH-P4] Extract answer-candidate evaluation core

### DIFF
--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -12,6 +12,7 @@ PACKAGE = "fossil_core"
 CANONICAL_MODULES = {
     "fossil_core.application",
     "fossil_core.application.evaluation",
+    "fossil_core.application.evaluation.answer",
     "fossil_core.application.evaluation.benchmark",
     "fossil_core.application.evaluation.cases",
     "fossil_core.application.evaluation.context_probe",

--- a/src/fossil_core/answer_eval.py
+++ b/src/fossil_core/answer_eval.py
@@ -4,94 +4,24 @@ import time
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping
 
+from .application.evaluation.answer import (
+    ANSWER_OUTCOMES,
+    AnswerReliabilityCase,
+    _CITATION_KEYS,
+    _candidate_claims,
+    _canonical_citation,
+    _documents_by_id,
+    evaluate_answer_candidate,
+)
 from .real_retrieval import LifecycleIntentReranker, RerankedRetriever
 from .services import BM25Retriever, ServiceMetadata, tokenize
 
-ANSWER_OUTCOMES = frozenset(
-    {"answer", "insufficient_evidence", "conflicting_evidence", "current_state_unresolved"}
-)
 CURRENT_STATES = frozenset({"supported", "open"})
 HISTORICAL_STATES = frozenset(
     {"superseded", "rejected", "retracted", "stale_pending_review", "disputed"}
 )
 UNRESOLVED_STATES = frozenset({"disputed", "stale_pending_review"})
 LIVE_CONFLICT_STATES = frozenset({"supported", "open", "disputed"})
-_CITATION_KEYS = (
-    "schema_version",
-    "citation_id",
-    "snapshot_id",
-    "artifact_id",
-    "byte_start",
-    "byte_end",
-    "passage_hash",
-)
-
-
-@dataclass(frozen=True)
-class AnswerReliabilityCase:
-    case_id: str
-    query: str
-    pack_ids: tuple[str, ...]
-    expected_outcome: str
-    required_claim_ids: frozenset[str] = frozenset()
-    allowed_claim_ids: frozenset[str] = frozenset()
-    forbidden_claim_ids: frozenset[str] = frozenset()
-    required_citation_ids: frozenset[str] = frozenset()
-    category: str = "general"
-    limit: int = 8
-
-    @classmethod
-    def from_mapping(cls, value: Mapping[str, Any]) -> "AnswerReliabilityCase":
-        required = frozenset(str(item) for item in value.get("required_claim_ids", []))
-        allowed_raw = value.get("allowed_claim_ids")
-        allowed = (
-            frozenset(str(item) for item in allowed_raw)
-            if allowed_raw is not None
-            else required
-        )
-        return cls(
-            case_id=str(value["case_id"]),
-            query=str(value["query"]),
-            pack_ids=tuple(str(item) for item in value["pack_ids"]),
-            expected_outcome=str(value["expected_outcome"]),
-            required_claim_ids=required,
-            allowed_claim_ids=allowed,
-            forbidden_claim_ids=frozenset(
-                str(item) for item in value.get("forbidden_claim_ids", [])
-            ),
-            required_citation_ids=frozenset(
-                str(item) for item in value.get("required_citation_ids", [])
-            ),
-            category=str(value.get("category", "general")),
-            limit=int(value.get("limit", 8)),
-        )
-
-    def __post_init__(self) -> None:
-        if not self.case_id or not self.query or not self.pack_ids:
-            raise ValueError("answer reliability cases require id/query/packs")
-        if self.expected_outcome not in ANSWER_OUTCOMES:
-            raise ValueError(f"invalid expected answer outcome: {self.expected_outcome}")
-        if self.limit < 1:
-            raise ValueError("answer reliability case limit must be positive")
-        if self.expected_outcome == "answer" and not self.required_claim_ids:
-            raise ValueError("answer cases require at least one required claim")
-
-
-def _documents_by_id(documents: Iterable[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
-    return {str(document["id"]): dict(document) for document in documents}
-
-
-def _canonical_citation(value: Mapping[str, Any] | None) -> dict[str, Any] | None:
-    if not isinstance(value, Mapping):
-        return None
-    return {key: value.get(key) for key in _CITATION_KEYS}
-
-
-def _candidate_claims(candidate: Mapping[str, Any]) -> list[dict[str, Any]]:
-    raw = candidate.get("claims", [])
-    if not isinstance(raw, list):
-        return []
-    return [dict(item) for item in raw if isinstance(item, Mapping)]
 
 
 def _claim_payload(document: Mapping[str, Any]) -> dict[str, Any]:
@@ -103,118 +33,6 @@ def _claim_payload(document: Mapping[str, Any]) -> dict[str, Any]:
     if citation is not None:
         payload["citation"] = citation
     return payload
-
-
-def evaluate_answer_candidate(
-    candidate: Mapping[str, Any],
-    *,
-    case: AnswerReliabilityCase,
-    documents: Iterable[Mapping[str, Any]],
-) -> dict[str, Any]:
-    document_by_id = _documents_by_id(documents)
-    observed_outcome = str(candidate.get("outcome", "invalid"))
-    claims = _candidate_claims(candidate)
-    claim_ids = [str(item.get("claim_id", "")) for item in claims if item.get("claim_id")]
-    claim_id_set = set(claim_ids)
-
-    unsupported_ids = sorted(
-        {
-            identifier
-            for identifier in claim_id_set
-            if identifier not in case.allowed_claim_ids
-            or identifier not in document_by_id
-            or str(document_by_id[identifier].get("document_type", "")) != "claim"
-        }
-    )
-    forbidden_present = sorted(claim_id_set & set(case.forbidden_claim_ids))
-    required_present = set(case.required_claim_ids) <= claim_id_set
-    completeness = (
-        len(set(case.required_claim_ids) & claim_id_set) / len(case.required_claim_ids)
-        if case.required_claim_ids
-        else 1.0
-    )
-
-    citation_checks: list[dict[str, Any]] = []
-    observed_citation_ids: set[str] = set()
-    for claim in claims:
-        identifier = str(claim.get("claim_id", ""))
-        expected_document = document_by_id.get(identifier)
-        expected = _canonical_citation(
-            expected_document.get("citation") if expected_document else None
-        )
-        observed = _canonical_citation(claim.get("citation"))
-        if observed and observed.get("citation_id"):
-            observed_citation_ids.add(str(observed["citation_id"]))
-        exact = expected is not None and observed == expected
-        citation_checks.append(
-            {
-                "claim_id": identifier,
-                "expected_citation_id": (
-                    str(expected.get("citation_id")) if expected else None
-                ),
-                "observed_citation_id": (
-                    str(observed.get("citation_id")) if observed else None
-                ),
-                "exact_match": exact,
-            }
-        )
-
-    required_citations_present = set(case.required_citation_ids) <= observed_citation_ids
-    citation_correct = all(item["exact_match"] for item in citation_checks) and (
-        required_citations_present
-    )
-    if not claims and not case.required_citation_ids:
-        citation_correct = True
-
-    outcome_match = observed_outcome == case.expected_outcome
-    contradiction_handled = (
-        outcome_match and required_present and citation_correct
-        if case.expected_outcome == "conflicting_evidence"
-        else True
-    )
-    appropriate_abstention = (
-        outcome_match if case.expected_outcome != "answer" else None
-    )
-    overabstention = case.expected_outcome == "answer" and observed_outcome != "answer"
-
-    try:
-        confidence = float(candidate.get("confidence", 0.0))
-    except (TypeError, ValueError):
-        confidence = 0.0
-    confidence = max(0.0, min(1.0, confidence))
-
-    case_correct = (
-        outcome_match
-        and required_present
-        and not unsupported_ids
-        and not forbidden_present
-        and citation_correct
-        and contradiction_handled
-    )
-    unsupported_rate = len(unsupported_ids) / max(len(claim_id_set), 1)
-
-    return {
-        "case_id": case.case_id,
-        "category": case.category,
-        "expected_outcome": case.expected_outcome,
-        "observed_outcome": observed_outcome,
-        "outcome_match": outcome_match,
-        "required_claim_ids": sorted(case.required_claim_ids),
-        "observed_claim_ids": claim_ids,
-        "unsupported_claim_ids": unsupported_ids,
-        "unsupported_claim_rate": unsupported_rate,
-        "forbidden_claim_ids_present": forbidden_present,
-        "completeness": completeness,
-        "citation_checks": citation_checks,
-        "required_citation_ids": sorted(case.required_citation_ids),
-        "required_citations_present": required_citations_present,
-        "citation_correct": citation_correct,
-        "contradiction_handled": contradiction_handled,
-        "appropriate_abstention": appropriate_abstention,
-        "overabstention": overabstention,
-        "confidence": confidence,
-        "case_correct": case_correct,
-    }
 
 
 class DeterministicEvidenceAnswerService:

--- a/src/fossil_core/application/evaluation/answer.py
+++ b/src/fossil_core/application/evaluation/answer.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+
+ANSWER_OUTCOMES = frozenset(
+    {"answer", "insufficient_evidence", "conflicting_evidence", "current_state_unresolved"}
+)
+_CITATION_KEYS = (
+    "schema_version",
+    "citation_id",
+    "snapshot_id",
+    "artifact_id",
+    "byte_start",
+    "byte_end",
+    "passage_hash",
+)
+
+
+@dataclass(frozen=True)
+class AnswerReliabilityCase:
+    case_id: str
+    query: str
+    pack_ids: tuple[str, ...]
+    expected_outcome: str
+    required_claim_ids: frozenset[str] = frozenset()
+    allowed_claim_ids: frozenset[str] = frozenset()
+    forbidden_claim_ids: frozenset[str] = frozenset()
+    required_citation_ids: frozenset[str] = frozenset()
+    category: str = "general"
+    limit: int = 8
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "AnswerReliabilityCase":
+        required = frozenset(str(item) for item in value.get("required_claim_ids", []))
+        allowed_raw = value.get("allowed_claim_ids")
+        allowed = (
+            frozenset(str(item) for item in allowed_raw)
+            if allowed_raw is not None
+            else required
+        )
+        return cls(
+            case_id=str(value["case_id"]),
+            query=str(value["query"]),
+            pack_ids=tuple(str(item) for item in value["pack_ids"]),
+            expected_outcome=str(value["expected_outcome"]),
+            required_claim_ids=required,
+            allowed_claim_ids=allowed,
+            forbidden_claim_ids=frozenset(
+                str(item) for item in value.get("forbidden_claim_ids", [])
+            ),
+            required_citation_ids=frozenset(
+                str(item) for item in value.get("required_citation_ids", [])
+            ),
+            category=str(value.get("category", "general")),
+            limit=int(value.get("limit", 8)),
+        )
+
+    def __post_init__(self) -> None:
+        if not self.case_id or not self.query or not self.pack_ids:
+            raise ValueError("answer reliability cases require id/query/packs")
+        if self.expected_outcome not in ANSWER_OUTCOMES:
+            raise ValueError(f"invalid expected answer outcome: {self.expected_outcome}")
+        if self.limit < 1:
+            raise ValueError("answer reliability case limit must be positive")
+        if self.expected_outcome == "answer" and not self.required_claim_ids:
+            raise ValueError("answer cases require at least one required claim")
+
+
+def _documents_by_id(documents: Iterable[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {str(document["id"]): dict(document) for document in documents}
+
+
+def _canonical_citation(value: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    return {key: value.get(key) for key in _CITATION_KEYS}
+
+
+def _candidate_claims(candidate: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw = candidate.get("claims", [])
+    if not isinstance(raw, list):
+        return []
+    return [dict(item) for item in raw if isinstance(item, Mapping)]
+
+
+def evaluate_answer_candidate(
+    candidate: Mapping[str, Any],
+    *,
+    case: AnswerReliabilityCase,
+    documents: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    document_by_id = _documents_by_id(documents)
+    observed_outcome = str(candidate.get("outcome", "invalid"))
+    claims = _candidate_claims(candidate)
+    claim_ids = [str(item.get("claim_id", "")) for item in claims if item.get("claim_id")]
+    claim_id_set = set(claim_ids)
+
+    unsupported_ids = sorted(
+        {
+            identifier
+            for identifier in claim_id_set
+            if identifier not in case.allowed_claim_ids
+            or identifier not in document_by_id
+            or str(document_by_id[identifier].get("document_type", "")) != "claim"
+        }
+    )
+    forbidden_present = sorted(claim_id_set & set(case.forbidden_claim_ids))
+    required_present = set(case.required_claim_ids) <= claim_id_set
+    completeness = (
+        len(set(case.required_claim_ids) & claim_id_set) / len(case.required_claim_ids)
+        if case.required_claim_ids
+        else 1.0
+    )
+
+    citation_checks: list[dict[str, Any]] = []
+    observed_citation_ids: set[str] = set()
+    for claim in claims:
+        identifier = str(claim.get("claim_id", ""))
+        expected_document = document_by_id.get(identifier)
+        expected = _canonical_citation(
+            expected_document.get("citation") if expected_document else None
+        )
+        observed = _canonical_citation(claim.get("citation"))
+        if observed and observed.get("citation_id"):
+            observed_citation_ids.add(str(observed["citation_id"]))
+        exact = expected is not None and observed == expected
+        citation_checks.append(
+            {
+                "claim_id": identifier,
+                "expected_citation_id": (
+                    str(expected.get("citation_id")) if expected else None
+                ),
+                "observed_citation_id": (
+                    str(observed.get("citation_id")) if observed else None
+                ),
+                "exact_match": exact,
+            }
+        )
+
+    required_citations_present = set(case.required_citation_ids) <= observed_citation_ids
+    citation_correct = all(item["exact_match"] for item in citation_checks) and (
+        required_citations_present
+    )
+    if not claims and not case.required_citation_ids:
+        citation_correct = True
+
+    outcome_match = observed_outcome == case.expected_outcome
+    contradiction_handled = (
+        outcome_match and required_present and citation_correct
+        if case.expected_outcome == "conflicting_evidence"
+        else True
+    )
+    appropriate_abstention = (
+        outcome_match if case.expected_outcome != "answer" else None
+    )
+    overabstention = case.expected_outcome == "answer" and observed_outcome != "answer"
+
+    try:
+        confidence = float(candidate.get("confidence", 0.0))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    confidence = max(0.0, min(1.0, confidence))
+
+    case_correct = (
+        outcome_match
+        and required_present
+        and not unsupported_ids
+        and not forbidden_present
+        and citation_correct
+        and contradiction_handled
+    )
+    unsupported_rate = len(unsupported_ids) / max(len(claim_id_set), 1)
+
+    return {
+        "case_id": case.case_id,
+        "category": case.category,
+        "expected_outcome": case.expected_outcome,
+        "observed_outcome": observed_outcome,
+        "outcome_match": outcome_match,
+        "required_claim_ids": sorted(case.required_claim_ids),
+        "observed_claim_ids": claim_ids,
+        "unsupported_claim_ids": unsupported_ids,
+        "unsupported_claim_rate": unsupported_rate,
+        "forbidden_claim_ids_present": forbidden_present,
+        "completeness": completeness,
+        "citation_checks": citation_checks,
+        "required_citation_ids": sorted(case.required_citation_ids),
+        "required_citations_present": required_citations_present,
+        "citation_correct": citation_correct,
+        "contradiction_handled": contradiction_handled,
+        "appropriate_abstention": appropriate_abstention,
+        "overabstention": overabstention,
+        "confidence": confidence,
+        "case_correct": case_correct,
+    }

--- a/src/fossil_core/poisoning_eval.py
+++ b/src/fossil_core/poisoning_eval.py
@@ -5,7 +5,8 @@ import time
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping
 
-from .answer_eval import AnswerReliabilityCase, build_answer_context, evaluate_answer_candidate
+from .answer_eval import build_answer_context
+from .application.evaluation.answer import AnswerReliabilityCase, evaluate_answer_candidate
 from .application.query.poisoning_eval import (
     RetrievalPoisoningCase,
     run_retrieval_poisoning_benchmark,

--- a/tests/test_answer_evaluation_application_compatibility.py
+++ b/tests/test_answer_evaluation_application_compatibility.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import inspect
+
+import fossil_core.answer_eval as legacy_answer_eval
+import fossil_core.application.evaluation.answer as canonical_answer_eval
+
+
+EXPECTED_IMPLICIT_NAMESPACE = {
+    "ANSWER_OUTCOMES",
+    "AnswerReliabilityCase",
+    "Any",
+    "BM25Retriever",
+    "CURRENT_STATES",
+    "DeterministicEvidenceAnswerService",
+    "HISTORICAL_STATES",
+    "Iterable",
+    "LIVE_CONFLICT_STATES",
+    "LifecycleIntentReranker",
+    "Mapping",
+    "RerankedRetriever",
+    "ServiceMetadata",
+    "UNRESOLVED_STATES",
+    "annotations",
+    "build_answer_context",
+    "dataclass",
+    "evaluate_answer_candidate",
+    "run_answer_reliability_benchmark",
+    "time",
+    "tokenize",
+}
+
+
+def test_answer_eval_legacy_namespace_and_moved_identity_are_frozen():
+    assert not hasattr(legacy_answer_eval, "__all__")
+    assert {
+        name for name in vars(legacy_answer_eval) if not name.startswith("_")
+    } == EXPECTED_IMPLICIT_NAMESPACE
+
+    assert legacy_answer_eval.ANSWER_OUTCOMES is canonical_answer_eval.ANSWER_OUTCOMES
+    assert legacy_answer_eval.AnswerReliabilityCase is canonical_answer_eval.AnswerReliabilityCase
+    assert legacy_answer_eval.evaluate_answer_candidate is canonical_answer_eval.evaluate_answer_candidate
+    assert legacy_answer_eval._CITATION_KEYS is canonical_answer_eval._CITATION_KEYS
+    assert legacy_answer_eval._documents_by_id is canonical_answer_eval._documents_by_id
+    assert legacy_answer_eval._canonical_citation is canonical_answer_eval._canonical_citation
+    assert legacy_answer_eval._candidate_claims is canonical_answer_eval._candidate_claims
+
+
+def test_answer_evaluation_call_shapes_are_unchanged():
+    from_mapping = list(
+        inspect.signature(canonical_answer_eval.AnswerReliabilityCase.from_mapping).parameters.values()
+    )
+    assert [parameter.name for parameter in from_mapping] == ["value"]
+
+    evaluation = list(
+        inspect.signature(canonical_answer_eval.evaluate_answer_candidate).parameters.values()
+    )
+    assert [parameter.name for parameter in evaluation] == ["candidate", "case", "documents"]
+    assert evaluation[0].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert evaluation[1].kind is inspect.Parameter.KEYWORD_ONLY
+    assert evaluation[2].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+def test_answer_candidate_evaluation_behavior_matches_legacy_path():
+    citation = {
+        "schema_version": "fossil.citation.v1",
+        "citation_id": "cite_one",
+        "snapshot_id": "snap_one",
+        "artifact_id": "artifact_one",
+        "byte_start": 0,
+        "byte_end": 4,
+        "passage_hash": {"algorithm": "sha256", "digest": "abc"},
+    }
+    documents = [
+        {
+            "id": "claim_one",
+            "document_type": "claim",
+            "text": "supported claim",
+            "citation": citation,
+        },
+        {
+            "id": "claim_forbidden",
+            "document_type": "claim",
+            "text": "forbidden claim",
+            "citation": citation,
+        },
+    ]
+    case = canonical_answer_eval.AnswerReliabilityCase(
+        case_id="case_one",
+        query="what is supported",
+        pack_ids=("pack_one",),
+        expected_outcome="answer",
+        required_claim_ids=frozenset({"claim_one"}),
+        allowed_claim_ids=frozenset({"claim_one"}),
+        forbidden_claim_ids=frozenset({"claim_forbidden"}),
+        required_citation_ids=frozenset({"cite_one"}),
+    )
+    candidate = {
+        "outcome": "answer",
+        "claims": [
+            {
+                "claim_id": "claim_one",
+                "text": "supported claim",
+                "citation": citation,
+            }
+        ],
+        "confidence": 1.5,
+    }
+
+    canonical = canonical_answer_eval.evaluate_answer_candidate(
+        candidate,
+        case=case,
+        documents=documents,
+    )
+    legacy = legacy_answer_eval.evaluate_answer_candidate(
+        candidate,
+        case=case,
+        documents=documents,
+    )
+    assert legacy == canonical
+    assert canonical["case_correct"] is True
+    assert canonical["citation_correct"] is True
+    assert canonical["completeness"] == 1.0
+    assert canonical["unsupported_claim_rate"] == 0.0
+    assert canonical["confidence"] == 1.0
+
+
+def test_answer_candidate_failure_classification_is_preserved():
+    documents = [
+        {"id": "claim_one", "document_type": "claim", "text": "supported"},
+        {"id": "claim_forbidden", "document_type": "claim", "text": "forbidden"},
+    ]
+    case = canonical_answer_eval.AnswerReliabilityCase(
+        case_id="case_two",
+        query="what is supported",
+        pack_ids=("pack_one",),
+        expected_outcome="answer",
+        required_claim_ids=frozenset({"claim_one"}),
+        allowed_claim_ids=frozenset({"claim_one"}),
+        forbidden_claim_ids=frozenset({"claim_forbidden"}),
+    )
+    candidate = {
+        "outcome": "insufficient_evidence",
+        "claims": [{"claim_id": "claim_forbidden"}],
+        "confidence": "not-a-number",
+    }
+
+    result = canonical_answer_eval.evaluate_answer_candidate(
+        candidate,
+        case=case,
+        documents=documents,
+    )
+    assert result["case_correct"] is False
+    assert result["outcome_match"] is False
+    assert result["forbidden_claim_ids_present"] == ["claim_forbidden"]
+    assert result["unsupported_claim_ids"] == ["claim_forbidden"]
+    assert result["overabstention"] is True
+    assert result["confidence"] == 0.0


### PR DESCRIPTION
Issue #82 Phase 4 bounded slice.

Extracts only the provider-neutral answer-reliability case definition and answer-candidate evaluation/citation-checking responsibility from `fossil_core.answer_eval` into `fossil_core.application.evaluation.answer`.

Behavior freeze / compatibility:
- `ANSWER_OUTCOMES`, `AnswerReliabilityCase`, citation canonicalization helpers, and `evaluate_answer_candidate` move without semantic changes
- `fossil_core.answer_eval` keeps the historical public namespace and moved symbols as the same canonical objects; its deterministic answer generation, retrieval/context assembly, benchmark metrics/orchestration, lifecycle policy use, and `ServiceMetadata` use remain in place
- `fossil_core.poisoning_eval` uses the canonical case/evaluator while retaining `build_answer_context` from the legacy orchestration module
- dedicated compatibility tests freeze legacy implicit namespace, moved public/private identity, call shapes, successful citation evaluation, confidence clamping, and failure classification
- architecture CI requires `application.evaluation.answer`
- internal-by-default: no Python public-API contract promotion or package re-export

Exact-head evidence on `ca570fb76bff3b06c2caa99e8c769d1e91124885`:
- DKG contract tests `32065120425`: SUCCESS — 404 passed, 1 skipped, 1 existing legacy-`dkg` deprecation warning
- Dependency integrity `32065120421`: SUCCESS — architecture-boundaries, vulnerability-scan, and pyproject-consistency all passed

Non-goals: no deterministic answer/model behavior, retrieval/ranking/context policy, benchmark metrics, LiteLLM gateway/model work, Cortex V5 work, event/schema/ID/hash, storage/provider/projection, or acceptance changes.