### PR TITLE
[ARCH-P4] Move engineering assurance behind application/engineering

### DIFF
--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -12,6 +12,7 @@ PACKAGE = "fossil_core"
 CANONICAL_MODULES = {
     "fossil_core.application",
     "fossil_core.application.engineering",
+    "fossil_core.application.engineering.assurance",
     "fossil_core.application.engineering.preflight",
     "fossil_core.application.evaluation",
     "fossil_core.application.evaluation.answer",
@@ -62,6 +63,7 @@ COMPATIBILITY_IMPORTS = {
     "fossil_core.benchmark": {"fossil_core.application.evaluation.benchmark"},
     "fossil_core.benchmark_cases": {"fossil_core.application.evaluation.cases"},
     "fossil_core.contracts": {"fossil_core.ports"},
+    "fossil_core.engineering_assurance": {"fossil_core.application.engineering.assurance"},
     "fossil_core.engineering_preflight": {"fossil_core.application.engineering.preflight"},
     "fossil_core.ids": {"fossil_core.domain.identity"},
     "fossil_core.io": {"fossil_core.adapters.filesystem.io"},

--- a/src/fossil_core/application/engineering/assurance.py
+++ b/src/fossil_core/application/engineering/assurance.py
@@ -1,0 +1,80 @@
+"""Small deterministic assurance checks for engineering contracts.
+
+These helpers intentionally validate a bounded semantic surface. They do not
+turn a 2xx response, a process exit, or a workflow success into product truth.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+
+CONTROL_PLANE_VERSION = "control-plane-contract-v1"
+REQUIRED_CORRELATION_FIELDS = (
+    "project_issue_id",
+    "work_order_id",
+    "task_id",
+    "attempt_id",
+    "generation",
+    "request_id",
+    "trace_id",
+    "checkpoint_id",
+    "commit_sha",
+    "deployment_id",
+)
+
+
+def semantic_http_errors(*, status_code: int, body: bytes, expected: str = "json") -> list[str]:
+    """Reject transport-only success when the requested semantic payload is absent."""
+    errors: list[str] = []
+    if not 200 <= status_code < 300:
+        errors.append("non-success HTTP status")
+        return errors
+    if not body:
+        return ["2xx response has an empty body"]
+    if expected == "json":
+        try:
+            parsed = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return ["2xx response has malformed JSON"]
+        if not isinstance(parsed, Mapping) or not parsed:
+            return ["2xx response has no usable JSON object"]
+    elif expected == "stream" and not body.strip():
+        return ["completed stream has zero usable payload"]
+    elif expected not in {"json", "stream", "bytes"}:
+        return [f"unsupported semantic expectation: {expected}"]
+    return errors
+
+
+def validate_control_plane_contract(contract: Mapping[str, Any]) -> list[str]:
+    """Validate the small, versioned FOSSIL/Cortex/LiteLLM compatibility seam."""
+    errors: list[str] = []
+    if contract.get("version") != CONTROL_PLANE_VERSION:
+        errors.append("unsupported control-plane contract version")
+    owners = contract.get("owners")
+    if not isinstance(owners, Mapping) or set(owners) != {"fossil", "cortex", "litellm_ckff_ops"}:
+        errors.append("control-plane owners must name fossil, cortex, and litellm_ckff_ops")
+    if contract.get("routing_policy_owner") != "caller":
+        errors.append("routing policy owner must remain caller")
+    shared = contract.get("shared_contracts")
+    required_shared = {
+        "build_context": "build-context-packet-v1",
+        "preflight": "preflight-v1",
+        "closeout": "closeout-v1",
+    }
+    if shared != required_shared:
+        errors.append("shared contract versions do not match v1 control-plane boundary")
+    if tuple(contract.get("correlation_fields", ())) != REQUIRED_CORRELATION_FIELDS:
+        errors.append("correlation fields do not match the shared receipt spine")
+    return errors
+
+
+def load_control_plane_contract(root: Path) -> dict[str, Any]:
+    path = root / "contracts" / "engineering" / "control-plane-contract-v1.json"
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("control-plane contract must be a JSON object")
+    return value

--- a/src/fossil_core/engineering_assurance.py
+++ b/src/fossil_core/engineering_assurance.py
@@ -1,80 +1,13 @@
-"""Small deterministic assurance checks for engineering contracts.
-
-These helpers intentionally validate a bounded semantic surface. They do not
-turn a 2xx response, a process exit, or a workflow success into product truth.
-"""
-
 from __future__ import annotations
 
-import json
-from collections.abc import Mapping
-from pathlib import Path
-from typing import Any
-
-
-CONTROL_PLANE_VERSION = "control-plane-contract-v1"
-REQUIRED_CORRELATION_FIELDS = (
-    "project_issue_id",
-    "work_order_id",
-    "task_id",
-    "attempt_id",
-    "generation",
-    "request_id",
-    "trace_id",
-    "checkpoint_id",
-    "commit_sha",
-    "deployment_id",
+from .application.engineering.assurance import (
+    Any,
+    CONTROL_PLANE_VERSION,
+    Mapping,
+    Path,
+    REQUIRED_CORRELATION_FIELDS,
+    json,
+    load_control_plane_contract,
+    semantic_http_errors,
+    validate_control_plane_contract,
 )
-
-
-def semantic_http_errors(*, status_code: int, body: bytes, expected: str = "json") -> list[str]:
-    """Reject transport-only success when the requested semantic payload is absent."""
-    errors: list[str] = []
-    if not 200 <= status_code < 300:
-        errors.append("non-success HTTP status")
-        return errors
-    if not body:
-        return ["2xx response has an empty body"]
-    if expected == "json":
-        try:
-            parsed = json.loads(body.decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError):
-            return ["2xx response has malformed JSON"]
-        if not isinstance(parsed, Mapping) or not parsed:
-            return ["2xx response has no usable JSON object"]
-    elif expected == "stream" and not body.strip():
-        return ["completed stream has zero usable payload"]
-    elif expected not in {"json", "stream", "bytes"}:
-        return [f"unsupported semantic expectation: {expected}"]
-    return errors
-
-
-def validate_control_plane_contract(contract: Mapping[str, Any]) -> list[str]:
-    """Validate the small, versioned FOSSIL/Cortex/LiteLLM compatibility seam."""
-    errors: list[str] = []
-    if contract.get("version") != CONTROL_PLANE_VERSION:
-        errors.append("unsupported control-plane contract version")
-    owners = contract.get("owners")
-    if not isinstance(owners, Mapping) or set(owners) != {"fossil", "cortex", "litellm_ckff_ops"}:
-        errors.append("control-plane owners must name fossil, cortex, and litellm_ckff_ops")
-    if contract.get("routing_policy_owner") != "caller":
-        errors.append("routing policy owner must remain caller")
-    shared = contract.get("shared_contracts")
-    required_shared = {
-        "build_context": "build-context-packet-v1",
-        "preflight": "preflight-v1",
-        "closeout": "closeout-v1",
-    }
-    if shared != required_shared:
-        errors.append("shared contract versions do not match v1 control-plane boundary")
-    if tuple(contract.get("correlation_fields", ())) != REQUIRED_CORRELATION_FIELDS:
-        errors.append("correlation fields do not match the shared receipt spine")
-    return errors
-
-
-def load_control_plane_contract(root: Path) -> dict[str, Any]:
-    path = root / "contracts" / "engineering" / "control-plane-contract-v1.json"
-    value = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(value, dict):
-        raise ValueError("control-plane contract must be a JSON object")
-    return value

--- a/tests/test_engineering_assurance.py
+++ b/tests/test_engineering_assurance.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from fossil_core.engineering_assurance import (
+from fossil_core.application.engineering.assurance import (
     load_control_plane_contract,
     semantic_http_errors,
     validate_control_plane_contract,

--- a/tests/test_engineering_assurance_application_compatibility.py
+++ b/tests/test_engineering_assurance_application_compatibility.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import fossil_core.application.engineering.assurance as canonical_assurance
+import fossil_core.engineering_assurance as legacy_assurance
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+EXPECTED_IMPLICIT_NAMESPACE = {
+    "Any",
+    "CONTROL_PLANE_VERSION",
+    "Mapping",
+    "Path",
+    "REQUIRED_CORRELATION_FIELDS",
+    "annotations",
+    "json",
+    "load_control_plane_contract",
+    "semantic_http_errors",
+    "validate_control_plane_contract",
+}
+
+SEMANTIC_SYMBOLS = (
+    "CONTROL_PLANE_VERSION",
+    "REQUIRED_CORRELATION_FIELDS",
+    "semantic_http_errors",
+    "validate_control_plane_contract",
+    "load_control_plane_contract",
+)
+
+
+def test_engineering_assurance_legacy_namespace_and_identity_are_frozen():
+    assert not hasattr(legacy_assurance, "__all__")
+    assert {
+        name for name in vars(legacy_assurance) if not name.startswith("_")
+    } == EXPECTED_IMPLICIT_NAMESPACE
+
+    for name in SEMANTIC_SYMBOLS:
+        assert getattr(legacy_assurance, name) is getattr(canonical_assurance, name)
+
+
+def test_engineering_assurance_call_shapes_are_unchanged():
+    semantic = list(
+        inspect.signature(canonical_assurance.semantic_http_errors).parameters.values()
+    )
+    assert [parameter.name for parameter in semantic] == ["status_code", "body", "expected"]
+    assert all(parameter.kind is inspect.Parameter.KEYWORD_ONLY for parameter in semantic)
+    assert semantic[2].default == "json"
+
+    validate = list(
+        inspect.signature(canonical_assurance.validate_control_plane_contract).parameters.values()
+    )
+    assert [parameter.name for parameter in validate] == ["contract"]
+    assert validate[0].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+
+    load = list(
+        inspect.signature(canonical_assurance.load_control_plane_contract).parameters.values()
+    )
+    assert [parameter.name for parameter in load] == ["root"]
+    assert load[0].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+
+
+def test_engineering_assurance_representative_behavior_matches_legacy_path():
+    samples = (
+        {"status_code": 200, "body": b""},
+        {"status_code": 200, "body": b"{"},
+        {"status_code": 200, "body": b'{"ok":true}'},
+        {"status_code": 503, "body": b"unavailable"},
+    )
+    for sample in samples:
+        assert legacy_assurance.semantic_http_errors(**sample) == canonical_assurance.semantic_http_errors(**sample)
+
+    canonical_contract = canonical_assurance.load_control_plane_contract(ROOT)
+    legacy_contract = legacy_assurance.load_control_plane_contract(ROOT)
+    assert legacy_contract == canonical_contract
+    assert legacy_assurance.validate_control_plane_contract(legacy_contract) == canonical_assurance.validate_control_plane_contract(canonical_contract) == []


### PR DESCRIPTION
## Scope

Issue #82 Phase 4 modularization: move one bounded responsibility only.

- make `fossil_core.application.engineering.assurance` the canonical implementation
- keep `fossil_core.engineering_assurance` as a thin compatibility import surface
- freeze legacy implicit namespace, semantic symbol identity, signatures, and representative behavior
- declare the canonical/compatibility relationship in the architecture boundary checker
- point the existing assurance tests at the canonical path

## Behavior / policy freeze

No control-plane contract or workflow semantics change. No model/routing/retrieval/context policy change. No storage, projection, event, schema, stable-ID, or hash semantics change. No LiteLLM/CKFF or Cortex V5 change. No acceptance weakening.

The implementation body is relocated without semantic edits; the existing flat path remains compatible.

## Validation

Hosted exact-head gates are authoritative for this connector-only lane. Before merge I will re-fetch the exact PR head, CI, submitted reviews and review threads, current `main`, dependencies, and Issue #94, then use a SHA-fenced squash merge only if all required gates are green.

Refs #82