### PR TITLE
[P1] Wire pack-scoped retrieval and context through CorpusService

### DIFF
--- a/schemas/agent-skill/v1.schema.json
+++ b/schemas/agent-skill/v1.schema.json
@@ -29,7 +29,7 @@
       "minItems": 1,
       "uniqueItems": true,
       "items": {
-        "enum": ["search", "read", "lineage", "propose", "validate", "commit", "manage"]
+        "enum": ["search", "context", "read", "lineage", "propose", "validate", "commit", "manage"]
       }
     },
     "triggers": {

--- a/skills/corpus-search/SKILL.md
+++ b/skills/corpus-search/SKILL.md
@@ -2,9 +2,9 @@
 
 Load this methodology only when the task requires finding or reconstructing corpus knowledge.
 
-1. Search only packs mounted for the caller.
+1. Search and build context only from packs mounted for the caller; an explicit context request may narrow that scope but may never widen it.
 2. Return stable FOSSIL IDs, pack IDs, event types, dates, and evidence/source refs before projection-native details.
 3. Prefer durable source evidence and lineage over generated summaries when answering historical questions.
 4. Distinguish current state from historical state and preserve disagreement.
 5. Follow lineage/citations back to immutable evidence when a conclusion matters.
-6. Never treat a graph-native node/edge UUID or model consensus as canonical evidence.
+6. Never treat a graph-native node/edge UUID, retrieval/reranker score, or model consensus as canonical evidence.

--- a/skills/corpus-search/manifest.json
+++ b/skills/corpus-search/manifest.json
@@ -5,7 +5,7 @@
   "name": "Corpus search",
   "summary": "Find durable FOSSIL knowledge across readable packs while preserving stable IDs and provenance.",
   "methodology_ref": "SKILL.md",
-  "capabilities": ["search", "read", "lineage"],
+  "capabilities": ["search", "context", "read", "lineage"],
   "triggers": ["search", "find", "locate", "what do we know", "history", "lineage"],
-  "risk_notes": "Search results are evidence pointers and corpus state, not permission to mutate graph storage."
+  "risk_notes": "Search and context results are evidence pointers and corpus state, not permission to mutate graph storage."
 }

--- a/src/fossil_core/agent.py
+++ b/src/fossil_core/agent.py
@@ -9,7 +9,7 @@ from typing import Any, Mapping
 from jsonschema import Draft202012Validator, FormatChecker
 
 from fossil_core.event_store import DurableEventStore
-from fossil_core.pack import PackAccess
+from fossil_core.pack import PackAccess, PackBoundaryError
 from fossil_core.promotion import build_promotion_event
 
 
@@ -127,7 +127,16 @@ class CorpusService:
     knowledge mutation. Projection workers operate downstream of accepted events.
     """
 
-    CAPABILITIES = ("search", "read", "lineage", "propose", "validate", "commit", "manage")
+    CAPABILITIES = (
+        "search",
+        "context",
+        "read",
+        "lineage",
+        "propose",
+        "validate",
+        "commit",
+        "manage",
+    )
 
     def __init__(
         self,
@@ -135,11 +144,15 @@ class CorpusService:
         event_store: DurableEventStore,
         skills: SkillRegistry,
         lineages: Mapping[str, tuple[str, Any]] | None = None,
+        retriever: Any | None = None,
+        context_provider: Any | None = None,
         service_version: str = "1",
     ):
         self.event_store = event_store
         self.skills = skills
         self.lineages = dict(lineages or {})
+        self.retriever = retriever
+        self.context_provider = context_provider
         self.service_version = service_version
 
     def _authorize(self, context: AgentContext, capability: str) -> dict[str, Any]:
@@ -158,6 +171,32 @@ class CorpusService:
                 "agent event actor/model/harness/skill provenance does not match session context"
             )
 
+    @staticmethod
+    def _authorized_pack_ids(requested: Any, *, access: PackAccess) -> list[str]:
+        if requested is None:
+            return sorted(access.read_mounts)
+        if not isinstance(requested, (list, tuple, set, frozenset)):
+            raise TypeError("pack_ids must be a sequence of pack IDs")
+        pack_ids = list(dict.fromkeys(str(item) for item in requested if str(item)))
+        if not pack_ids:
+            raise ValueError("pack_ids must contain at least one readable pack")
+        for pack_id in pack_ids:
+            access.require_read(pack_id)
+        return pack_ids
+
+    @staticmethod
+    def _require_result_scope(
+        items: list[dict[str, Any]], *, allowed_pack_ids: set[str]
+    ) -> None:
+        for item in items:
+            pack_id = str(item.get("pack_id") or "")
+            if not pack_id:
+                raise PackBoundaryError("retrieval result is missing pack_id")
+            if pack_id not in allowed_pack_ids:
+                raise PackBoundaryError(
+                    f"retrieval result from unmounted pack {pack_id} crossed query boundary"
+                )
+
     def search(
         self,
         query: str,
@@ -169,6 +208,16 @@ class CorpusService:
         self._authorize(context, "search")
         if limit < 1 or limit > 100:
             raise ValueError("search limit must be between 1 and 100")
+
+        if self.retriever is not None:
+            pack_ids = sorted(access.read_mounts)
+            results = [
+                copy.deepcopy(dict(item))
+                for item in self.retriever.search(query, pack_ids=pack_ids, limit=limit)
+            ]
+            self._require_result_scope(results, allowed_pack_ids=set(pack_ids))
+            return results[:limit]
+
         needle = query.lower().strip()
         results: list[dict[str, Any]] = []
         for event in self.event_store.iter_events():
@@ -191,6 +240,27 @@ class CorpusService:
             if len(results) >= limit:
                 break
         return results
+
+    def context(
+        self,
+        request: Mapping[str, Any],
+        *,
+        access: PackAccess,
+        context: AgentContext,
+    ) -> dict[str, Any]:
+        self._authorize(context, "context")
+        if self.context_provider is None:
+            raise CapabilityError("FOSSIL context provider is not configured")
+
+        safe_request = copy.deepcopy(dict(request))
+        pack_ids = self._authorized_pack_ids(safe_request.get("pack_ids"), access=access)
+        safe_request["pack_ids"] = pack_ids
+        result = copy.deepcopy(dict(self.context_provider.build_context(safe_request)))
+        items = [copy.deepcopy(dict(item)) for item in result.get("items", [])]
+        self._require_result_scope(items, allowed_pack_ids=set(pack_ids))
+        result["items"] = items
+        result["pack_ids"] = pack_ids
+        return result
 
     def read(
         self,

--- a/tests/test_agent_query_composition.py
+++ b/tests/test_agent_query_composition.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fossil_core.agent import AgentContext, CorpusService, SkillRegistry
+from fossil_core.event_store import DurableEventStore
+from fossil_core.pack import PackAccess, PackBoundaryError
+from fossil_core.services import BM25Retriever, BudgetedContextProvider
+
+COMMON = "pack_269099f7b2ba43b7a99b9427d64092de"
+PROJECT = "pack_f024177f89a5442db84171c3dd7f58e5"
+OTHER_PROJECT = "pack_other_project_fixture"
+
+
+def root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def registry() -> SkillRegistry:
+    return SkillRegistry(
+        root() / "skills", root() / "schemas" / "agent-skill" / "v1.schema.json"
+    )
+
+
+def store(tmp_path: Path) -> DurableEventStore:
+    return DurableEventStore(
+        tmp_path / "events", root() / "schemas" / "events" / "v1.schema.json"
+    )
+
+
+def project_access() -> PackAccess:
+    return PackAccess(
+        pack_id=PROJECT,
+        read_mounts=frozenset({COMMON, PROJECT}),
+        write_targets=frozenset({PROJECT}),
+    )
+
+
+def search_context() -> AgentContext:
+    return AgentContext(
+        actor_id="agent-query-composition-fixture",
+        model_id="fixture-model-v1",
+        harness_version="fixture-harness-v1",
+        skill_id="skill_corpus-search",
+        skill_version="1.0.0",
+    )
+
+
+def documents() -> list[dict]:
+    return [
+        {
+            "id": "doc_common",
+            "pack_id": COMMON,
+            "text": "lineage pack scoped retrieval evidence",
+            "current_state": "supported",
+        },
+        {
+            "id": "doc_project",
+            "pack_id": PROJECT,
+            "text": "project pack scoped retrieval evidence",
+            "current_state": "supported",
+        },
+        {
+            "id": "doc_other",
+            "pack_id": OTHER_PROJECT,
+            "text": "retrieval retrieval retrieval evidence from another project",
+            "current_state": "supported",
+        },
+    ]
+
+
+def test_rich_search_uses_only_project_read_mounts(tmp_path):
+    service = CorpusService(
+        event_store=store(tmp_path),
+        skills=registry(),
+        retriever=BM25Retriever(documents()),
+    )
+
+    results = service.search(
+        "retrieval evidence",
+        access=project_access(),
+        context=search_context(),
+        limit=10,
+    )
+
+    assert {item["id"] for item in results} == {"doc_common", "doc_project"}
+    assert {item["pack_id"] for item in results} == {COMMON, PROJECT}
+    assert OTHER_PROJECT not in {item["pack_id"] for item in results}
+
+
+def test_context_can_narrow_to_one_mounted_project_pack(tmp_path):
+    retriever = BM25Retriever(documents())
+    service = CorpusService(
+        event_store=store(tmp_path),
+        skills=registry(),
+        retriever=retriever,
+        context_provider=BudgetedContextProvider(retriever, max_chars=2_000),
+    )
+
+    result = service.context(
+        {
+            "query": "retrieval evidence",
+            "pack_ids": [PROJECT],
+            "limit": 10,
+        },
+        access=project_access(),
+        context=search_context(),
+    )
+
+    assert result["pack_ids"] == [PROJECT]
+    assert [item["id"] for item in result["items"]] == ["doc_project"]
+    assert {item["pack_id"] for item in result["items"]} == {PROJECT}
+
+
+def test_context_rejects_unmounted_project_pack_before_provider_call(tmp_path):
+    retriever = BM25Retriever(documents())
+    service = CorpusService(
+        event_store=store(tmp_path),
+        skills=registry(),
+        context_provider=BudgetedContextProvider(retriever, max_chars=2_000),
+    )
+
+    with pytest.raises(PackBoundaryError, match="not mounted for reading"):
+        service.context(
+            {
+                "query": "retrieval evidence",
+                "pack_ids": [OTHER_PROJECT],
+                "limit": 10,
+            },
+            access=project_access(),
+            context=search_context(),
+        )
+
+
+class LeakyRetriever:
+    def search(self, query: str, *, pack_ids: list[str], limit: int = 20):
+        del query, pack_ids, limit
+        return [
+            {
+                "id": "doc_leaked",
+                "pack_id": OTHER_PROJECT,
+                "text": "leaked foreign project knowledge",
+            }
+        ]
+
+
+def test_agent_boundary_fails_closed_if_retriever_ignores_pack_scope(tmp_path):
+    service = CorpusService(
+        event_store=store(tmp_path),
+        skills=registry(),
+        retriever=LeakyRetriever(),
+    )
+
+    with pytest.raises(PackBoundaryError, match="crossed query boundary"):
+        service.search(
+            "leaked",
+            access=project_access(),
+            context=search_context(),
+        )
+
+
+class LeakyContextProvider:
+    def build_context(self, request: dict):
+        return {
+            "query": request["query"],
+            "pack_ids": request["pack_ids"],
+            "items": [
+                {
+                    "id": "doc_leaked_context",
+                    "pack_id": OTHER_PROJECT,
+                    "text": "leaked context from another project",
+                }
+            ],
+            "context_text": "leaked context from another project",
+        }
+
+
+def test_agent_boundary_fails_closed_if_context_provider_widens_scope(tmp_path):
+    service = CorpusService(
+        event_store=store(tmp_path),
+        skills=registry(),
+        context_provider=LeakyContextProvider(),
+    )
+
+    with pytest.raises(PackBoundaryError, match="crossed query boundary"):
+        service.context(
+            {"query": "leaked", "pack_ids": [PROJECT]},
+            access=project_access(),
+            context=search_context(),
+        )


### PR DESCRIPTION
Tracking: #174

## Problem

FOSSIL already has richer Retriever and ContextProvider implementations, but the agent-facing CorpusService search path still used only the simple durable-event scan. The composed boundary therefore did not yet prove that rich retrieval/context remains constrained to each project's mounted knowledge packs.

## Changes

- allow CorpusService to receive an existing Retriever and ContextProvider
- force rich search to use only the caller's PackAccess.read_mounts
- add `context` as a corpus-search capability
- allow context requests to narrow mounted packs but never widen them
- independently validate returned search/context items and fail closed if a provider leaks an unmounted pack
- preserve the existing durable-event search as the compatibility fallback when no Retriever is configured
- add composition tests using BM25Retriever + BudgetedContextProvider plus deliberately leaky providers

## Pack ownership preserved

`common/* -> domain/* -> project/<project>` is a dependency/read relationship, not shared write authority. A project may read its mounted shared packs and writes remain controlled by `write_targets`; cross-pack promotion remains explicit.

## Acceptance evidence requested from CI

- project search sees project + explicitly mounted shared pack
- stronger matching unmounted project is absent
- explicit context scope can narrow to the project pack
- unmounted context request fails before provider execution
- malicious/misconfigured retriever or context provider that widens scope fails closed
- existing agent-boundary and corpus tests remain green

Docs-Impact: updated `skills/corpus-search/SKILL.md` and capability manifest/schema to make the context/pack boundary explicit. No durable storage/event/schema/stable-ID, D021 ranking policy, graph authority, Cortex runtime, or provider-routing semantics changed.