### PR TITLE
[P1][ASSURANCE] Reconcile pack-scoped query composition and property oracle

### DIFF
--- a/contracts/properties/fossil-properties-v1.json
+++ b/contracts/properties/fossil-properties-v1.json
@@ -88,14 +88,14 @@
       "semantic_owner": "pack access / agent query boundary",
       "modules": ["src/fossil_core/domain/pack.py", "src/fossil_core/agent.py", "src/fossil_core/application/query/security.py"],
       "deterministic_oracles": ["tests/test_pack.py", "tests/test_agent_boundary.py", "tests/test_context_security.py"],
-      "property_oracles": ["tests/test_pack_properties.py"],
+      "property_oracles": ["tests/test_agent_query_composition_properties.py", "tests/test_pack_properties.py"],
       "mutation_scope": ["src/fossil_core/domain/pack.py", "src/fossil_core/agent.py", "src/fossil_core/application/query/security.py"],
       "tla_refs": [],
       "lean_refs": ["formal/lean/Fossil/PackAccess.lean"],
       "hidden_acceptance_required": true,
       "status": "active",
       "source_refs": ["ARCHITECTURE.md"],
-      "notes": "PR #175 adds stronger composed retrieval/context scope oracles; catalog remains valid before that draft is merged."
+      "notes": "Composed rich retrieval/context scope is exercised through the agent-facing CorpusService boundary; provider leakage fails closed."
     },
     {
       "property_id": "FOSSIL-PROP-PACK-MANIFEST-001",
@@ -231,7 +231,7 @@
       "semantic_owner": "application query security",
       "modules": ["src/fossil_core/application/query/security.py", "src/fossil_core/agent.py"],
       "deterministic_oracles": ["tests/test_context_security.py", "tests/test_agent_boundary.py"],
-      "property_oracles": [],
+      "property_oracles": ["tests/test_agent_query_composition_properties.py"],
       "mutation_scope": ["src/fossil_core/application/query/security.py", "src/fossil_core/agent.py"],
       "tla_refs": [],
       "lean_refs": [],

--- a/schemas/agent-skill/v1.schema.json
+++ b/schemas/agent-skill/v1.schema.json
@@ -29,7 +29,7 @@
       "minItems": 1,
       "uniqueItems": true,
       "items": {
-        "enum": ["search", "read", "lineage", "propose", "validate", "commit", "manage"]
+        "enum": ["search", "context", "read", "lineage", "propose", "validate", "commit", "manage"]
       }
     },
     "triggers": {

--- a/skills/corpus-search/SKILL.md
+++ b/skills/corpus-search/SKILL.md
@@ -2,9 +2,9 @@
 
 Load this methodology only when the task requires finding or reconstructing corpus knowledge.
 
-1. Search only packs mounted for the caller.
+1. Search and build context only from packs mounted for the caller; an explicit context request may narrow that scope but may never widen it.
 2. Return stable FOSSIL IDs, pack IDs, event types, dates, and evidence/source refs before projection-native details.
 3. Prefer durable source evidence and lineage over generated summaries when answering historical questions.
 4. Distinguish current state from historical state and preserve disagreement.
 5. Follow lineage/citations back to immutable evidence when a conclusion matters.
-6. Never treat a graph-native node/edge UUID or model consensus as canonical evidence.
+6. Never treat a graph-native node/edge UUID, retrieval/reranker score, or model consensus as canonical evidence.

--- a/skills/corpus-search/manifest.json
+++ b/skills/corpus-search/manifest.json
@@ -5,7 +5,7 @@
   "name": "Corpus search",
   "summary": "Find durable FOSSIL knowledge across readable packs while preserving stable IDs and provenance.",
   "methodology_ref": "SKILL.md",
-  "capabilities": ["search", "read", "lineage"],
+  "capabilities": ["search", "context", "read", "lineage"],
   "triggers": ["search", "find", "locate", "what do we know", "history", "lineage"],
-  "risk_notes": "Search results are evidence pointers and corpus state, not permission to mutate graph storage."
+  "risk_notes": "Search and context results are evidence pointers and corpus state, not permission to mutate graph storage."
 }

--- a/src/fossil_core/agent.py
+++ b/src/fossil_core/agent.py
@@ -9,7 +9,7 @@ from typing import Any, Mapping
 from jsonschema import Draft202012Validator, FormatChecker
 
 from fossil_core.event_store import DurableEventStore
-from fossil_core.pack import PackAccess
+from fossil_core.pack import PackAccess, PackBoundaryError
 from fossil_core.promotion import build_promotion_event
 
 
@@ -127,7 +127,16 @@ class CorpusService:
     knowledge mutation. Projection workers operate downstream of accepted events.
     """
 
-    CAPABILITIES = ("search", "read", "lineage", "propose", "validate", "commit", "manage")
+    CAPABILITIES = (
+        "search",
+        "context",
+        "read",
+        "lineage",
+        "propose",
+        "validate",
+        "commit",
+        "manage",
+    )
 
     def __init__(
         self,
@@ -135,11 +144,15 @@ class CorpusService:
         event_store: DurableEventStore,
         skills: SkillRegistry,
         lineages: Mapping[str, tuple[str, Any]] | None = None,
+        retriever: Any | None = None,
+        context_provider: Any | None = None,
         service_version: str = "1",
     ):
         self.event_store = event_store
         self.skills = skills
         self.lineages = dict(lineages or {})
+        self.retriever = retriever
+        self.context_provider = context_provider
         self.service_version = service_version
 
     def _authorize(self, context: AgentContext, capability: str) -> dict[str, Any]:
@@ -158,6 +171,32 @@ class CorpusService:
                 "agent event actor/model/harness/skill provenance does not match session context"
             )
 
+    @staticmethod
+    def _authorized_pack_ids(requested: Any, *, access: PackAccess) -> list[str]:
+        if requested is None:
+            return sorted(access.read_mounts)
+        if not isinstance(requested, (list, tuple, set, frozenset)):
+            raise TypeError("pack_ids must be a sequence of pack IDs")
+        pack_ids = list(dict.fromkeys(str(item) for item in requested if str(item)))
+        if not pack_ids:
+            raise ValueError("pack_ids must contain at least one readable pack")
+        for pack_id in pack_ids:
+            access.require_read(pack_id)
+        return pack_ids
+
+    @staticmethod
+    def _require_result_scope(
+        items: list[dict[str, Any]], *, allowed_pack_ids: set[str]
+    ) -> None:
+        for item in items:
+            pack_id = str(item.get("pack_id") or "")
+            if not pack_id:
+                raise PackBoundaryError("retrieval result is missing pack_id")
+            if pack_id not in allowed_pack_ids:
+                raise PackBoundaryError(
+                    f"retrieval result from unmounted pack {pack_id} crossed query boundary"
+                )
+
     def search(
         self,
         query: str,
@@ -169,6 +208,16 @@ class CorpusService:
         self._authorize(context, "search")
         if limit < 1 or limit > 100:
             raise ValueError("search limit must be between 1 and 100")
+
+        if self.retriever is not None:
+            pack_ids = sorted(access.read_mounts)
+            results = [
+                copy.deepcopy(dict(item))
+                for item in self.retriever.search(query, pack_ids=pack_ids, limit=limit)
+            ]
+            self._require_result_scope(results, allowed_pack_ids=set(pack_ids))
+            return results[:limit]
+
         needle = query.lower().strip()
         results: list[dict[str, Any]] = []
         for event in self.event_store.iter_events():
@@ -191,6 +240,27 @@ class CorpusService:
             if len(results) >= limit:
                 break
         return results
+
+    def context(
+        self,
+        request: Mapping[str, Any],
+        *,
+        access: PackAccess,
+        context: AgentContext,
+    ) -> dict[str, Any]:
+        self._authorize(context, "context")
+        if self.context_provider is None:
+            raise CapabilityError("FOSSIL context provider is not configured")
+
+        safe_request = copy.deepcopy(dict(request))
+        pack_ids = self._authorized_pack_ids(safe_request.get("pack_ids"), access=access)
+        safe_request["pack_ids"] = pack_ids
+        result = copy.deepcopy(dict(self.context_provider.build_context(safe_request)))
+        items = [copy.deepcopy(dict(item)) for item in result.get("items", [])]
+        self._require_result_scope(items, allowed_pack_ids=set(pack_ids))
+        result["items"] = items
+        result["pack_ids"] = pack_ids
+        return result
 
     def read(
         self,

--- a/tests/test_agent_query_composition.py
+++ b/tests/test_agent_query_composition.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fossil_core.agent import AgentContext, CorpusService, SkillRegistry
+from fossil_core.event_store import DurableEventStore
+from fossil_core.pack import PackAccess, PackBoundaryError
+from fossil_core.services import BM25Retriever, BudgetedContextProvider
+
+COMMON = "pack_269099f7b2ba43b7a99b9427d64092de"
+PROJECT = "pack_f024177f89a5442db84171c3dd7f58e5"
+OTHER_PROJECT = "pack_other_project_fixture"
+
+
+def root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def registry() -> SkillRegistry:
+    return SkillRegistry(
+        root() / "skills", root() / "schemas" / "agent-skill" / "v1.schema.json"
+    )
+
+
+def store(tmp_path: Path) -> DurableEventStore:
+    return DurableEventStore(
+        tmp_path / "events", root() / "schemas" / "events" / "v1.schema.json"
+    )
+
+
+def project_access() -> PackAccess:
+    return PackAccess(
+        pack_id=PROJECT,
+        read_mounts=frozenset({COMMON, PROJECT}),
+        write_targets=frozenset({PROJECT}),
+    )
+
+
+def search_context() -> AgentContext:
+    return AgentContext(
+        actor_id="agent-query-composition-fixture",
+        model_id="fixture-model-v1",
+        harness_version="fixture-harness-v1",
+        skill_id="skill_corpus-search",
+        skill_version="1.0.0",
+    )
+
+
+def documents() -> list[dict]:
+    return [
+        {
+            "id": "doc_common",
+            "pack_id": COMMON,
+            "text": "lineage pack scoped retrieval evidence",
+            "current_state": "supported",
+        },
+        {
+            "id": "doc_project",
+            "pack_id": PROJECT,
+            "text": "project pack scoped retrieval evidence",
+            "current_state": "supported",
+        },
+        {
+            "id": "doc_other",
+            "pack_id": OTHER_PROJECT,
+            "text": "retrieval retrieval retrieval evidence from another project",
+            "current_state": "supported",
+        },
+    ]
+
+
+def test_rich_search_uses_only_project_read_mounts(tmp_path):
+    service = CorpusService(
+        event_store=store(tmp_path),
+        skills=registry(),
+        retriever=BM25Retriever(documents()),
+    )
+
+    results = service.search(
+        "retrieval evidence",
+        access=project_access(),
+        context=search_context(),
+        limit=10,
+    )
+
+    assert {item["id"] for item in results} == {"doc_common", "doc_project"}
+    assert {item["pack_id"] for item in results} == {COMMON, PROJECT}
+    assert OTHER_PROJECT not in {item["pack_id"] for item in results}
+
+
+def test_context_can_narrow_to_one_mounted_project_pack(tmp_path):
+    retriever = BM25Retriever(documents())
+    service = CorpusService(
+        event_store=store(tmp_path),
+        skills=registry(),
+        retriever=retriever,
+        context_provider=BudgetedContextProvider(retriever, max_chars=2_000),
+    )
+
+    result = service.context(
+        {
+            "query": "retrieval evidence",
+            "pack_ids": [PROJECT],
+            "limit": 10,
+        },
+        access=project_access(),
+        context=search_context(),
+    )
+
+    assert result["pack_ids"] == [PROJECT]
+    assert [item["id"] for item in result["items"]] == ["doc_project"]
+    assert {item["pack_id"] for item in result["items"]} == {PROJECT}
+
+
+def test_context_rejects_unmounted_project_pack_before_provider_call(tmp_path):
+    retriever = BM25Retriever(documents())
+    service = CorpusService(
+        event_store=store(tmp_path),
+        skills=registry(),
+        context_provider=BudgetedContextProvider(retriever, max_chars=2_000),
+    )
+
+    with pytest.raises(PackBoundaryError, match="not mounted for reading"):
+        service.context(
+            {
+                "query": "retrieval evidence",
+                "pack_ids": [OTHER_PROJECT],
+                "limit": 10,
+            },
+            access=project_access(),
+            context=search_context(),
+        )
+
+
+class LeakyRetriever:
+    def search(self, query: str, *, pack_ids: list[str], limit: int = 20):
+        del query, pack_ids, limit
+        return [
+            {
+                "id": "doc_leaked",
+                "pack_id": OTHER_PROJECT,
+                "text": "leaked foreign project knowledge",
+            }
+        ]
+
+
+def test_agent_boundary_fails_closed_if_retriever_ignores_pack_scope(tmp_path):
+    service = CorpusService(
+        event_store=store(tmp_path),
+        skills=registry(),
+        retriever=LeakyRetriever(),
+    )
+
+    with pytest.raises(PackBoundaryError, match="crossed query boundary"):
+        service.search(
+            "leaked",
+            access=project_access(),
+            context=search_context(),
+        )
+
+
+class LeakyContextProvider:
+    def build_context(self, request: dict):
+        return {
+            "query": request["query"],
+            "pack_ids": request["pack_ids"],
+            "items": [
+                {
+                    "id": "doc_leaked_context",
+                    "pack_id": OTHER_PROJECT,
+                    "text": "leaked context from another project",
+                }
+            ],
+            "context_text": "leaked context from another project",
+        }
+
+
+def test_agent_boundary_fails_closed_if_context_provider_widens_scope(tmp_path):
+    service = CorpusService(
+        event_store=store(tmp_path),
+        skills=registry(),
+        context_provider=LeakyContextProvider(),
+    )
+
+    with pytest.raises(PackBoundaryError, match="crossed query boundary"):
+        service.context(
+            {"query": "leaked", "pack_ids": [PROJECT]},
+            access=project_access(),
+            context=search_context(),
+        )

--- a/tests/test_agent_query_composition_properties.py
+++ b/tests/test_agent_query_composition_properties.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import string
+
+import pytest
+from hypothesis import given, settings, strategies as st
+
+from fossil_core.agent import AgentContext, CorpusService
+from fossil_core.pack import PackAccess, PackBoundaryError
+
+
+PACK_ID = st.text(
+    alphabet=string.ascii_lowercase + string.digits,
+    min_size=16,
+    max_size=24,
+).map(lambda suffix: f"pack_{suffix}")
+
+
+class AllowingSkills:
+    def require_capability(self, skill_id: str, capability: str) -> dict[str, str]:
+        assert skill_id == "skill_corpus-search"
+        assert capability in {"search", "context"}
+        return {"version": "1.0.0"}
+
+
+class RecordingRetriever:
+    def __init__(self, *, leak_pack_id: str | None = None):
+        self.leak_pack_id = leak_pack_id
+        self.seen_pack_ids: list[str] | None = None
+
+    def search(self, query: str, *, pack_ids: list[str], limit: int = 20):
+        del query, limit
+        self.seen_pack_ids = list(pack_ids)
+        results = [
+            {"id": f"doc_{index}", "pack_id": pack_id, "text": "generated scoped result"}
+            for index, pack_id in enumerate(pack_ids)
+        ]
+        if self.leak_pack_id is not None:
+            results.append(
+                {
+                    "id": "doc_leaked",
+                    "pack_id": self.leak_pack_id,
+                    "text": "generated leaked result",
+                }
+            )
+        return results
+
+
+class RecordingContextProvider:
+    def __init__(self, *, leak_pack_id: str | None = None):
+        self.leak_pack_id = leak_pack_id
+        self.requests: list[dict] = []
+
+    def build_context(self, request: dict):
+        self.requests.append(dict(request))
+        pack_ids = list(request["pack_ids"])
+        items = [
+            {"id": f"ctx_{index}", "pack_id": pack_id, "text": "generated scoped context"}
+            for index, pack_id in enumerate(pack_ids)
+        ]
+        if self.leak_pack_id is not None:
+            items.append(
+                {
+                    "id": "ctx_leaked",
+                    "pack_id": self.leak_pack_id,
+                    "text": "generated leaked context",
+                }
+            )
+        return {
+            "query": request.get("query", ""),
+            "items": items,
+            "context_text": "generated context",
+        }
+
+
+def agent_context() -> AgentContext:
+    return AgentContext(
+        actor_id="property-agent",
+        model_id="property-model",
+        harness_version="property-harness",
+        skill_id="skill_corpus-search",
+        skill_version="1.0.0",
+    )
+
+
+@st.composite
+def access_cases(draw):
+    mounts = draw(st.lists(PACK_ID, min_size=1, max_size=5, unique=True))
+    mounted = frozenset(mounts)
+    unmounted = draw(PACK_ID.filter(lambda pack_id: pack_id not in mounted))
+    requested = draw(
+        st.sets(st.sampled_from(mounts), min_size=1, max_size=len(mounts))
+    )
+    return mounted, unmounted, frozenset(requested)
+
+
+def service(*, retriever=None, context_provider=None) -> CorpusService:
+    return CorpusService(
+        event_store=object(),
+        skills=AllowingSkills(),
+        retriever=retriever,
+        context_provider=context_provider,
+    )
+
+
+@settings(max_examples=150, derandomize=True)
+@given(case=access_cases())
+def test_rich_search_scope_is_exactly_the_read_mount_set(case) -> None:
+    mounts, unmounted, _requested = case
+    access = PackAccess(
+        pack_id=sorted(mounts)[0],
+        read_mounts=mounts,
+        write_targets=frozenset(),
+    )
+    retriever = RecordingRetriever()
+
+    results = service(retriever=retriever).search(
+        "generated query",
+        access=access,
+        context=agent_context(),
+        limit=100,
+    )
+
+    assert retriever.seen_pack_ids == sorted(mounts)
+    assert {item["pack_id"] for item in results} == set(mounts)
+
+    leaky = RecordingRetriever(leak_pack_id=unmounted)
+    with pytest.raises(PackBoundaryError, match="crossed query boundary"):
+        service(retriever=leaky).search(
+            "generated query",
+            access=access,
+            context=agent_context(),
+            limit=100,
+        )
+
+
+@settings(max_examples=150, derandomize=True)
+@given(case=access_cases())
+def test_context_scope_can_narrow_but_never_widen(case) -> None:
+    mounts, unmounted, requested = case
+    access = PackAccess(
+        pack_id=sorted(mounts)[0],
+        read_mounts=mounts,
+        write_targets=frozenset(),
+    )
+    provider = RecordingContextProvider()
+    requested_list = sorted(requested)
+
+    result = service(context_provider=provider).context(
+        {"query": "generated query", "pack_ids": requested_list},
+        access=access,
+        context=agent_context(),
+    )
+
+    assert provider.requests[-1]["pack_ids"] == requested_list
+    assert result["pack_ids"] == requested_list
+    assert {item["pack_id"] for item in result["items"]} == set(requested)
+    assert set(result["pack_ids"]) <= set(mounts)
+
+    before = len(provider.requests)
+    with pytest.raises(PackBoundaryError, match="not mounted for reading"):
+        service(context_provider=provider).context(
+            {"query": "generated query", "pack_ids": [unmounted]},
+            access=access,
+            context=agent_context(),
+        )
+    assert len(provider.requests) == before
+
+    leaky = RecordingContextProvider(leak_pack_id=unmounted)
+    with pytest.raises(PackBoundaryError, match="crossed query boundary"):
+        service(context_provider=leaky).context(
+            {"query": "generated query", "pack_ids": requested_list},
+            access=access,
+            context=agent_context(),
+        )
+
+
+@settings(max_examples=100, derandomize=True)
+@given(case=access_cases())
+def test_context_defaults_to_all_read_mounts_without_explicit_scope(case) -> None:
+    mounts, _unmounted, _requested = case
+    access = PackAccess(
+        pack_id=sorted(mounts)[0],
+        read_mounts=mounts,
+        write_targets=frozenset(),
+    )
+    provider = RecordingContextProvider()
+
+    result = service(context_provider=provider).context(
+        {"query": "generated query"},
+        access=access,
+        context=agent_context(),
+    )
+
+    assert provider.requests[-1]["pack_ids"] == sorted(mounts)
+    assert result["pack_ids"] == sorted(mounts)
+    assert {item["pack_id"] for item in result["items"]} == set(mounts)


### PR DESCRIPTION
Tracking: #174 #176
Coordination: #94
Replaces stale draft: #175

## Stage 1: exact runtime composition port

This branch ports the exact five file blobs from previously green draft PR #175 onto current `main` (`36be5728...`). None of those five paths changed between #175's base `8808b4d...` and current main, so this is a byte-identical semantic reconciliation rather than a hand-resolved rewrite.

Preserved behavior:
- rich search is forced to caller `PackAccess.read_mounts`
- context may narrow mounted pack scope but cannot widen it
- provider results are independently scope-validated and fail closed on leakage
- durable-event search remains the compatibility fallback when no Retriever is configured
- retrieval/reranker metadata remains candidate-ordering evidence, not semantic truth
- no Cortex, D021, storage/event/schema/stable-ID, graph/vector authority, or acceptance-policy changes

After this exact port passes hosted CI on current main, the deferred Phase 1 PDD composed pack/context property oracle will be added on this same bounded branch, followed by exact-head CI before merge.