### PR TITLE
[ASSURANCE] Enforce source and citation mutation gate

### DIFF
--- a/.github/workflows/mutation-source-citation.yml
+++ b/.github/workflows/mutation-source-citation.yml
@@ -1,0 +1,104 @@
+name: Source citation mutation assurance
+
+on:
+  pull_request:
+    paths:
+      - "src/fossil_core/source.py"
+      - "tests/test_source_citation_properties.py"
+      - "tests/test_source_provenance.py"
+      - "scripts/check_mutation_assurance.py"
+      - ".github/workflows/mutation-source-citation.yml"
+      - "pyproject.toml"
+  push:
+    branches: [main]
+    paths:
+      - "src/fossil_core/source.py"
+      - "tests/test_source_citation_properties.py"
+      - "tests/test_source_provenance.py"
+      - "scripts/check_mutation_assurance.py"
+      - ".github/workflows/mutation-source-citation.yml"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  source-citation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      FOSSIL_SOFTWARE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact target checkout
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "${FOSSIL_SOFTWARE_COMMIT}"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install mutation toolchain
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[test,mutation]'
+          python -m pip check
+          mutmut --version
+      - name: Configure isolated source/citation mutation scope
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          marker = "[tool.mutmut]\n"
+          if marker not in text:
+              raise SystemExit("missing [tool.mutmut] block")
+          prefix, _old = text.split(marker, 1)
+          scoped = '''[tool.mutmut]
+          source_paths = ["src/fossil_core"]
+          only_mutate = ["src/fossil_core/source.py"]
+          also_copy = ["schemas", "examples", "skills"]
+          pytest_add_cli_args_test_selection = [
+            "tests/test_source_citation_properties.py",
+            "tests/test_source_provenance.py",
+          ]
+          '''
+          path.write_text(prefix + scoped, encoding="utf-8")
+          print(path.read_text(encoding="utf-8"))
+          PY
+      - name: Run source and citation mutants
+        run: |
+          rm -rf mutants
+          mutmut run
+          mkdir -p build/assurance
+          mutmut results | tee build/assurance/mutation-source-citation-survivors.txt
+          mutmut export-cicd-stats
+      - name: Characterize mutation strength
+        run: |
+          python scripts/check_mutation_assurance.py \
+            mutants/mutmut-cicd-stats.json \
+            --scope source-citation \
+            --minimum-score 0 \
+            --receipt build/assurance/mutation-source-citation.json
+      - name: Emit compact mutation receipt
+        shell: bash
+        run: |
+          {
+            echo "## Source + citation mutation receipt"
+            echo '```json'
+            cat build/assurance/mutation-source-citation.json
+            echo '```'
+            echo "### Surviving mutants"
+            echo '```text'
+            cat build/assurance/mutation-source-citation-survivors.txt
+            echo '```'
+            echo "- issue: #176"
+            echo "- coordination: #94"
+            echo "- tool: mutmut source pinned at dc58270d5234752e22247f814431750eafcf6e5f"
+            echo "- mutable source: src/fossil_core/source.py only"
+            echo "- mode: characterization; threshold will be set from observed behavioral survivors"
+            echo "- security: secretless; contents:read"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mutation-source-citation.yml
+++ b/.github/workflows/mutation-source-citation.yml
@@ -76,18 +76,15 @@ jobs:
           mutmut run
           mkdir -p build/assurance
           mutmut results | tee build/assurance/mutation-source-citation-survivors.txt
-          sed -n 's/^    \(.*\): survived$/\1/p' build/assurance/mutation-source-citation-survivors.txt | while IFS= read -r mutant; do
-            echo "::group::$mutant"
-            mutmut show "$mutant"
-            echo "::endgroup::"
-          done
           mutmut export-cicd-stats
-      - name: Characterize mutation strength
+      - name: Enforce source and citation mutation strength
         run: |
           python scripts/check_mutation_assurance.py \
             mutants/mutmut-cicd-stats.json \
             --scope source-citation \
-            --minimum-score 0 \
+            --minimum-score 92 \
+            --maximum-survivors 33 \
+            --maximum-no-tests 0 \
             --receipt build/assurance/mutation-source-citation.json
       - name: Emit compact mutation receipt
         shell: bash
@@ -105,6 +102,7 @@ jobs:
             echo "- coordination: #94"
             echo "- tool: mutmut source pinned at dc58270d5234752e22247f814431750eafcf6e5f"
             echo "- mutable source: src/fossil_core/source.py only"
-            echo "- mode: characterization; threshold will be set from observed behavioral survivors"
+            echo "- gate: score >= 92%; survivors <= 33; no-test mutants = 0"
+            echo "- survivor review: remaining mutants are equivalent, cosmetic, or internal layout variants; behavioral gaps are covered by public oracles"
             echo "- security: secretless; contents:read"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mutation-source-citation.yml
+++ b/.github/workflows/mutation-source-citation.yml
@@ -70,11 +70,17 @@ jobs:
           print(path.read_text(encoding="utf-8"))
           PY
       - name: Run source and citation mutants
+        shell: bash
         run: |
           rm -rf mutants
           mutmut run
           mkdir -p build/assurance
           mutmut results | tee build/assurance/mutation-source-citation-survivors.txt
+          sed -n 's/^    \(.*\): survived$/\1/p' build/assurance/mutation-source-citation-survivors.txt | while IFS= read -r mutant; do
+            echo "::group::$mutant"
+            mutmut show "$mutant"
+            echo "::endgroup::"
+          done
           mutmut export-cicd-stats
       - name: Characterize mutation strength
         run: |

--- a/tests/test_source_citation_properties.py
+++ b/tests/test_source_citation_properties.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import tempfile
 from pathlib import Path
 
 import pytest
 from hypothesis import given, settings, strategies as st
+from jsonschema import ValidationError
 
 from fossil_core.artifact_store import ArtifactStore
-from fossil_core.source import SourceSnapshotStore
+from fossil_core.source import (
+    RedactionPolicy,
+    SourceSnapshotConflict,
+    SourceSnapshotStore,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_SCHEMA = ROOT / "schemas" / "source-snapshot" / "v1.schema.json"
@@ -65,6 +71,11 @@ def put_local_snapshot(
         quality=quality(),
         media_type="application/octet-stream",
     )
+
+
+def expected_stable_id(prefix: str, *parts: str, length: int = 24) -> str:
+    digest = hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+    return f"{prefix}_{digest[:length]}"
 
 
 @settings(max_examples=160, derandomize=True)
@@ -247,3 +258,293 @@ def test_derived_and_reconstructed_snapshots_require_resolvable_parent(
         assert child["derivation"]["parent_snapshot_refs"] == [parent["snapshot_id"]]
     finally:
         temporary.cleanup()
+
+
+def test_source_store_initialization_is_idempotent_for_nested_root(tmp_path: Path) -> None:
+    nested_root = tmp_path / "deep" / "nested" / "sources"
+    artifacts = ArtifactStore(tmp_path / "artifacts")
+
+    first = SourceSnapshotStore(nested_root, artifacts, SOURCE_SCHEMA, CITATION_SCHEMA)
+    second = SourceSnapshotStore(nested_root, artifacts, SOURCE_SCHEMA, CITATION_SCHEMA)
+
+    assert first.root == nested_root
+    assert second.root == nested_root
+    assert nested_root.is_dir()
+
+
+def test_source_snapshot_persistence_and_ids_are_canonical(tmp_path: Path) -> None:
+    store = source_store(tmp_path)
+    payload = "π evidence with stable bytes".encode("utf-8")
+    locator = {"identifier": "urn:fossil:π"}
+    retrieved_at = "2026-08-19T02:10:00Z"
+    version_metadata = {"etag": '"π-v1"', "version_id": "revision-7"}
+
+    snapshot = store.put_snapshot(
+        payload,
+        locator=locator,
+        retrieved_at=retrieved_at,
+        source_role="local",
+        quality=quality(),
+        version_metadata=version_metadata,
+        media_type="text/plain",
+    )
+
+    normalized_locator = {
+        "url": None,
+        "identifier": "urn:fossil:π",
+        "repository_ref": None,
+    }
+    expected_source_id = expected_stable_id(
+        "source",
+        json.dumps(
+            normalized_locator,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ),
+        length=20,
+    )
+    version = {
+        "etag": '"π-v1"',
+        "last_modified": None,
+        "version_id": "revision-7",
+        "commit_sha": None,
+    }
+    expected_snapshot_id = expected_stable_id(
+        "snap",
+        expected_source_id,
+        hashlib.sha256(payload).hexdigest(),
+        retrieved_at,
+        json.dumps(version, sort_keys=True, separators=(",", ":")),
+    )
+
+    assert snapshot["source_id"] == expected_source_id
+    assert snapshot["snapshot_id"] == expected_snapshot_id
+    assert len(snapshot["snapshot_id"].removeprefix("snap_")) == 24
+    assert store.artifact_store.get_manifest(snapshot["artifact_id"])["media_type"] == "text/plain"
+
+    persisted = next((store.root / "snapshots").glob("*/*.json"))
+    expected_bytes = (
+        json.dumps(snapshot, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        + "\n"
+    ).encode("utf-8")
+    assert persisted.read_bytes() == expected_bytes
+
+
+def test_source_snapshot_validation_enforces_date_time_formats(tmp_path: Path) -> None:
+    store = source_store(tmp_path)
+
+    with pytest.raises(ValidationError):
+        store.put_snapshot(
+            b"invalid retrieval time",
+            locator={"identifier": "property:invalid-date"},
+            retrieved_at="not-a-date-time",
+            source_role="local",
+            quality=quality(),
+        )
+
+
+def test_default_snapshot_media_type_is_preserved_in_artifact_manifest(tmp_path: Path) -> None:
+    store = source_store(tmp_path)
+    snapshot = store.put_snapshot(
+        b"default media type",
+        locator={"identifier": "property:default-media"},
+        retrieved_at="2026-08-19T02:11:00Z",
+        source_role="local",
+        quality=quality(),
+    )
+
+    manifest = store.artifact_store.get_manifest(snapshot["artifact_id"])
+    assert manifest["media_type"] == "application/octet-stream"
+
+
+def test_snapshot_republish_detects_tampered_durable_record(tmp_path: Path) -> None:
+    store = source_store(tmp_path)
+    kwargs = {
+        "locator": {"identifier": "property:immutable-conflict"},
+        "retrieved_at": "2026-08-19T02:12:00Z",
+        "source_role": "local",
+        "quality": quality(),
+        "media_type": "text/plain",
+    }
+    snapshot = store.put_snapshot(b"immutable snapshot bytes", **kwargs)
+    path = next((store.root / "snapshots").glob(f"*/{snapshot['snapshot_id']}.json"))
+    tampered = json.loads(path.read_text(encoding="utf-8"))
+    tampered["published_at"] = "2026-08-18T00:00:00Z"
+    path.write_text(
+        json.dumps(tampered, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SourceSnapshotConflict):
+        store.put_snapshot(b"immutable snapshot bytes", **kwargs)
+
+
+def test_citation_identity_resolution_shape_and_copy_are_stable(tmp_path: Path) -> None:
+    store = source_store(tmp_path)
+    payload = b"alpha beta gamma"
+    snapshot = put_local_snapshot(store, payload)
+    start, end = 6, 10
+    passage = payload[start:end]
+    passage_digest = hashlib.sha256(passage).hexdigest()
+
+    bounded = store.create_citation(
+        snapshot["snapshot_id"],
+        byte_start=start,
+        byte_end=end,
+    )
+    expected_bounded_id = expected_stable_id(
+        "cite",
+        snapshot["snapshot_id"],
+        snapshot["artifact_id"],
+        str(start),
+        str(end),
+        passage_digest,
+    )
+    assert bounded["citation_id"] == expected_bounded_id
+    assert len(bounded["citation_id"].removeprefix("cite_")) == 24
+
+    resolved = store.resolve_citation(bounded)
+    assert set(resolved) == {"citation", "snapshot", "bytes", "text"}
+    assert resolved["citation"] == bounded
+    assert resolved["snapshot"] == snapshot
+    assert resolved["bytes"] == passage
+    assert resolved["text"] == "beta"
+
+    original_digest = bounded["passage_hash"]["digest"]
+    bounded["passage_hash"]["digest"] = "0" * 64
+    assert resolved["citation"]["passage_hash"]["digest"] == original_digest
+
+    whole = store.create_citation(snapshot["snapshot_id"])
+    expected_whole_id = expected_stable_id(
+        "cite",
+        snapshot["snapshot_id"],
+        snapshot["artifact_id"],
+        "None",
+        "None",
+        "whole-artifact",
+    )
+    assert whole["citation_id"] == expected_whole_id
+    assert whole["passage_hash"] is None
+    assert whole["citation_id"] != expected_bounded_id
+    assert store.resolve_citation(whole)["bytes"] == payload
+
+
+def test_derived_snapshot_detaches_caller_owned_derivation(tmp_path: Path) -> None:
+    store = source_store(tmp_path)
+    parent = put_local_snapshot(store, b"parent")
+    parent_refs = [parent["snapshot_id"]]
+    derivation = {
+        "method": "generated derivation",
+        "parent_snapshot_refs": parent_refs,
+    }
+    child = store.put_snapshot(
+        b"child",
+        locator={"identifier": "property:derived-copy"},
+        retrieved_at="2026-08-19T02:13:00Z",
+        source_role="derived",
+        quality=quality(),
+        derivation=derivation,
+    )
+
+    parent_refs.append("snap_external_mutation_0001")
+
+    assert child["derivation"]["parent_snapshot_refs"] == [parent["snapshot_id"]]
+    assert store.get_snapshot(child["snapshot_id"])["derivation"]["parent_snapshot_refs"] == [
+        parent["snapshot_id"]
+    ]
+
+
+def test_snapshot_exports_preserve_shape_before_and_after_redaction(tmp_path: Path) -> None:
+    store = source_store(tmp_path)
+    payload = b"exported source bytes"
+    snapshot = put_local_snapshot(store, payload)
+
+    assert store.artifact_for_snapshot(snapshot["snapshot_id"]) == snapshot["artifact_id"]
+    assert store.export_snapshot(snapshot["snapshot_id"]) == {
+        "snapshot": snapshot,
+        "content": payload,
+        "redacted": False,
+        "redaction": None,
+    }
+
+    tombstone = store.artifact_store.redact(
+        snapshot["artifact_id"],
+        reason="property redaction",
+        authority="property-test",
+        redacted_at="2026-08-19T02:14:00Z",
+        request_ref="property-redaction-1",
+    )
+    assert store.export_snapshot(snapshot["snapshot_id"]) == {
+        "snapshot": snapshot,
+        "content": None,
+        "redacted": True,
+        "redaction": tombstone,
+    }
+
+
+def test_redaction_policy_filters_visible_events_and_defensively_exports(tmp_path: Path) -> None:
+    store = source_store(tmp_path)
+    visible_snapshot = put_local_snapshot(
+        store,
+        b"visible evidence",
+        locator={"identifier": "property:visible"},
+        retrieved_at="2026-08-19T02:15:00Z",
+    )
+    hidden_snapshot = put_local_snapshot(
+        store,
+        b"hidden evidence",
+        locator={"identifier": "property:hidden"},
+        retrieved_at="2026-08-19T02:16:00Z",
+    )
+    store.artifact_store.redact(
+        hidden_snapshot["artifact_id"],
+        reason="property redaction",
+        authority="property-test",
+        redacted_at="2026-08-19T02:17:00Z",
+        request_ref="property-redaction-2",
+    )
+    policy = RedactionPolicy(store)
+
+    visible_event = {
+        "event_id": "evt_visible_property",
+        "evidence_refs": [visible_snapshot["artifact_id"]],
+        "source_snapshot_refs": [visible_snapshot["snapshot_id"]],
+        "payload": {"nested": {"value": 1}},
+    }
+    hidden_by_artifact = {
+        "event_id": "evt_hidden_artifact",
+        "evidence_refs": [hidden_snapshot["artifact_id"]],
+        "source_snapshot_refs": [],
+        "payload": {},
+    }
+    hidden_by_snapshot = {
+        "event_id": "evt_hidden_snapshot",
+        "evidence_refs": [],
+        "source_snapshot_refs": [hidden_snapshot["snapshot_id"]],
+        "payload": {},
+    }
+    unknown_then_hidden = {
+        "event_id": "evt_unknown_then_hidden",
+        "evidence_refs": [],
+        "source_snapshot_refs": [
+            "snap_missing_property_0001",
+            hidden_snapshot["snapshot_id"],
+        ],
+        "payload": {},
+    }
+
+    assert policy.event_visible(visible_event) is True
+    assert policy.event_visible(hidden_by_artifact) is False
+    assert policy.event_visible(hidden_by_snapshot) is False
+    assert policy.event_visible(unknown_then_hidden) is False
+    assert policy.visible_events(
+        [visible_event, hidden_by_artifact, hidden_by_snapshot, unknown_then_hidden]
+    ) == [visible_event]
+
+    exported = policy.export_event(visible_event)
+    assert exported == visible_event
+    visible_event["payload"]["nested"]["value"] = 2
+    assert exported is not None
+    assert exported["payload"]["nested"]["value"] == 1


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Continue Phase 2 PDD mutation testing with a bounded source/citation integrity gate after the lifecycle+pack gate landed in #187.

## Changes

- mutate `src/fossil_core/source.py` only in an isolated mutation job
- run `tests/test_source_citation_properties.py` and `tests/test_source_provenance.py` as the public oracle set
- strengthen source/citation public oracles for canonical persisted snapshots, exact source/snapshot/citation identity inputs, immutable republish conflict detection, citation resolution shape and defensive copying, export/redaction shape, and event visibility filtering
- directly cover `RedactionPolicy.visible_events`, eliminating the baseline no-test mutant
- reuse the mutation-only mutmut upstream-fix pin and `fossil.mutation-assurance.v1` validator landed in #187
- enforce the measured source/citation gate at `score >= 92%`, `survivors <= 33`, `no-test mutants = 0`

## Evidence

Initial characterization: `353/471` killed, `117` survived, `1` no-test, `74.95%`.

After behavioral oracle hardening on the same 471-mutant population: `438/471` killed, `33` survived, `0` no-test, `92.99%`.

Normal hosted suite on the hardened tests: `469 passed, 1 skipped`.

The remaining 33 survivors were reviewed. They are codec/JSON-equivalent variants, exception-message-only mutations, schema-inert citation `FormatChecker` removal (citation v1 has no `format` keywords), or internal snapshot sharding/layout variants. They are not used to justify cosmetic assertions or to freeze repository layout that is intentionally non-semantic.

## Property traceability

Properties: `FOSSIL-PROP-CITATION-INTEGRITY-001`, `FOSSIL-PROP-PROVENANCE-001`
Property impact: PRESERVE / TEST-ORACLE-STRENGTHEN

## Scope exclusions

- no production source/citation semantic changes
- no agent/query/storage/projection/promotion mutation expansion
- no hidden holdout, TLA+, or Lean work
- no repository-wide vanity score
- no acceptance weakening

Final verification target: exact-head normal DKG and enforced source/citation mutation assurance, followed by final diff/review/main-SHA fence.