### PR TITLE
[ASSURANCE] Enforce identity mutation gate

### DIFF
--- a/.github/workflows/mutation-identity.yml
+++ b/.github/workflows/mutation-identity.yml
@@ -83,20 +83,20 @@ jobs:
           mkdir -p build/assurance
           mutmut results | tee build/assurance/mutation-identity-survivors.txt
           mutmut export-cicd-stats
-      - name: Show characterization survivor
-        run: mutmut show fossil_core.domain.identity.x_deterministic_event_id__mutmut_5
-      - name: Characterize identity mutation strength
+      - name: Enforce identity mutation strength
         run: |
           python scripts/check_mutation_assurance.py \
             mutants/mutmut-cicd-stats.json \
             --scope identity \
-            --minimum-score 0 \
+            --minimum-score 83.33 \
+            --maximum-survivors 1 \
+            --maximum-no-tests 0 \
             --receipt build/assurance/mutation-identity.json
       - name: Emit compact mutation receipt
         shell: bash
         run: |
           {
-            echo "## Identity mutation characterization receipt"
+            echo "## Identity mutation receipt"
             echo '```json'
             cat build/assurance/mutation-identity.json
             echo '```'
@@ -108,6 +108,7 @@ jobs:
             echo "- coordination: #94"
             echo "- tool: mutmut source pinned at dc58270d5234752e22247f814431750eafcf6e5f"
             echo "- mutable source: src/fossil_core/domain/identity.py only"
-            echo "- characterization floor: 0%; threshold will be derived after survivor review"
+            echo "- gate: score >= 83.33%; survivors <= 1; no-test mutants = 0"
+            echo "- reviewed survivor: UTF-8 codec name casing only (utf-8 -> UTF-8), behaviorally equivalent"
             echo "- security: secretless; contents:read"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mutation-identity.yml
+++ b/.github/workflows/mutation-identity.yml
@@ -83,6 +83,8 @@ jobs:
           mkdir -p build/assurance
           mutmut results | tee build/assurance/mutation-identity-survivors.txt
           mutmut export-cicd-stats
+      - name: Show characterization survivor
+        run: mutmut show fossil_core.domain.identity.x_deterministic_event_id__mutmut_5
       - name: Characterize identity mutation strength
         run: |
           python scripts/check_mutation_assurance.py \

--- a/.github/workflows/mutation-identity.yml
+++ b/.github/workflows/mutation-identity.yml
@@ -1,0 +1,111 @@
+name: Identity mutation assurance
+
+on:
+  pull_request:
+    paths:
+      - "src/fossil_core/domain/identity.py"
+      - "tests/test_identity_properties.py"
+      - "tests/test_identity_domain_compatibility.py"
+      - "tests/test_event_store.py"
+      - "tests/test_s3_storage_adapter.py"
+      - "scripts/check_mutation_assurance.py"
+      - ".github/workflows/mutation-identity.yml"
+      - "pyproject.toml"
+  push:
+    branches: [main]
+    paths:
+      - "src/fossil_core/domain/identity.py"
+      - "tests/test_identity_properties.py"
+      - "tests/test_identity_domain_compatibility.py"
+      - "tests/test_event_store.py"
+      - "tests/test_s3_storage_adapter.py"
+      - "scripts/check_mutation_assurance.py"
+      - ".github/workflows/mutation-identity.yml"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  identity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      FOSSIL_SOFTWARE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact target checkout
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "${FOSSIL_SOFTWARE_COMMIT}"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install mutation toolchain
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[test,mutation,s3]'
+          python -m pip check
+          mutmut --version
+      - name: Configure isolated identity mutation scope
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          marker = "[tool.mutmut]\n"
+          if marker not in text:
+              raise SystemExit("missing [tool.mutmut] block")
+          prefix, _old = text.split(marker, 1)
+          scoped = '''[tool.mutmut]
+          source_paths = ["src/fossil_core"]
+          only_mutate = ["src/fossil_core/domain/identity.py"]
+          also_copy = ["schemas", "examples", "skills"]
+          pytest_add_cli_args_test_selection = [
+            "tests/test_identity_properties.py",
+            "tests/test_identity_domain_compatibility.py",
+            "tests/test_event_store.py",
+            "tests/test_s3_storage_adapter.py",
+          ]
+          '''
+          path.write_text(prefix + scoped, encoding="utf-8")
+          print(path.read_text(encoding="utf-8"))
+          PY
+      - name: Run identity mutants
+        shell: bash
+        run: |
+          rm -rf mutants
+          mutmut run
+          mkdir -p build/assurance
+          mutmut results | tee build/assurance/mutation-identity-survivors.txt
+          mutmut export-cicd-stats
+      - name: Characterize identity mutation strength
+        run: |
+          python scripts/check_mutation_assurance.py \
+            mutants/mutmut-cicd-stats.json \
+            --scope identity \
+            --minimum-score 0 \
+            --receipt build/assurance/mutation-identity.json
+      - name: Emit compact mutation receipt
+        shell: bash
+        run: |
+          {
+            echo "## Identity mutation characterization receipt"
+            echo '```json'
+            cat build/assurance/mutation-identity.json
+            echo '```'
+            echo "### Surviving mutants"
+            echo '```text'
+            cat build/assurance/mutation-identity-survivors.txt
+            echo '```'
+            echo "- issue: #176"
+            echo "- coordination: #94"
+            echo "- tool: mutmut source pinned at dc58270d5234752e22247f814431750eafcf6e5f"
+            echo "- mutable source: src/fossil_core/domain/identity.py only"
+            echo "- characterization floor: 0%; threshold will be derived after survivor review"
+            echo "- security: secretless; contents:read"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Continue Phase 2 Property-Driven Development with a bounded mutation gate for corpus-owned identity after source/citation assurance landed in #188.

## Changes

- mutate `src/fossil_core/domain/identity.py` only in an isolated mutation job
- run `tests/test_identity_properties.py`, `tests/test_identity_domain_compatibility.py`, `tests/test_event_store.py`, and `tests/test_s3_storage_adapter.py`
- reuse the mutation-only mutmut upstream-fix pin and `fossil.mutation-assurance.v1` receipt validator
- enforce the measured identity gate at `score >= 83.33%`, `survivors <= 1`, `no-test mutants = 0`

## Evidence

Initial characterization on the six-mutant identity population: `5/6` killed, `1` survived, `0` no-test, `83.33%`.

The sole survivor was inspected directly with `mutmut show`: it changes `.encode("utf-8")` to `.encode("UTF-8")`. Python codec lookup treats those names equivalently, so no semantic assertion is added solely to distinguish encoding-name casing.

## Property traceability

Properties: `FOSSIL-PROP-STABLE-ID-001`, `FOSSIL-PROP-IDEMPOTENCY-001`
Property impact: PRESERVE / MUTATION-GATE

## Scope exclusions

- no production identity changes
- no storage/redaction mutation bundle
- no promotion semantics while #111 remains unresolved
- no hidden holdout, TLA+, or Lean changes
- no repository-wide vanity score
- no acceptance weakening

Final verification target: exact-head normal DKG and enforced identity mutation assurance, then final one-file diff/review/main-SHA fence and auto-merge under the user's standing authorization.