### PR TITLE
[ASSURANCE] Enforce query context security mutation gate

### DIFF
--- a/.github/workflows/mutation-query-context-security.yml
+++ b/.github/workflows/mutation-query-context-security.yml
@@ -7,6 +7,7 @@ on:
       - "src/fossil_core/context_security.py"
       - "tests/test_context_security.py"
       - "tests/test_context_security_mutation_oracles.py"
+      - "tests/test_context_security_mutation_oracles_edge.py"
       - "tests/test_context_security_application_compatibility.py"
       - "scripts/check_mutation_assurance.py"
       - ".github/workflows/mutation-query-context-security.yml"
@@ -18,6 +19,7 @@ on:
       - "src/fossil_core/context_security.py"
       - "tests/test_context_security.py"
       - "tests/test_context_security_mutation_oracles.py"
+      - "tests/test_context_security_mutation_oracles_edge.py"
       - "tests/test_context_security_application_compatibility.py"
       - "scripts/check_mutation_assurance.py"
       - ".github/workflows/mutation-query-context-security.yml"
@@ -68,6 +70,7 @@ jobs:
           pytest_add_cli_args_test_selection = [
             "tests/test_context_security.py",
             "tests/test_context_security_mutation_oracles.py",
+            "tests/test_context_security_mutation_oracles_edge.py",
             "tests/test_context_security_application_compatibility.py",
           ]
           '''

--- a/.github/workflows/mutation-query-context-security.yml
+++ b/.github/workflows/mutation-query-context-security.yml
@@ -93,8 +93,8 @@ jobs:
           python scripts/check_mutation_assurance.py \
             mutants/mutmut-cicd-stats.json \
             --scope query-context-security \
-            --minimum-score 89 \
-            --maximum-survivors 54 \
+            --minimum-score 88 \
+            --maximum-survivors 55 \
             --maximum-no-tests 0 \
             --receipt build/assurance/mutation-query-context-security.json
       - name: Emit compact mutation receipt
@@ -113,7 +113,7 @@ jobs:
             echo "- coordination: #94"
             echo "- tool: mutmut source pinned at dc58270d5234752e22247f814431750eafcf6e5f"
             echo "- mutable source: src/fossil_core/application/query/security.py only"
-            echo "- gate: score >= 89%; survivors <= 54; no-test mutants = 0"
-            echo "- survivor review: remaining mutants are equivalent private-projection key/default/casing variants, unreachable/default-only branches under valid durable inputs, or behavior-preserving copy/default variants"
+            echo "- gate: score >= 88%; survivors <= 55; no-test mutants = 0"
+            echo "- survivor review: remaining mutants are predominantly equivalent private-projection key/default/casing variants; the canonical-citation deep-copy law is separately asserted by a direct oracle even though mutmut still reports its shallow-copy mutant as surviving"
             echo "- security: secretless; contents:read"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mutation-query-context-security.yml
+++ b/.github/workflows/mutation-query-context-security.yml
@@ -8,6 +8,7 @@ on:
       - "tests/test_context_security.py"
       - "tests/test_context_security_mutation_oracles.py"
       - "tests/test_context_security_mutation_oracles_edge.py"
+      - "tests/test_context_security_citation_copy_oracle.py"
       - "tests/test_context_security_application_compatibility.py"
       - "scripts/check_mutation_assurance.py"
       - ".github/workflows/mutation-query-context-security.yml"
@@ -20,6 +21,7 @@ on:
       - "tests/test_context_security.py"
       - "tests/test_context_security_mutation_oracles.py"
       - "tests/test_context_security_mutation_oracles_edge.py"
+      - "tests/test_context_security_citation_copy_oracle.py"
       - "tests/test_context_security_application_compatibility.py"
       - "scripts/check_mutation_assurance.py"
       - ".github/workflows/mutation-query-context-security.yml"
@@ -71,6 +73,7 @@ jobs:
             "tests/test_context_security.py",
             "tests/test_context_security_mutation_oracles.py",
             "tests/test_context_security_mutation_oracles_edge.py",
+            "tests/test_context_security_citation_copy_oracle.py",
             "tests/test_context_security_application_compatibility.py",
           ]
           '''
@@ -85,28 +88,20 @@ jobs:
           mkdir -p build/assurance
           mutmut results | tee build/assurance/mutation-query-context-security-survivors.txt
           mutmut export-cicd-stats
-      - name: Diagnose surviving mutants
-        shell: bash
-        run: |
-          sed -n 's/^[[:space:]]*\(.*\): survived$/\1/p' \
-            build/assurance/mutation-query-context-security-survivors.txt \
-            > build/assurance/mutation-query-context-security-survivor-names.txt
-          while IFS= read -r mutant; do
-            echo "===== ${mutant} ====="
-            mutmut show "${mutant}"
-          done < build/assurance/mutation-query-context-security-survivor-names.txt
-      - name: Characterize query/context-security mutation strength
+      - name: Enforce query/context-security mutation strength
         run: |
           python scripts/check_mutation_assurance.py \
             mutants/mutmut-cicd-stats.json \
             --scope query-context-security \
-            --minimum-score 0 \
+            --minimum-score 89 \
+            --maximum-survivors 54 \
+            --maximum-no-tests 0 \
             --receipt build/assurance/mutation-query-context-security.json
       - name: Emit compact mutation receipt
         shell: bash
         run: |
           {
-            echo "## Query/context-security mutation characterization"
+            echo "## Query/context-security mutation receipt"
             echo '```json'
             cat build/assurance/mutation-query-context-security.json
             echo '```'
@@ -118,6 +113,7 @@ jobs:
             echo "- coordination: #94"
             echo "- tool: mutmut source pinned at dc58270d5234752e22247f814431750eafcf6e5f"
             echo "- mutable source: src/fossil_core/application/query/security.py only"
-            echo "- mode: characterization; threshold will be set from survivor evidence"
+            echo "- gate: score >= 89%; survivors <= 54; no-test mutants = 0"
+            echo "- survivor review: remaining mutants are equivalent private-projection key/default/casing variants, unreachable/default-only branches under valid durable inputs, or behavior-preserving copy/default variants"
             echo "- security: secretless; contents:read"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mutation-query-context-security.yml
+++ b/.github/workflows/mutation-query-context-security.yml
@@ -1,0 +1,107 @@
+name: Query context security mutation assurance
+
+on:
+  pull_request:
+    paths:
+      - "src/fossil_core/application/query/security.py"
+      - "src/fossil_core/context_security.py"
+      - "tests/test_context_security.py"
+      - "tests/test_context_security_application_compatibility.py"
+      - "scripts/check_mutation_assurance.py"
+      - ".github/workflows/mutation-query-context-security.yml"
+      - "pyproject.toml"
+  push:
+    branches: [main]
+    paths:
+      - "src/fossil_core/application/query/security.py"
+      - "src/fossil_core/context_security.py"
+      - "tests/test_context_security.py"
+      - "tests/test_context_security_application_compatibility.py"
+      - "scripts/check_mutation_assurance.py"
+      - ".github/workflows/mutation-query-context-security.yml"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  query-context-security:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      FOSSIL_SOFTWARE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact target checkout
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "${FOSSIL_SOFTWARE_COMMIT}"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install mutation toolchain
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[test,mutation]'
+          python -m pip check
+          mutmut --version
+      - name: Configure isolated query/context-security mutation scope
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          marker = "[tool.mutmut]\n"
+          if marker not in text:
+              raise SystemExit("missing [tool.mutmut] block")
+          prefix, _old = text.split(marker, 1)
+          scoped = '''[tool.mutmut]
+          source_paths = ["src/fossil_core"]
+          only_mutate = ["src/fossil_core/application/query/security.py"]
+          also_copy = ["schemas", "examples", "skills"]
+          pytest_add_cli_args_test_selection = [
+            "tests/test_context_security.py",
+            "tests/test_context_security_application_compatibility.py",
+          ]
+          '''
+          path.write_text(prefix + scoped, encoding="utf-8")
+          print(path.read_text(encoding="utf-8"))
+          PY
+      - name: Run query/context-security mutants
+        shell: bash
+        run: |
+          rm -rf mutants
+          mutmut run
+          mkdir -p build/assurance
+          mutmut results | tee build/assurance/mutation-query-context-security-survivors.txt
+          mutmut export-cicd-stats
+      - name: Characterize query/context-security mutation strength
+        run: |
+          python scripts/check_mutation_assurance.py \
+            mutants/mutmut-cicd-stats.json \
+            --scope query-context-security \
+            --minimum-score 0 \
+            --receipt build/assurance/mutation-query-context-security.json
+      - name: Emit compact mutation receipt
+        shell: bash
+        run: |
+          {
+            echo "## Query/context-security mutation characterization"
+            echo '```json'
+            cat build/assurance/mutation-query-context-security.json
+            echo '```'
+            echo "### Surviving mutants"
+            echo '```text'
+            cat build/assurance/mutation-query-context-security-survivors.txt
+            echo '```'
+            echo "- issue: #176"
+            echo "- coordination: #94"
+            echo "- tool: mutmut source pinned at dc58270d5234752e22247f814431750eafcf6e5f"
+            echo "- mutable source: src/fossil_core/application/query/security.py only"
+            echo "- mode: characterization; threshold will be set from survivor evidence"
+            echo "- security: secretless; contents:read"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mutation-query-context-security.yml
+++ b/.github/workflows/mutation-query-context-security.yml
@@ -82,6 +82,16 @@ jobs:
           mkdir -p build/assurance
           mutmut results | tee build/assurance/mutation-query-context-security-survivors.txt
           mutmut export-cicd-stats
+      - name: Diagnose surviving mutants
+        shell: bash
+        run: |
+          sed -n 's/^[[:space:]]*\(.*\): survived$/\1/p' \
+            build/assurance/mutation-query-context-security-survivors.txt \
+            > build/assurance/mutation-query-context-security-survivor-names.txt
+          while IFS= read -r mutant; do
+            echo "===== ${mutant} ====="
+            mutmut show "${mutant}"
+          done < build/assurance/mutation-query-context-security-survivor-names.txt
       - name: Characterize query/context-security mutation strength
         run: |
           python scripts/check_mutation_assurance.py \

--- a/.github/workflows/mutation-query-context-security.yml
+++ b/.github/workflows/mutation-query-context-security.yml
@@ -6,6 +6,7 @@ on:
       - "src/fossil_core/application/query/security.py"
       - "src/fossil_core/context_security.py"
       - "tests/test_context_security.py"
+      - "tests/test_context_security_mutation_oracles.py"
       - "tests/test_context_security_application_compatibility.py"
       - "scripts/check_mutation_assurance.py"
       - ".github/workflows/mutation-query-context-security.yml"
@@ -16,6 +17,7 @@ on:
       - "src/fossil_core/application/query/security.py"
       - "src/fossil_core/context_security.py"
       - "tests/test_context_security.py"
+      - "tests/test_context_security_mutation_oracles.py"
       - "tests/test_context_security_application_compatibility.py"
       - "scripts/check_mutation_assurance.py"
       - ".github/workflows/mutation-query-context-security.yml"
@@ -65,6 +67,7 @@ jobs:
           also_copy = ["schemas", "examples", "skills"]
           pytest_add_cli_args_test_selection = [
             "tests/test_context_security.py",
+            "tests/test_context_security_mutation_oracles.py",
             "tests/test_context_security_application_compatibility.py",
           ]
           '''

--- a/tests/test_context_security_citation_copy_oracle.py
+++ b/tests/test_context_security_citation_copy_oracle.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from fossil_core.application.query.security import _canonical_citation
+
+
+def test_canonical_citation_deeply_detaches_nested_hash_data() -> None:
+    original = {
+        "schema_version": "fossil.citation.v1",
+        "citation_id": "cite_defensive_copy_0001",
+        "snapshot_id": "snap_defensive_copy_0001",
+        "artifact_id": "art_defensive_copy_0001",
+        "byte_start": 0,
+        "byte_end": 4,
+        "passage_hash": {"algorithm": "sha256", "digest": "b" * 64},
+        "ignored_extra": {"nested": [1]},
+    }
+
+    canonical = _canonical_citation(original)
+
+    assert canonical is not None
+    assert set(canonical) == {
+        "schema_version",
+        "citation_id",
+        "snapshot_id",
+        "artifact_id",
+        "byte_start",
+        "byte_end",
+        "passage_hash",
+    }
+    assert canonical["passage_hash"] == original["passage_hash"]
+    canonical["passage_hash"]["digest"] = "0" * 64
+    assert original["passage_hash"]["digest"] == "b" * 64

--- a/tests/test_context_security_mutation_oracles.py
+++ b/tests/test_context_security_mutation_oracles.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from fossil_core.application.query.security import (
+    CONTEXT_SECURITY_RESOLVER,
+    UntrustedContextModelService,
+    canonicalize_untrusted_context,
+)
+
+PACK_A = "pack_security_a"
+PACK_B = "pack_security_b"
+
+
+def citation(identifier: str) -> dict:
+    return {
+        "schema_version": "fossil.citation.v1",
+        "citation_id": identifier,
+        "snapshot_id": f"snap_{identifier}",
+        "artifact_id": f"art_{identifier}",
+        "byte_start": 0,
+        "byte_end": 12,
+        "passage_hash": {"algorithm": "sha256", "digest": "b" * 64},
+    }
+
+
+def claim(identifier: str, text: str, *, pack_id: str = PACK_A) -> dict:
+    return {
+        "id": identifier,
+        "pack_id": pack_id,
+        "text": text,
+        "document_type": "claim",
+        "current_state": "supported",
+        "state_history": ["supported"],
+        "citation": citation(f"cite_{identifier}"),
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "spoofed_value"),
+    [
+        ("pack_id", PACK_B),
+        ("text", "retrieved text must never replace durable text"),
+        ("document_type", "claim"),
+        ("current_state", "superseded"),
+        ("state_history", ["proposed", "superseded"]),
+        ("relation_type", "CONTRADICTS"),
+        ("source_ref", "clm_forged_source"),
+        ("target_ref", "clm_forged_target"),
+        ("citation", citation("cite_forged_authority")),
+    ],
+)
+def test_each_retrieved_authority_field_is_resolved_from_durable_truth(
+    field: str, spoofed_value: object
+) -> None:
+    durable = {
+        "id": "rel_authority_truth",
+        "pack_id": PACK_A,
+        "text": "durable relation text",
+        "document_type": "relation",
+        "current_state": "active",
+        "state_history": ["active"],
+        "relation_type": "DEPENDS_ON",
+        "source_ref": "clm_source",
+        "target_ref": "clm_target",
+        "citation": citation("cite_authority_truth"),
+    }
+    retrieved = {**durable, field: spoofed_value}
+
+    secured, diagnostics = canonicalize_untrusted_context(
+        [retrieved], documents=[durable], pack_ids=[PACK_A]
+    )
+
+    assert len(secured) == 1
+    assert secured[0][field] == durable[field]
+    assert secured[0]["context_security"] == {
+        "resolver": CONTEXT_SECURITY_RESOLVER,
+        "trust": "untrusted_source_data",
+        "authority": "durable_identity_resolved",
+        "retrieved_payload_mismatch": True,
+    }
+    assert diagnostics["canonicalized_ids"] == [durable["id"]]
+    assert diagnostics["retrieved_payload_mismatch_ids"] == [durable["id"]]
+
+
+def test_exact_durable_payload_has_no_false_mismatch() -> None:
+    durable = {
+        "id": "rel_exact",
+        "pack_id": PACK_A,
+        "text": "exact durable relation",
+        "document_type": "relation",
+        "current_state": "active",
+        "state_history": ["active"],
+        "relation_type": "DEPENDS_ON",
+        "source_ref": "clm_source",
+        "target_ref": "clm_target",
+        "citation": citation("cite_exact"),
+    }
+
+    secured, diagnostics = canonicalize_untrusted_context(
+        [durable], documents=[durable], pack_ids=[PACK_A]
+    )
+
+    assert secured[0]["context_security"]["retrieved_payload_mismatch"] is False
+    assert diagnostics["canonicalized_ids"] == ["rel_exact"]
+    assert diagnostics["retrieved_payload_mismatch_ids"] == []
+
+
+def test_unknown_context_uses_exact_fingerprint_and_complete_diagnostics() -> None:
+    text = "unknown retrieved π text"
+    digest = hashlib.sha256(f"{PACK_A}\x00{text}".encode("utf-8")).hexdigest()
+    expected_id = f"untrusted_{digest[:24]}"
+
+    secured, diagnostics = canonicalize_untrusted_context(
+        [
+            {"pack_id": PACK_A, "text": text, "document_type": "claim"},
+            {"id": "duplicate_unknown", "pack_id": PACK_A, "text": text},
+            {"id": "foreign_unknown", "pack_id": PACK_B, "text": text},
+        ],
+        documents=[],
+        pack_ids=[PACK_A],
+    )
+
+    assert secured == [
+        {
+            "id": expected_id,
+            "pack_id": PACK_A,
+            "text": text,
+            "document_type": "untrusted_context",
+            "context_security": {
+                "resolver": CONTEXT_SECURITY_RESOLVER,
+                "trust": "untrusted_source_data",
+                "authority": "unresolved_untrusted_payload",
+                "claimed_document_type": "claim",
+            },
+        }
+    ]
+    assert diagnostics == {
+        "resolver": CONTEXT_SECURITY_RESOLVER,
+        "source_text_trust": "untrusted_source_data",
+        "allowed_pack_ids": [PACK_A],
+        "input_item_count": 3,
+        "forwarded_item_count": 1,
+        "forwarded_item_ids": [expected_id],
+        "forwarded_pack_ids": [PACK_A],
+        "canonicalized_ids": [],
+        "retrieved_payload_mismatch_ids": [],
+        "demoted_untrusted_ids": [expected_id],
+        "dropped_out_of_scope_ids": ["foreign_unknown"],
+        "deduplicated_ids": ["duplicate_unknown"],
+    }
+
+
+def test_duplicate_durable_identity_is_forwarded_once() -> None:
+    durable = claim("clm_duplicate", "durable")
+
+    secured, diagnostics = canonicalize_untrusted_context(
+        [durable, {**durable}], documents=[durable], pack_ids=[PACK_A]
+    )
+
+    assert [item["id"] for item in secured] == ["clm_duplicate"]
+    assert diagnostics["canonicalized_ids"] == ["clm_duplicate"]
+    assert diagnostics["deduplicated_ids"] == ["clm_duplicate"]
+    assert diagnostics["input_item_count"] == 2
+    assert diagnostics["forwarded_item_count"] == 1
+
+
+class RecordingService:
+    def __init__(self, response: dict):
+        self.response = response
+        self.last_task = None
+        self.metadata_value = {
+            "kind": "model",
+            "provider": "fixture",
+            "provider_version": "1",
+            "implementation": "recording-fixture",
+            "implementation_version": "1",
+            "model_id": "fixture",
+            "local": True,
+            "estimated_cost_per_call_usd": 0.0,
+            "runtime": {"inner": "preserved"},
+        }
+
+    def metadata(self):
+        return self.metadata_value
+
+    def run(self, task):
+        self.last_task = task
+        return self.response
+
+
+def test_security_metadata_is_defensive_and_adds_exact_runtime_contract() -> None:
+    inner = RecordingService({"output": {}})
+    service = UntrustedContextModelService(inner, documents=[])
+
+    metadata = service.metadata()
+
+    assert metadata["runtime"] == {
+        "inner": "preserved",
+        "context_security_resolver": CONTEXT_SECURITY_RESOLVER,
+        "retrieved_source_text_trust": "untrusted_source_data",
+        "answer_tool_execution": "disabled",
+    }
+    metadata["runtime"]["inner"] = "mutated"
+    assert inner.metadata_value["runtime"] == {"inner": "preserved"}
+
+
+def test_model_boundary_strips_all_executable_and_unknown_fields() -> None:
+    executable = {
+        "actions",
+        "commit",
+        "commit_request",
+        "commit_requests",
+        "proposals",
+        "requested_actions",
+        "tool_call",
+        "tool_calls",
+        "tools",
+    }
+    durable = claim("clm_exec", "durable claim")
+    raw_response = {key: {"malicious": True} for key in executable}
+    raw_response["output"] = {
+        "outcome": "answer",
+        "answer_text": "durable claim",
+        "claims": [{"claim_id": durable["id"], "forged": True}],
+        "confidence": 0.75,
+        **{key: {"malicious": True} for key in executable},
+        "unknown_output_field": "drop me",
+    }
+    inner = RecordingService(raw_response)
+    service = UntrustedContextModelService(inner, documents=[durable])
+    request = {
+        "query": "q",
+        "pack_ids": [PACK_A],
+        "context_items": [durable],
+        **{key: {"malicious": True} for key in executable},
+    }
+
+    response = service.run(request)
+
+    assert set(executable).isdisjoint(inner.last_task)
+    assert set(executable).issubset(request)
+    assert response["authority"] == "candidate_only"
+    assert set(executable).isdisjoint(response)
+    assert set(response["output"]) == {"outcome", "answer_text", "claims", "confidence"}
+    assert response["output"]["claims"] == [
+        {
+            "claim_id": durable["id"],
+            "text": durable["text"],
+            "citation": durable["citation"],
+        }
+    ]
+    assert response["context_security"]["blocked_response_fields"] == sorted(executable)
+    assert set(response["context_security"]["blocked_output_fields"]) == executable | {
+        "unknown_output_field"
+    }
+    assert response["context_security"]["blocked_claim_fields"] == {
+        durable["id"]: ["forged"]
+    }
+
+
+@pytest.mark.parametrize("raw_output", ["not-a-mapping", 3, None, ["claims"]])
+def test_non_mapping_model_output_is_contained(raw_output: object) -> None:
+    service = UntrustedContextModelService(RecordingService({"output": raw_output}), documents=[])
+
+    response = service.run({"query": "q", "pack_ids": [PACK_A], "context_items": []})
+
+    assert response["output"] == {"claims": []}
+    assert response["authority"] == "candidate_only"
+    assert response["context_security"]["invalid_output_claim_ids"] == []
+
+
+def test_non_list_claims_are_discarded() -> None:
+    durable = claim("clm_local", "local")
+    service = UntrustedContextModelService(
+        RecordingService(
+            {"output": {"outcome": "answer", "claims": {"claim_id": durable["id"]}}}
+        ),
+        documents=[durable],
+    )
+
+    response = service.run({"query": "q", "pack_ids": [PACK_A], "context_items": []})
+
+    assert response["output"] == {"outcome": "answer", "claims": []}
+
+
+def test_foreign_or_missing_model_claim_ids_fail_closed() -> None:
+    local = claim("clm_local", "local")
+    foreign = claim("clm_foreign", "foreign", pack_id=PACK_B)
+    service = UntrustedContextModelService(
+        RecordingService(
+            {
+                "output": {
+                    "outcome": "answer",
+                    "answer_text": "untrusted",
+                    "claims": [{"claim_id": foreign["id"]}, {}],
+                    "confidence": 0.25,
+                }
+            }
+        ),
+        documents=[local, foreign],
+    )
+
+    response = service.run({"query": "q", "pack_ids": [PACK_A], "context_items": []})
+
+    assert response["output"] == {
+        "outcome": "insufficient_evidence",
+        "answer_text": "Insufficient evidence.",
+        "claims": [],
+        "confidence": 1.0,
+    }
+    assert response["context_security"]["invalid_output_claim_ids"] == [
+        foreign["id"],
+        "<missing-id>",
+    ]
+
+
+def test_emitted_claim_and_citation_are_canonical_and_detached() -> None:
+    durable = claim("clm_citation", "durable claim")
+    durable["citation"]["ignored_extra"] = {"nested": [1]}
+    service = UntrustedContextModelService(
+        RecordingService(
+            {
+                "output": {
+                    "outcome": "answer",
+                    "claims": [
+                        {
+                            "claim_id": durable["id"],
+                            "text": "forged",
+                            "citation": citation("forged"),
+                        }
+                    ],
+                }
+            }
+        ),
+        documents=[durable],
+    )
+
+    response = service.run(
+        {"query": "q", "pack_ids": [PACK_A], "context_items": [durable]}
+    )
+    emitted = response["output"]["claims"][0]
+
+    assert emitted["claim_id"] == durable["id"]
+    assert emitted["text"] == durable["text"]
+    assert set(emitted["citation"]) == {
+        "schema_version",
+        "citation_id",
+        "snapshot_id",
+        "artifact_id",
+        "byte_start",
+        "byte_end",
+        "passage_hash",
+    }
+    assert "ignored_extra" not in emitted["citation"]
+    emitted["citation"]["passage_hash"]["digest"] = "0" * 64
+    assert service.documents[0]["citation"]["passage_hash"]["digest"] == "b" * 64

--- a/tests/test_context_security_mutation_oracles_edge.py
+++ b/tests/test_context_security_mutation_oracles_edge.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import hashlib
+
+from fossil_core.application.query.security import (
+    CONTEXT_SECURITY_RESOLVER,
+    UntrustedContextModelService,
+    canonicalize_untrusted_context,
+)
+
+PACK_A = "pack_security_a"
+PACK_B = "pack_security_b"
+
+
+def citation(identifier: str) -> dict:
+    return {
+        "schema_version": "fossil.citation.v1",
+        "citation_id": identifier,
+        "snapshot_id": f"snap_{identifier}",
+        "artifact_id": f"art_{identifier}",
+        "byte_start": 0,
+        "byte_end": 12,
+        "passage_hash": {"algorithm": "sha256", "digest": "b" * 64},
+    }
+
+
+def claim(identifier: str, text: str = "durable", *, pack_id: str = PACK_A) -> dict:
+    return {
+        "id": identifier,
+        "pack_id": pack_id,
+        "text": text,
+        "document_type": "claim",
+        "current_state": "supported",
+        "state_history": ["supported"],
+        "citation": citation(f"cite_{identifier}"),
+    }
+
+
+class RecordingService:
+    def __init__(self, response: dict, *, metadata: dict | None = None):
+        self.response = response
+        self.last_task = None
+        self.metadata_value = metadata or {
+            "kind": "model",
+            "provider": "fixture",
+            "provider_version": "1",
+            "implementation": "recording-fixture",
+            "implementation_version": "1",
+            "model_id": "fixture",
+            "local": True,
+            "estimated_cost_per_call_usd": 0.0,
+            "runtime": {"inner": "preserved"},
+        }
+
+    def metadata(self):
+        return self.metadata_value
+
+    def run(self, task):
+        self.last_task = task
+        return self.response
+
+
+class MutatingService(RecordingService):
+    def run(self, task):
+        self.last_task = task
+        task["client_metadata"]["tags"].append("inner-mutated")
+        return self.response
+
+
+def test_foreign_durable_item_does_not_abort_later_valid_context() -> None:
+    foreign = claim("clm_foreign_first", pack_id=PACK_B)
+    local = claim("clm_local_after_foreign")
+
+    secured, diagnostics = canonicalize_untrusted_context(
+        [foreign, local], documents=[foreign, local], pack_ids=[PACK_A]
+    )
+
+    assert [item["id"] for item in secured] == [local["id"]]
+    assert diagnostics["dropped_out_of_scope_ids"] == [foreign["id"]]
+    assert diagnostics["canonicalized_ids"] == [local["id"]]
+
+
+def test_duplicate_durable_item_does_not_abort_later_distinct_context() -> None:
+    first = claim("clm_first")
+    second = claim("clm_second")
+
+    secured, diagnostics = canonicalize_untrusted_context(
+        [first, {**first}, second], documents=[first, second], pack_ids=[PACK_A]
+    )
+
+    assert [item["id"] for item in secured] == [first["id"], second["id"]]
+    assert diagnostics["deduplicated_ids"] == [first["id"]]
+    assert diagnostics["canonicalized_ids"] == [first["id"], second["id"]]
+
+
+def test_missing_unknown_fields_use_empty_string_canonical_defaults() -> None:
+    digest = hashlib.sha256(f"{PACK_A}\x00".encode("utf-8")).hexdigest()
+    expected_id = f"untrusted_{digest[:24]}"
+
+    secured, diagnostics = canonicalize_untrusted_context(
+        [{"pack_id": PACK_A}], documents=[], pack_ids=[PACK_A]
+    )
+
+    assert secured == [
+        {
+            "id": expected_id,
+            "pack_id": PACK_A,
+            "text": "",
+            "document_type": "untrusted_context",
+            "context_security": {
+                "resolver": CONTEXT_SECURITY_RESOLVER,
+                "trust": "untrusted_source_data",
+                "authority": "unresolved_untrusted_payload",
+                "claimed_document_type": "",
+            },
+        }
+    ]
+    assert diagnostics["forwarded_item_ids"] == [expected_id]
+
+
+def test_missing_id_duplicate_uses_stable_sha256_diagnostic_key() -> None:
+    text = "duplicate without ids"
+    digest = hashlib.sha256(f"{PACK_A}\x00{text}".encode("utf-8")).hexdigest()
+
+    _secured, diagnostics = canonicalize_untrusted_context(
+        [{"pack_id": PACK_A, "text": text}, {"pack_id": PACK_A, "text": text}],
+        documents=[],
+        pack_ids=[PACK_A],
+    )
+
+    assert diagnostics["deduplicated_ids"] == [f"sha256:{digest[:16]}"]
+
+
+def test_canonicalized_context_is_deeply_detached_from_both_inputs() -> None:
+    durable = claim("clm_detached")
+    retrieved = {**durable, "citation": {**durable["citation"]}}
+
+    secured, _diagnostics = canonicalize_untrusted_context(
+        [retrieved], documents=[durable], pack_ids=[PACK_A]
+    )
+
+    secured[0]["state_history"].append("mutated")
+    secured[0]["citation"]["passage_hash"]["digest"] = "0" * 64
+
+    assert durable["state_history"] == ["supported"]
+    assert retrieved["state_history"] == ["supported"]
+    assert durable["citation"]["passage_hash"]["digest"] == "b" * 64
+    assert retrieved["citation"]["passage_hash"]["digest"] == "b" * 64
+
+
+def test_service_constructor_detaches_nested_documents_from_caller() -> None:
+    durable = claim("clm_constructor_copy")
+    service = UntrustedContextModelService(RecordingService({"output": {}}), documents=[durable])
+
+    durable["state_history"].append("caller-mutated")
+    durable["citation"]["passage_hash"]["digest"] = "0" * 64
+
+    assert service.documents[0]["state_history"] == ["supported"]
+    assert service.documents[0]["citation"]["passage_hash"]["digest"] == "b" * 64
+
+
+def test_metadata_handles_missing_runtime_and_detaches_other_nested_provider_data() -> None:
+    inner = RecordingService(
+        {"output": {}},
+        metadata={
+            "kind": "model",
+            "provider": "fixture",
+            "provider_details": {"regions": ["local"]},
+        },
+    )
+    service = UntrustedContextModelService(inner, documents=[])
+
+    metadata = service.metadata()
+
+    assert metadata["runtime"] == {
+        "context_security_resolver": CONTEXT_SECURITY_RESOLVER,
+        "retrieved_source_text_trust": "untrusted_source_data",
+        "answer_tool_execution": "disabled",
+    }
+    metadata["provider_details"]["regions"].append("mutated")
+    assert inner.metadata_value["provider_details"] == {"regions": ["local"]}
+
+
+def test_inner_task_gets_exact_security_contract_and_missing_request_fields_default_safely() -> None:
+    inner = RecordingService({"output": {}})
+    service = UntrustedContextModelService(inner, documents=[])
+
+    response = service.run({"query": "q"})
+
+    assert inner.last_task is not None
+    assert inner.last_task["context_items"] == []
+    assert inner.last_task["context_security"] == {
+        "resolver": CONTEXT_SECURITY_RESOLVER,
+        "retrieved_source_text": "untrusted_source_data",
+        "retrieved_text_can_issue_policy": False,
+        "model_can_execute_tools": False,
+        "durable_claim_resolution_required": True,
+    }
+    assert response["authority"] == "candidate_only"
+
+
+def test_wrapper_owns_deep_request_copy_against_inner_mutation() -> None:
+    inner = MutatingService({"output": {}})
+    service = UntrustedContextModelService(inner, documents=[])
+    request = {
+        "query": "q",
+        "pack_ids": [],
+        "context_items": [],
+        "client_metadata": {"tags": ["caller"]},
+    }
+
+    service.run(request)
+
+    assert request["client_metadata"] == {"tags": ["caller"]}
+    assert inner.last_task["client_metadata"] == {"tags": ["caller", "inner-mutated"]}
+
+
+def test_wrapper_detaches_nested_inner_response_and_allowed_output_values() -> None:
+    inner_response = {
+        "telemetry": {"nested": [1]},
+        "output": {"claims": [], "confidence": {"nested": [1]}},
+    }
+    service = UntrustedContextModelService(RecordingService(inner_response), documents=[])
+
+    response = service.run({"query": "q", "pack_ids": [], "context_items": []})
+    response["telemetry"]["nested"].append(2)
+    response["output"]["confidence"]["nested"].append(2)
+
+    assert inner_response["telemetry"] == {"nested": [1]}
+    assert inner_response["output"]["confidence"] == {"nested": [1]}
+
+
+def test_durable_claim_missing_text_emits_empty_text() -> None:
+    durable = {"id": "clm_no_text", "pack_id": PACK_A, "document_type": "claim"}
+    inner = RecordingService(
+        {"output": {"outcome": "answer", "claims": [{"claim_id": durable["id"]}]}}
+    )
+    service = UntrustedContextModelService(inner, documents=[durable])
+
+    response = service.run({"query": "q", "pack_ids": [PACK_A], "context_items": []})
+
+    assert response["output"]["claims"] == [{"claim_id": durable["id"], "text": ""}]
+
+
+def test_non_mapping_claim_item_fails_closed() -> None:
+    inner = RecordingService(
+        {"output": {"outcome": "answer", "claims": ["not-a-claim"], "confidence": 0.2}}
+    )
+    service = UntrustedContextModelService(inner, documents=[])
+
+    response = service.run({"query": "q", "pack_ids": [PACK_A], "context_items": []})
+
+    assert response["output"] == {
+        "outcome": "insufficient_evidence",
+        "answer_text": "Insufficient evidence.",
+        "claims": [],
+        "confidence": 1.0,
+    }
+    assert response["context_security"]["invalid_output_claim_ids"] == ["<missing-id>"]
+
+
+def test_response_includes_exact_service_metadata_key_and_value() -> None:
+    inner = RecordingService({"output": {"claims": []}})
+    service = UntrustedContextModelService(inner, documents=[])
+
+    response = service.run({"query": "q", "pack_ids": [], "context_items": []})
+
+    assert "service" in response
+    assert "SERVICE" not in response
+    assert "XXserviceXX" not in response
+    assert response["service"] == service.metadata()


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Continue Phase 2 PDD mutation assurance with a bounded query/context-security gate after identity mutation assurance landed.

## Changes

- mutate `src/fossil_core/application/query/security.py` only in an isolated mutation job
- keep all existing production source unchanged
- add focused public mutation oracles for durable authority-field canonicalization, out-of-scope filtering, deduplication, untrusted fingerprinting, executable-field stripping, malformed model-output containment, mounted durable-claim resolution, defensive-copy boundaries, and canonical citation isolation
- reuse the mutation-only mutmut upstream-fix pin and `fossil.mutation-assurance.v1` validator already on `main`
- keep lifecycle/pack, source/citation, and identity mutation gates unchanged
- enforce the measured query/context-security gate at `score >= 88%`, `survivors <= 55`, `no-test mutants = 0`

## Evidence

Initial characterization: `287/496` killed, `209` survived, `0` no-test, `57.86%`.

After the first behavioral hardening pass: `404/496` killed, `92` survived, `0` no-test, `81.45%`.

After the second behavioral hardening pass: `441/496` killed, `55` survived, `0` no-test, `88.91%`.

Final exact-head hosted verification on `0e6e0ada7dd214734dfa04e16db7392f5526f5a7`: DKG `504 passed, 1 skipped, 1 warning`; query/context-security mutation assurance PASS at `441/496` killed, `55` survived, `0` no-test, `88.91%`.

The remaining survivors were reviewed rather than score-gamed. They are predominantly equivalent private projection-key/default/casing variants or behavior-preserving defaults. One mutmut survivor changes `_canonical_citation` from `copy.deepcopy` to `copy.copy`; its nested citation-hash isolation law is separately asserted by a direct oracle, but mutmut still reports the helper mutant as surviving due to its per-function test association. The gate therefore freezes the observed reviewed baseline instead of pretending that survivor was killed.

## Property traceability

Properties: `FOSSIL-PROP-UNTRUSTED-CONTEXT-001`, `FOSSIL-PROP-PACK-ISOLATION-001`
Property impact: PRESERVE / TEST-ORACLE-STRENGTHEN

## Final scope

Exactly four files:
- `.github/workflows/mutation-query-context-security.yml`
- `tests/test_context_security_citation_copy_oracle.py`
- `tests/test_context_security_mutation_oracles.py`
- `tests/test_context_security_mutation_oracles_edge.py`

No production-source changes; no `agent.py` mutation; no storage/redaction bundle; no promotion work while #111 remains unfrozen; no hidden holdout, TLA+, or Lean work; no acceptance weakening.