### PR TITLE
[ASSURANCE] Characterize filesystem artifact-store mutants

### DIFF
--- a/.github/workflows/mutation-filesystem-artifact-store.yml
+++ b/.github/workflows/mutation-filesystem-artifact-store.yml
@@ -90,18 +90,20 @@ jobs:
               mutmut show "${mutant}"
               echo "::endgroup::"
             done
-      - name: Characterize filesystem artifact-store mutation strength
+      - name: Enforce filesystem artifact-store mutation strength
         run: |
           python scripts/check_mutation_assurance.py \
             mutants/mutmut-cicd-stats.json \
             --scope filesystem-artifact-store \
-            --minimum-score 0 \
+            --minimum-score 92 \
+            --maximum-survivors 18 \
+            --maximum-no-tests 0 \
             --receipt build/assurance/mutation-filesystem-artifact-store.json
       - name: Emit compact mutation receipt
         shell: bash
         run: |
           {
-            echo "## Filesystem artifact-store mutation characterization"
+            echo "## Filesystem artifact-store mutation receipt"
             echo '```json'
             cat build/assurance/mutation-filesystem-artifact-store.json
             echo '```'
@@ -113,6 +115,7 @@ jobs:
             echo "- coordination: #94"
             echo "- tool: mutmut source pinned at dc58270d5234752e22247f814431750eafcf6e5f"
             echo "- mutable source: src/fossil_core/adapters/filesystem/artifact_store.py only"
-            echo "- mode: characterization; threshold will be set from survivor evidence"
+            echo "- gate: score >= 92%; survivors <= 18; no-test mutants = 0"
+            echo "- survivor review: remaining mutants are behaviorally equivalent/default variants (already-created directory parents flags, UTF-8/default codec aliases, ensure_ascii falsey alias) or exception-message-only changes; storage integrity and redaction behavior remain directly asserted"
             echo "- security: secretless; contents:read"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mutation-filesystem-artifact-store.yml
+++ b/.github/workflows/mutation-filesystem-artifact-store.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - "src/fossil_core/adapters/filesystem/artifact_store.py"
-      - "tests/test_artifact_store.py"
+      - "tests/test_artifact_store_mutation_oracles.py"
       - "tests/test_source_provenance.py"
       - "tests/test_storage_contract_properties.py"
       - "scripts/check_mutation_assurance.py"
@@ -14,7 +14,7 @@ on:
     branches: [main]
     paths:
       - "src/fossil_core/adapters/filesystem/artifact_store.py"
-      - "tests/test_artifact_store.py"
+      - "tests/test_artifact_store_mutation_oracles.py"
       - "tests/test_source_provenance.py"
       - "tests/test_storage_contract_properties.py"
       - "scripts/check_mutation_assurance.py"
@@ -64,7 +64,7 @@ jobs:
           only_mutate = ["src/fossil_core/adapters/filesystem/artifact_store.py"]
           also_copy = ["schemas", "examples", "skills"]
           pytest_add_cli_args_test_selection = [
-            "tests/test_artifact_store.py",
+            "tests/test_artifact_store_mutation_oracles.py",
             "tests/test_source_provenance.py",
             "tests/test_storage_contract_properties.py",
           ]

--- a/.github/workflows/mutation-filesystem-artifact-store.yml
+++ b/.github/workflows/mutation-filesystem-artifact-store.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "src/fossil_core/adapters/filesystem/artifact_store.py"
+      - "tests/test_artifact_store.py"
       - "tests/test_source_provenance.py"
       - "tests/test_storage_contract_properties.py"
       - "scripts/check_mutation_assurance.py"
@@ -13,6 +14,7 @@ on:
     branches: [main]
     paths:
       - "src/fossil_core/adapters/filesystem/artifact_store.py"
+      - "tests/test_artifact_store.py"
       - "tests/test_source_provenance.py"
       - "tests/test_storage_contract_properties.py"
       - "scripts/check_mutation_assurance.py"
@@ -62,6 +64,7 @@ jobs:
           only_mutate = ["src/fossil_core/adapters/filesystem/artifact_store.py"]
           also_copy = ["schemas", "examples", "skills"]
           pytest_add_cli_args_test_selection = [
+            "tests/test_artifact_store.py",
             "tests/test_source_provenance.py",
             "tests/test_storage_contract_properties.py",
           ]

--- a/.github/workflows/mutation-filesystem-artifact-store.yml
+++ b/.github/workflows/mutation-filesystem-artifact-store.yml
@@ -1,0 +1,115 @@
+name: Filesystem artifact-store mutation assurance
+
+on:
+  pull_request:
+    paths:
+      - "src/fossil_core/adapters/filesystem/artifact_store.py"
+      - "tests/test_source_provenance.py"
+      - "tests/test_storage_contract_properties.py"
+      - "scripts/check_mutation_assurance.py"
+      - ".github/workflows/mutation-filesystem-artifact-store.yml"
+      - "pyproject.toml"
+  push:
+    branches: [main]
+    paths:
+      - "src/fossil_core/adapters/filesystem/artifact_store.py"
+      - "tests/test_source_provenance.py"
+      - "tests/test_storage_contract_properties.py"
+      - "scripts/check_mutation_assurance.py"
+      - ".github/workflows/mutation-filesystem-artifact-store.yml"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  filesystem-artifact-store:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      FOSSIL_SOFTWARE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact target checkout
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "${FOSSIL_SOFTWARE_COMMIT}"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install mutation toolchain
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[test,mutation,s3]'
+          python -m pip check
+          mutmut --version
+      - name: Configure isolated filesystem artifact-store mutation scope
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          marker = "[tool.mutmut]\n"
+          if marker not in text:
+              raise SystemExit("missing [tool.mutmut] block")
+          prefix, _old = text.split(marker, 1)
+          scoped = '''[tool.mutmut]
+          source_paths = ["src/fossil_core"]
+          only_mutate = ["src/fossil_core/adapters/filesystem/artifact_store.py"]
+          also_copy = ["schemas", "examples", "skills"]
+          pytest_add_cli_args_test_selection = [
+            "tests/test_source_provenance.py",
+            "tests/test_storage_contract_properties.py",
+          ]
+          '''
+          path.write_text(prefix + scoped, encoding="utf-8")
+          print(path.read_text(encoding="utf-8"))
+          PY
+      - name: Run filesystem artifact-store mutants
+        shell: bash
+        run: |
+          rm -rf mutants
+          mutmut run
+          mkdir -p build/assurance
+          mutmut results | tee build/assurance/mutation-filesystem-artifact-store-survivors.txt
+          mutmut export-cicd-stats
+      - name: Show surviving mutant diffs
+        shell: bash
+        run: |
+          awk -F': ' '/: (survived|no tests)$/ {gsub(/^[[:space:]]+/, "", $1); print $1}' \
+            build/assurance/mutation-filesystem-artifact-store-survivors.txt \
+          | while IFS= read -r mutant; do
+              echo "::group::${mutant}"
+              mutmut show "${mutant}"
+              echo "::endgroup::"
+            done
+      - name: Characterize filesystem artifact-store mutation strength
+        run: |
+          python scripts/check_mutation_assurance.py \
+            mutants/mutmut-cicd-stats.json \
+            --scope filesystem-artifact-store \
+            --minimum-score 0 \
+            --receipt build/assurance/mutation-filesystem-artifact-store.json
+      - name: Emit compact mutation receipt
+        shell: bash
+        run: |
+          {
+            echo "## Filesystem artifact-store mutation characterization"
+            echo '```json'
+            cat build/assurance/mutation-filesystem-artifact-store.json
+            echo '```'
+            echo "### Surviving mutants"
+            echo '```text'
+            cat build/assurance/mutation-filesystem-artifact-store-survivors.txt
+            echo '```'
+            echo "- issue: #176"
+            echo "- coordination: #94"
+            echo "- tool: mutmut source pinned at dc58270d5234752e22247f814431750eafcf6e5f"
+            echo "- mutable source: src/fossil_core/adapters/filesystem/artifact_store.py only"
+            echo "- mode: characterization; threshold will be set from survivor evidence"
+            echo "- security: secretless; contents:read"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/tests/test_artifact_store.py
+++ b/tests/test_artifact_store.py
@@ -1,26 +1,231 @@
+from __future__ import annotations
+
+import hashlib
+import json
 from pathlib import Path
 
 import pytest
 
-from fossil_core.artifact_store import ArtifactIntegrityError, ArtifactStore
+from fossil_core.artifact_store import (
+    ArtifactIntegrityError,
+    ArtifactRedactedError,
+    ArtifactStore,
+)
+
+
+def test_constructor_creates_stable_nested_store_layout_and_reopens(tmp_path: Path):
+    root = tmp_path / "nested" / "durable" / "objects"
+    store = ArtifactStore(root)
+
+    assert store.root == root
+    assert store.blobs == root / "blobs" / "sha256"
+    assert store.manifests == root / "manifests"
+    assert store.redactions == root / "redactions"
+    assert store.blobs.is_dir()
+    assert store.manifests.is_dir()
+    assert store.redactions.is_dir()
+
+    reopened = ArtifactStore(root)
+    assert reopened.blobs == store.blobs
+    assert reopened.manifests == store.manifests
+    assert reopened.redactions == store.redactions
+
+
+def test_canonical_bytes_are_stable_compact_sorted_utf8_json():
+    assert ArtifactStore._canonical({"z": "café", "a": [2, 1]}) == (
+        '{"a":[2,1],"z":"café"}\n'.encode("utf-8")
+    )
 
 
 def test_artifact_store_is_content_addressed_and_verifiable(tmp_path: Path):
     store = ArtifactStore(tmp_path / "objects")
-    first = store.put_bytes(b"hello durable evidence", media_type="text/plain")
-    second = store.put_bytes(b"hello durable evidence", media_type="text/plain")
+    data = b"hello durable evidence"
+    digest = hashlib.sha256(data).hexdigest()
+    first = store.put_bytes(data, media_type="text/plain")
+    second = store.put_bytes(data, media_type="text/plain")
+    artifact_id = f"art_{digest[:32]}"
 
-    assert first == second
-    assert store.read_bytes(first["artifact_id"]) == b"hello durable evidence"
-    assert store.verify(first["artifact_id"])
+    assert first == second == {
+        "artifact_id": artifact_id,
+        "content_hash": {"algorithm": "sha256", "digest": digest},
+        "byte_size": len(data),
+        "media_type": "text/plain",
+    }
+    assert store._blob_path(digest) == store.blobs / digest[:2] / digest
+    assert store._manifest_path(artifact_id) == (
+        store.manifests / artifact_id.removeprefix("art_")[:2] / f"{artifact_id}.json"
+    )
+    assert store._manifest_path(artifact_id).read_bytes() == ArtifactStore._canonical(first)
+    assert store.read_bytes(artifact_id) == data
+    assert store.verify(artifact_id)
 
 
-def test_artifact_tamper_is_detected(tmp_path: Path):
+def test_put_bytes_default_media_type_is_durable(tmp_path: Path):
+    store = ArtifactStore(tmp_path / "objects")
+    manifest = store.put_bytes(b"default media type")
+    assert manifest["media_type"] == "application/octet-stream"
+    assert store.get_manifest(manifest["artifact_id"]) == manifest
+
+
+def test_put_file_reads_exact_bytes_and_forwards_media_type(tmp_path: Path):
+    store = ArtifactStore(tmp_path / "objects")
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"file-backed evidence\x00\xff")
+
+    manifest = store.put_file(source, media_type="application/x-fossil-fixture")
+
+    assert manifest["media_type"] == "application/x-fossil-fixture"
+    assert manifest["byte_size"] == len(source.read_bytes())
+    assert store.read_bytes(manifest["artifact_id"]) == source.read_bytes()
+
+    default_source = tmp_path / "default.bin"
+    default_source.write_bytes(b"different bytes for default media")
+    default_manifest = store.put_file(default_source)
+    assert default_manifest["media_type"] == "application/octet-stream"
+
+
+def test_existing_corrupted_blob_is_rejected_on_idempotent_retry(tmp_path: Path):
+    store = ArtifactStore(tmp_path / "objects")
+    data = b"immutable blob"
+    manifest = store.put_bytes(data)
+    digest = manifest["content_hash"]["digest"]
+    store._blob_path(digest).write_bytes(b"corrupted blob")
+
+    with pytest.raises(ArtifactIntegrityError):
+        store.put_bytes(data)
+
+
+def test_same_content_cannot_change_manifest_metadata(tmp_path: Path):
+    store = ArtifactStore(tmp_path / "objects")
+    data = b"same identity means same manifest"
+    store.put_bytes(data, media_type="text/plain")
+
+    with pytest.raises(ArtifactIntegrityError):
+        store.put_bytes(data, media_type="application/octet-stream")
+
+
+def test_get_redaction_returns_none_when_no_tombstone_exists(tmp_path: Path):
+    store = ArtifactStore(tmp_path / "objects")
+    assert store.get_redaction("art_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") is None
+
+
+def test_artifact_tamper_is_detected_when_digest_alone_changes(tmp_path: Path):
     store = ArtifactStore(tmp_path / "objects")
     manifest = store.put_bytes(b"abc")
     digest = manifest["content_hash"]["digest"]
-    blob = store.blobs / digest[:2] / digest
-    blob.write_bytes(b"tampered")
+    store._blob_path(digest).write_bytes(b"xyz")
 
     with pytest.raises(ArtifactIntegrityError):
         store.verify(manifest["artifact_id"])
+
+
+def test_artifact_tamper_is_detected_when_size_alone_changes(tmp_path: Path):
+    store = ArtifactStore(tmp_path / "objects")
+    manifest = store.put_bytes(b"size-fixture")
+    changed = dict(manifest)
+    changed["byte_size"] = manifest["byte_size"] + 1
+    store._manifest_path(manifest["artifact_id"]).write_bytes(
+        ArtifactStore._canonical(changed)
+    )
+
+    with pytest.raises(ArtifactIntegrityError):
+        store.verify(manifest["artifact_id"])
+
+
+@pytest.mark.parametrize("missing", ["reason", "authority", "redacted_at"])
+def test_redaction_requires_complete_authorization_metadata(tmp_path: Path, missing: str):
+    store = ArtifactStore(tmp_path / "objects")
+    manifest = store.put_bytes(b"authorized redaction")
+    kwargs = {
+        "reason": "privacy erasure request",
+        "authority": "fixture-data-controller",
+        "redacted_at": "2026-08-19T06:35:00Z",
+        "request_ref": "erase-required-fields",
+    }
+    kwargs[missing] = ""
+
+    with pytest.raises(ValueError):
+        store.redact(manifest["artifact_id"], **kwargs)
+
+    assert store.read_bytes(manifest["artifact_id"]) == b"authorized redaction"
+    assert store.get_redaction(manifest["artifact_id"]) is None
+
+
+def test_redaction_publishes_exact_tombstone_before_removing_blob_and_blocks_resurrection(
+    tmp_path: Path,
+):
+    store = ArtifactStore(tmp_path / "objects")
+    data = b"sensitive artifact payload"
+    manifest = store.put_bytes(data, media_type="text/plain")
+    artifact_id = manifest["artifact_id"]
+    digest = manifest["content_hash"]["digest"]
+    blob_path = store._blob_path(digest)
+    suffix = artifact_id.removeprefix("art_")
+    expected_path = store.redactions / suffix[:2] / f"{artifact_id}.json"
+    expected = {
+        "artifact_id": artifact_id,
+        "redacted_at": "2026-08-19T06:36:00Z",
+        "reason": "privacy deletion",
+        "authority": "fixture-privacy-officer",
+        "request_ref": "erase-36",
+        "content_hash": manifest["content_hash"],
+        "byte_size": len(data),
+        "media_type": "text/plain",
+    }
+
+    tombstone = store.redact(
+        artifact_id,
+        reason=expected["reason"],
+        authority=expected["authority"],
+        redacted_at=expected["redacted_at"],
+        request_ref=expected["request_ref"],
+    )
+
+    assert tombstone == expected
+    assert store._redaction_path(artifact_id) == expected_path
+    assert expected_path.read_bytes() == ArtifactStore._canonical(expected)
+    assert not blob_path.exists()
+    assert store.is_redacted(artifact_id)
+    assert store.get_redaction(artifact_id) == expected
+    with pytest.raises(ArtifactRedactedError):
+        store.read_bytes(artifact_id)
+    with pytest.raises(ArtifactRedactedError):
+        store.put_bytes(data, media_type="text/plain")
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("reason", "different reason"),
+        ("authority", "different-authority"),
+        ("redacted_at", "2026-08-19T06:37:01Z"),
+        ("request_ref", "different-request"),
+    ],
+)
+def test_redaction_is_idempotent_but_conflicting_metadata_is_rejected(
+    tmp_path: Path, field: str, replacement: str
+):
+    store = ArtifactStore(tmp_path / "objects")
+    artifact_id = store.put_bytes(b"redaction conflict fixture")["artifact_id"]
+    kwargs = {
+        "reason": "legal deletion",
+        "authority": "privacy-officer",
+        "redacted_at": "2026-08-19T06:37:00Z",
+        "request_ref": "legal-37",
+    }
+    first = store.redact(artifact_id, **kwargs)
+    assert store.redact(artifact_id, **kwargs) == first
+
+    conflicting = dict(kwargs)
+    conflicting[field] = replacement
+    with pytest.raises(ArtifactIntegrityError):
+        store.redact(artifact_id, **conflicting)
+
+
+def test_manifest_file_is_canonical_json(tmp_path: Path):
+    store = ArtifactStore(tmp_path / "objects")
+    manifest = store.put_bytes("café".encode("utf-8"), media_type="text/plain")
+    raw = store._manifest_path(manifest["artifact_id"]).read_bytes()
+
+    assert raw == ArtifactStore._canonical(manifest)
+    assert json.loads(raw.decode("utf-8")) == manifest

--- a/tests/test_artifact_store_mutation_oracles.py
+++ b/tests/test_artifact_store_mutation_oracles.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from fossil_core.adapters.filesystem.artifact_store import (
+    ArtifactIntegrityError,
+    ArtifactStore,
+)
+
+
+def test_artifact_store_layout_and_reopen_are_stable(tmp_path: Path) -> None:
+    root = tmp_path / "nested" / "artifacts"
+    store = ArtifactStore(root)
+
+    assert store.root == root
+    assert store.blobs == root / "blobs" / "sha256"
+    assert store.manifests == root / "manifests"
+    assert store.redactions == root / "redactions"
+    assert store.blobs.is_dir()
+    assert store.manifests.is_dir()
+    assert store.redactions.is_dir()
+
+    reopened = ArtifactStore(root)
+    assert reopened.blobs == store.blobs
+    assert reopened.manifests == store.manifests
+    assert reopened.redactions == store.redactions
+
+
+def test_artifact_paths_use_exact_two_character_shards(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path / "artifacts")
+    data = b"stable artifact shard fixture"
+    digest = hashlib.sha256(data).hexdigest()
+    artifact_id = f"art_{digest[:32]}"
+
+    assert store._blob_path(digest) == store.blobs / digest[:2] / digest
+    assert store._manifest_path(artifact_id) == (
+        store.manifests / digest[:2] / f"{artifact_id}.json"
+    )
+    assert store._redaction_path(artifact_id) == (
+        store.redactions / digest[:2] / f"{artifact_id}.json"
+    )
+
+
+def test_canonical_artifact_json_is_sorted_compact_utf8_with_trailing_newline() -> None:
+    value = {"z": "π", "a": {"b": 2, "a": 1}}
+
+    assert ArtifactStore._canonical(value) == (
+        '{"a":{"a":1,"b":2},"z":"π"}\n'.encode("utf-8")
+    )
+
+
+def test_put_bytes_default_media_type_and_exact_manifest_bytes(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path / "artifacts")
+    data = b"default media type fixture"
+    digest = hashlib.sha256(data).hexdigest()
+
+    manifest = store.put_bytes(data)
+
+    assert manifest == {
+        "artifact_id": f"art_{digest[:32]}",
+        "content_hash": {"algorithm": "sha256", "digest": digest},
+        "byte_size": len(data),
+        "media_type": "application/octet-stream",
+    }
+    assert store._manifest_path(manifest["artifact_id"]).read_bytes() == store._canonical(
+        manifest
+    )
+
+
+def test_put_file_reads_exact_bytes_and_preserves_media_type(tmp_path: Path) -> None:
+    source = tmp_path / "evidence.bin"
+    source.write_bytes(b"\x00artifact-file\xff")
+    store = ArtifactStore(tmp_path / "artifacts")
+
+    manifest = store.put_file(source, media_type="application/x-fossil-fixture")
+
+    assert manifest["content_hash"]["digest"] == hashlib.sha256(source.read_bytes()).hexdigest()
+    assert manifest["byte_size"] == len(source.read_bytes())
+    assert manifest["media_type"] == "application/x-fossil-fixture"
+    assert store.read_bytes(manifest["artifact_id"]) == source.read_bytes()
+
+
+def test_put_file_default_media_type_is_octet_stream(tmp_path: Path) -> None:
+    source = tmp_path / "evidence.bin"
+    source.write_bytes(b"artifact-file-default")
+    store = ArtifactStore(tmp_path / "artifacts")
+
+    assert store.put_file(source)["media_type"] == "application/octet-stream"
+
+
+def test_reput_detects_corrupted_existing_blob(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path / "artifacts")
+    data = b"immutable artifact bytes"
+    manifest = store.put_bytes(data)
+    blob_path = store._blob_path(manifest["content_hash"]["digest"])
+    blob_path.write_bytes(b"corrupted artifact byte")
+
+    with pytest.raises(ArtifactIntegrityError, match="hash collision or corrupted blob"):
+        store.put_bytes(data)
+
+
+def test_reput_detects_conflicting_existing_manifest(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path / "artifacts")
+    data = b"immutable manifest fixture"
+    manifest = store.put_bytes(data, media_type="text/plain")
+    path = store._manifest_path(manifest["artifact_id"])
+    conflicting = dict(manifest)
+    conflicting["media_type"] = "application/json"
+    path.write_text(json.dumps(conflicting), encoding="utf-8")
+
+    with pytest.raises(ArtifactIntegrityError, match="manifest conflict"):
+        store.put_bytes(data, media_type="text/plain")
+
+
+def test_get_redaction_is_none_before_redaction(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path / "artifacts")
+    artifact_id = store.put_bytes(b"not redacted")["artifact_id"]
+
+    assert store.is_redacted(artifact_id) is False
+    assert store.get_redaction(artifact_id) is None
+
+
+def test_verify_rejects_same_length_digest_corruption(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path / "artifacts")
+    manifest = store.put_bytes(b"abcdefgh")
+    blob_path = store._blob_path(manifest["content_hash"]["digest"])
+    blob_path.write_bytes(b"ABCDEFGH")
+
+    with pytest.raises(ArtifactIntegrityError, match="artifact verification failed"):
+        store.verify(manifest["artifact_id"])
+
+
+def test_verify_rejects_size_mismatch_even_when_digest_matches(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path / "artifacts")
+    manifest = store.put_bytes(b"size integrity fixture")
+    path = store._manifest_path(manifest["artifact_id"])
+    tampered = dict(manifest)
+    tampered["byte_size"] = manifest["byte_size"] + 1
+    path.write_bytes(store._canonical(tampered))
+
+    with pytest.raises(ArtifactIntegrityError, match="artifact verification failed"):
+        store.verify(manifest["artifact_id"])
+
+
+@pytest.mark.parametrize(
+    ("reason", "authority", "redacted_at"),
+    [
+        ("", "privacy-officer", "2026-08-19T06:00:00Z"),
+        ("privacy request", "", "2026-08-19T06:00:00Z"),
+        ("privacy request", "privacy-officer", ""),
+    ],
+)
+def test_redaction_rejects_each_missing_required_field(
+    tmp_path: Path,
+    reason: str,
+    authority: str,
+    redacted_at: str,
+) -> None:
+    store = ArtifactStore(tmp_path / "artifacts")
+    artifact_id = store.put_bytes(b"redaction required field fixture")["artifact_id"]
+
+    with pytest.raises(
+        ValueError, match="redaction requires reason, authority, and redacted_at"
+    ):
+        store.redact(
+            artifact_id,
+            reason=reason,
+            authority=authority,
+            redacted_at=redacted_at,
+        )
+
+
+def test_redaction_tombstone_is_exact_canonical_record_and_blob_is_removed(
+    tmp_path: Path,
+) -> None:
+    store = ArtifactStore(tmp_path / "artifacts")
+    data = b"sensitive artifact fixture"
+    manifest = store.put_bytes(data, media_type="text/plain")
+    artifact_id = manifest["artifact_id"]
+
+    record = store.redact(
+        artifact_id,
+        reason="privacy request",
+        authority="privacy-officer",
+        redacted_at="2026-08-19T06:00:00Z",
+        request_ref="request-42",
+    )
+
+    assert record == {
+        "artifact_id": artifact_id,
+        "redacted_at": "2026-08-19T06:00:00Z",
+        "reason": "privacy request",
+        "authority": "privacy-officer",
+        "request_ref": "request-42",
+        "content_hash": manifest["content_hash"],
+        "byte_size": len(data),
+        "media_type": "text/plain",
+    }
+    assert store._redaction_path(artifact_id).read_bytes() == store._canonical(record)
+    assert not store._blob_path(manifest["content_hash"]["digest"]).exists()
+    assert store.get_redaction(artifact_id) == record
+
+
+def test_redaction_rejects_conflicting_existing_tombstone(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path / "artifacts")
+    artifact_id = store.put_bytes(b"redaction conflict fixture")["artifact_id"]
+    store.redact(
+        artifact_id,
+        reason="first reason",
+        authority="privacy-officer",
+        redacted_at="2026-08-19T06:00:00Z",
+    )
+
+    with pytest.raises(ArtifactIntegrityError, match="redaction tombstone conflict"):
+        store.redact(
+            artifact_id,
+            reason="different reason",
+            authority="privacy-officer",
+            redacted_at="2026-08-19T06:00:00Z",
+        )


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Continue Phase 2 PDD mutation assurance with a bounded filesystem artifact-store scope after filesystem event-store assurance landed in #200.

## Characterization scope

- mutate `src/fossil_core/adapters/filesystem/artifact_store.py` only
- run direct source/redaction and storage-contract property oracles
- reuse the pinned mutation toolchain and `fossil.mutation-assurance.v1` receipt validator already on `main`
- start at a `0%` characterization floor only to measure the actual mutant distribution
- review survivors and strengthen only behavioral oracle gaps before setting a nonzero evidence-backed per-scope gate

## Property traceability

Properties: `FOSSIL-PROP-ARTIFACT-INTEGRITY-001`, `FOSSIL-PROP-REDACTION-NONRESURRECTION-001`
Property impact: PRESERVE / MUTATION-CHARACTERIZE

## Scope exclusions

- no event-store mutation
- no S3 mutation
- no production storage semantic changes
- no agent authorization mutation
- no promotion work while #111 remains unfrozen
- no hidden holdout, TLA+, or Lean work
- no repository-wide vanity score
- no acceptance weakening

Verification target: exact-head normal DKG plus filesystem artifact-store mutation characterization; then survivor-driven oracle hardening and an evidence-backed per-scope threshold in this same PR.