### PR TITLE
[ASSURANCE] Characterize architecture boundary checker mutants

### DIFF
--- a/.github/workflows/mutation-architecture-boundaries.yml
+++ b/.github/workflows/mutation-architecture-boundaries.yml
@@ -1,0 +1,115 @@
+name: Architecture boundary mutation assurance
+
+on:
+  pull_request:
+    paths:
+      - "scripts/check_architecture_boundaries.py"
+      - "scripts/architecture_inventory.py"
+      - "tests/test_architecture_boundaries.py"
+      - "scripts/check_mutation_assurance.py"
+      - ".github/workflows/mutation-architecture-boundaries.yml"
+      - "pyproject.toml"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/check_architecture_boundaries.py"
+      - "scripts/architecture_inventory.py"
+      - "tests/test_architecture_boundaries.py"
+      - "scripts/check_mutation_assurance.py"
+      - ".github/workflows/mutation-architecture-boundaries.yml"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  architecture-boundaries:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      FOSSIL_SOFTWARE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact target checkout
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "${FOSSIL_SOFTWARE_COMMIT}"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install mutation toolchain
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[test,mutation]'
+          python -m pip check
+          mutmut --version
+      - name: Configure isolated architecture-checker mutation scope
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          marker = "[tool.mutmut]\n"
+          if marker not in text:
+              raise SystemExit("missing [tool.mutmut] block")
+          prefix, _old = text.split(marker, 1)
+          scoped = '''[tool.mutmut]
+          source_paths = ["scripts"]
+          only_mutate = ["scripts/check_architecture_boundaries.py"]
+          also_copy = ["src"]
+          pytest_add_cli_args_test_selection = [
+            "tests/test_architecture_boundaries.py",
+          ]
+          '''
+          path.write_text(prefix + scoped, encoding="utf-8")
+          print(path.read_text(encoding="utf-8"))
+          PY
+      - name: Run architecture boundary mutants
+        shell: bash
+        run: |
+          rm -rf mutants
+          mutmut run
+          mkdir -p build/assurance
+          mutmut results | tee build/assurance/mutation-architecture-boundaries-survivors.txt
+          mutmut export-cicd-stats
+      - name: Show surviving mutant diffs
+        shell: bash
+        run: |
+          awk -F': ' '/: (survived|no tests)$/ {gsub(/^[[:space:]]+/, "", $1); print $1}' \
+            build/assurance/mutation-architecture-boundaries-survivors.txt \
+          | while IFS= read -r mutant; do
+              echo "::group::${mutant}"
+              mutmut show "${mutant}"
+              echo "::endgroup::"
+            done
+      - name: Characterize architecture boundary mutation strength
+        run: |
+          python scripts/check_mutation_assurance.py \
+            mutants/mutmut-cicd-stats.json \
+            --scope architecture-boundaries \
+            --minimum-score 0 \
+            --receipt build/assurance/mutation-architecture-boundaries.json
+      - name: Emit compact mutation receipt
+        shell: bash
+        run: |
+          {
+            echo "## Architecture boundary mutation characterization"
+            echo '```json'
+            cat build/assurance/mutation-architecture-boundaries.json
+            echo '```'
+            echo "### Surviving mutants"
+            echo '```text'
+            cat build/assurance/mutation-architecture-boundaries-survivors.txt
+            echo '```'
+            echo "- issue: #176"
+            echo "- coordination: #94"
+            echo "- property: FOSSIL-PROP-ARCH-BOUNDARY-001"
+            echo "- tool: mutmut source pinned at dc58270d5234752e22247f814431750eafcf6e5f"
+            echo "- mutable source: scripts/check_architecture_boundaries.py only"
+            echo "- mode: characterization; threshold will be set from survivor evidence"
+            echo "- security: secretless; contents:read"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mutation-architecture-boundaries.yml
+++ b/.github/workflows/mutation-architecture-boundaries.yml
@@ -93,18 +93,20 @@ jobs:
               mutmut show "${mutant}"
               echo "::endgroup::"
             done
-      - name: Characterize architecture boundary mutation strength
+      - name: Enforce architecture boundary mutation strength
         run: |
           python scripts/check_mutation_assurance.py \
             mutants/mutmut-cicd-stats.json \
             --scope architecture-boundaries \
-            --minimum-score 0 \
+            --minimum-score 94 \
+            --maximum-survivors 10 \
+            --maximum-no-tests 0 \
             --receipt build/assurance/mutation-architecture-boundaries.json
       - name: Emit compact mutation receipt
         shell: bash
         run: |
           {
-            echo "## Architecture boundary mutation characterization"
+            echo "## Architecture boundary mutation assurance"
             echo '```json'
             cat build/assurance/mutation-architecture-boundaries.json
             echo '```'
@@ -117,7 +119,8 @@ jobs:
             echo "- property: FOSSIL-PROP-ARCH-BOUNDARY-001"
             echo "- tool: mutmut source pinned at dc58270d5234752e22247f814431750eafcf6e5f"
             echo "- mutable source: scripts/check_architecture_boundaries.py only"
-            echo "- mode: characterization; threshold will be set from survivor evidence"
+            echo "- gate: score >= 94%; survivors <= 10; no-test mutants = 0"
+            echo "- survivor review: two Tarjan index-start/spacing mutants are behaviorally equivalent because SCC results depend on monotonic unique ordering, not absolute index values; remaining survivors alter argparse description/help text or formatting only and do not weaken the enforced dependency-boundary property"
             echo "- harness: mutation checkout imports the checker as scripts.check_architecture_boundaries so mutmut's module key matches; committed tests remain unchanged"
             echo "- security: secretless; contents:read"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mutation-architecture-boundaries.yml
+++ b/.github/workflows/mutation-architecture-boundaries.yml
@@ -66,7 +66,14 @@ jobs:
           ]
           '''
           path.write_text(prefix + scoped, encoding="utf-8")
-          print(path.read_text(encoding="utf-8"))
+
+          test_path = Path("tests/test_architecture_boundaries.py")
+          test_text = test_path.read_text(encoding="utf-8")
+          needle = "import check_architecture_boundaries as boundaries  # noqa: E402"
+          replacement = "import scripts.check_architecture_boundaries as boundaries  # noqa: E402"
+          if needle not in test_text:
+              raise SystemExit("architecture test import shape changed")
+          test_path.write_text(test_text.replace(needle, replacement), encoding="utf-8")
           PY
       - name: Run architecture boundary mutants
         shell: bash
@@ -111,5 +118,6 @@ jobs:
             echo "- tool: mutmut source pinned at dc58270d5234752e22247f814431750eafcf6e5f"
             echo "- mutable source: scripts/check_architecture_boundaries.py only"
             echo "- mode: characterization; threshold will be set from survivor evidence"
+            echo "- harness: mutation checkout imports the checker as scripts.check_architecture_boundaries so mutmut's module key matches; committed tests remain unchanged"
             echo "- security: secretless; contents:read"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -41,6 +41,46 @@ def test_current_repository_satisfies_enforced_boundaries():
     assert boundaries.check(ROOT) == []
 
 
+def test_edges_ignore_imports_with_unknown_endpoints():
+    payload = _synthetic_clean_payload()
+    known = "fossil_core.ports.artifact_store"
+    unknown = "fossil_core.not_a_real_module"
+    payload["internal_import_edges"].extend(
+        [
+            {"from": known, "to": unknown},
+            {"from": unknown, "to": known},
+        ]
+    )
+
+    graph = boundaries._edges(payload)
+
+    assert unknown not in graph
+    assert unknown not in graph[known]
+
+
+def test_missing_canonical_module_reports_exact_module():
+    payload = _synthetic_clean_payload()
+    missing = "fossil_core.domain.provenance"
+    payload["modules"].pop(missing)
+
+    problems = boundaries.violations(payload)
+
+    assert f"missing canonical architecture module: {missing}" in problems
+
+
+def test_all_missing_compatibility_modules_are_reported():
+    payload = _synthetic_clean_payload()
+    missing = ["fossil_core.event_store", "fossil_core.ids"]
+    for module in missing:
+        payload["modules"].pop(module)
+
+    problems = boundaries.violations(payload)
+
+    assert {f"missing compatibility module: {module}" for module in missing}.issubset(
+        problems
+    )
+
+
 def test_domain_cannot_depend_on_ports_or_concrete_adapters():
     payload = _synthetic_clean_payload()
     payload["modules"]["fossil_core.domain.lifecycle"]["internal_imports"] = [
@@ -100,30 +140,60 @@ def test_adapter_cannot_import_its_own_legacy_shim():
     assert any("adapter compatibility-cycle risk" in problem for problem in problems)
 
 
-def test_first_party_import_cycles_fail_closed():
+def test_first_party_import_cycles_fail_closed_with_exact_diagnostic():
     payload = deepcopy(_synthetic_clean_payload())
-    payload["modules"]["fossil_core.ports.artifact_store"]["internal_imports"] = [
-        "fossil_core.ports.event_store"
-    ]
-    payload["modules"]["fossil_core.ports.event_store"]["internal_imports"] = [
-        "fossil_core.ports.artifact_store"
-    ]
+    left = "fossil_core.ports.artifact_store"
+    right = "fossil_core.ports.event_store"
+    payload["modules"][left]["internal_imports"] = [right]
+    payload["modules"][right]["internal_imports"] = [left]
     payload["internal_import_edges"].extend(
         [
-            {
-                "from": "fossil_core.ports.artifact_store",
-                "to": "fossil_core.ports.event_store",
-            },
-            {
-                "from": "fossil_core.ports.event_store",
-                "to": "fossil_core.ports.artifact_store",
-            },
+            {"from": left, "to": right},
+            {"from": right, "to": left},
         ]
     )
 
     problems = boundaries.violations(payload)
 
-    assert any("first-party import cycle" in problem for problem in problems)
+    assert f"first-party import cycle: {left} -> {right}" in problems
+
+
+def test_main_uses_explicit_repo_root_and_reports_pass(monkeypatch, capsys, tmp_path):
+    seen: list[Path] = []
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_architecture_boundaries.py", "--repo-root", str(tmp_path)],
+    )
+    monkeypatch.setattr(boundaries, "check", lambda root: seen.append(root) or [])
+
+    assert boundaries.main() == 0
+    assert seen == [tmp_path.resolve()]
+    assert capsys.readouterr().out == "Architecture boundary check PASS\n"
+
+
+def test_main_uses_checker_parent_as_default_repo_root(monkeypatch, capsys):
+    seen: list[Path] = []
+    monkeypatch.setattr(sys, "argv", ["check_architecture_boundaries.py"])
+    monkeypatch.setattr(boundaries, "check", lambda root: seen.append(root) or [])
+
+    assert boundaries.main() == 0
+    assert seen == [Path(boundaries.__file__).resolve().parents[1]]
+    assert capsys.readouterr().out == "Architecture boundary check PASS\n"
+
+
+def test_main_fails_closed_and_reports_each_problem(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_architecture_boundaries.py", "--repo-root", str(tmp_path)],
+    )
+    monkeypatch.setattr(boundaries, "check", lambda root: ["alpha", "beta"])
+
+    assert boundaries.main() == 1
+    assert capsys.readouterr().out == (
+        "Architecture boundary check FAILED:\n- alpha\n- beta\n"
+    )
 
 
 def test_inventory_remains_the_single_source_of_import_edges():


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Continue Phase 2 PDD mutation assurance with the bounded architecture dependency checker scope.

## Characterization scope

- mutate `scripts/check_architecture_boundaries.py` only
- run `tests/test_architecture_boundaries.py`
- reuse the pinned mutation toolchain and `fossil.mutation-assurance.v1` receipt validator already on `main`
- start at a `0%` characterization floor only to measure the actual mutant distribution
- review survivors and strengthen only behavioral oracle gaps before setting a nonzero evidence-backed per-scope gate

## Property traceability

Properties: `FOSSIL-PROP-ARCH-BOUNDARY-001`
Property impact: PRESERVE / MUTATION-CHARACTERIZE

## Scope exclusions

- no production package semantic changes
- no architecture/module moves
- no promotion work while #111 remains unfrozen
- no hidden holdout, TLA+, or Lean work
- no repository-wide vanity score
- no acceptance weakening

Verification target: exact-head normal DKG/dependency integrity plus architecture-checker mutation characterization; then survivor-driven test-oracle hardening and an evidence-backed per-scope threshold in this same PR.