### PR TITLE
[ASSURANCE] Add public hidden-acceptance receipt contract

### DIFF
--- a/contracts/holdout/aggregate-receipt-v1.schema.json
+++ b/contracts/holdout/aggregate-receipt-v1.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fossil.local/contracts/holdout/aggregate-receipt-v1.schema.json",
+  "title": "FOSSIL hidden-acceptance aggregate receipt v1",
+  "description": "Public, non-sensitive aggregate evidence emitted by a separately approved sealed holdout executor. This contract intentionally excludes sealed cases, private oracle details, credentials, and private placement/access information.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "suite_id",
+    "software_commit",
+    "property_ids",
+    "result",
+    "counts",
+    "failure_classes",
+    "sealed_material_disclosed",
+    "private_oracle_disclosed",
+    "credentials_disclosed"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "fossil.hidden-acceptance-aggregate.v1"
+    },
+    "suite_id": {
+      "type": "string",
+      "pattern": "^holdout_[a-z0-9][a-z0-9._-]{0,63}$",
+      "description": "Public logical suite identifier only. It must not encode a private storage location or access path."
+    },
+    "software_commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "property_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^FOSSIL-PROP-[A-Z0-9-]+$"
+      }
+    },
+    "result": {
+      "enum": ["PASS", "FAIL", "BLOCKED"]
+    },
+    "counts": {
+      "type": "object",
+      "required": ["total", "passed", "failed"],
+      "properties": {
+        "total": {"type": "integer", "minimum": 0},
+        "passed": {"type": "integer", "minimum": 0},
+        "failed": {"type": "integer", "minimum": 0}
+      },
+      "additionalProperties": false
+    },
+    "failure_classes": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "required": ["class_id", "count"],
+        "properties": {
+          "class_id": {
+            "enum": [
+              "property_violation",
+              "invalid_output",
+              "missing_evidence",
+              "authority_violation",
+              "non_deterministic_result"
+            ]
+          },
+          "count": {"type": "integer", "minimum": 1}
+        },
+        "additionalProperties": false
+      }
+    },
+    "blocker_class": {
+      "enum": [
+        "private_suite_unavailable",
+        "execution_unavailable",
+        "dependency_unavailable",
+        "policy_not_approved"
+      ]
+    },
+    "public_run_ref": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "Optional public execution reference. Do not place private storage or credential references here."
+    },
+    "sealed_material_disclosed": {"const": false},
+    "private_oracle_disclosed": {"const": false},
+    "credentials_disclosed": {"const": false}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"result": {"const": "BLOCKED"}}, "required": ["result"]},
+      "then": {"required": ["blocker_class"]},
+      "else": {"not": {"required": ["blocker_class"]}}
+    }
+  ],
+  "additionalProperties": false
+}

--- a/contracts/holdout/aggregate-receipt-v1.schema.json
+++ b/contracts/holdout/aggregate-receipt-v1.schema.json
@@ -80,12 +80,6 @@
         "policy_not_approved"
       ]
     },
-    "public_run_ref": {
-      "type": "string",
-      "minLength": 1,
-      "maxLength": 200,
-      "description": "Optional public execution reference. Do not place private storage or credential references here."
-    },
     "sealed_material_disclosed": {"const": false},
     "private_oracle_disclosed": {"const": false},
     "credentials_disclosed": {"const": false}

--- a/docs/architecture/hidden-acceptance-interface.md
+++ b/docs/architecture/hidden-acceptance-interface.md
@@ -6,11 +6,10 @@ Status: Phase 3 public foundation for #176. This document defines only the non-s
 
 Public FOSSIL source may define:
 
-- which public `FOSSIL-PROP-*` properties require hidden acceptance;
+- which active public `FOSSIL-PROP-*` properties require hidden acceptance;
 - a versioned aggregate receipt schema;
 - deterministic validation of that receipt;
-- safe aggregate result counts and coarse failure classes;
-- an optional public execution reference.
+- safe aggregate result counts and coarse failure classes.
 
 Public FOSSIL source must not contain or require:
 
@@ -18,7 +17,7 @@ Public FOSSIL source must not contain or require:
 - exact private oracle expectations;
 - credentials, tokens, secret references, or secret-bearing configuration;
 - a private bucket, repository, path, endpoint, runner, or other placement/access mechanism;
-- free-form failure payloads that could reconstruct private cases.
+- free-form notes, execution references, or failure payloads that could reconstruct private cases or leak placement.
 
 The private placement/access decision remains a separately approved least-privilege concern. This Phase 3 slice does not invent it.
 
@@ -34,7 +33,7 @@ Schema version:
 
 A receipt names a public logical `suite_id`, exact public software commit, one or more public property IDs, a result (`PASS`, `FAIL`, or `BLOCKED`), aggregate case counts, and enumerated aggregate failure classes. Disclosure flags are required and fixed to `false`.
 
-The public validator additionally requires every referenced property to be present in the property catalog with `hidden_acceptance_required: true`, enforces count/result consistency, and rejects unclassified failures.
+The public validator additionally requires every referenced property to be active in the property catalog with `hidden_acceptance_required: true`, enforces count/result consistency, and rejects unclassified failures.
 
 Validator:
 
@@ -52,7 +51,7 @@ Validator:
 
 The aggregate receipt is operational acceptance evidence, not a new source of semantic authority. Architecture and accepted FOSSIL property/contracts remain authoritative. A green receipt cannot weaken deterministic public oracles, mutation gates, live integration gates, or any other required acceptance surface.
 
-The schema intentionally uses `additionalProperties: false` and has no free-form notes field. This makes accidental insertion of case IDs, prompts, exact expected answers, private locations, or credential references fail closed at the public boundary.
+The schema intentionally uses `additionalProperties: false` and has no free-form notes or execution-reference field. This makes accidental insertion of case IDs, prompts, exact expected answers, private locations, credential references, or arbitrary text fail closed at the public boundary.
 
 ## Phase separation
 

--- a/docs/architecture/hidden-acceptance-interface.md
+++ b/docs/architecture/hidden-acceptance-interface.md
@@ -1,0 +1,61 @@
+# Hidden Acceptance Public Interface
+
+Status: Phase 3 public foundation for #176. This document defines only the non-sensitive boundary between FOSSIL's public property catalog and a separately approved sealed holdout executor. It does not select, provision, or expose a private suite location, credential, access mechanism, or execution service.
+
+## Boundary
+
+Public FOSSIL source may define:
+
+- which public `FOSSIL-PROP-*` properties require hidden acceptance;
+- a versioned aggregate receipt schema;
+- deterministic validation of that receipt;
+- safe aggregate result counts and coarse failure classes;
+- an optional public execution reference.
+
+Public FOSSIL source must not contain or require:
+
+- sealed/adversarial case contents or identifiers;
+- exact private oracle expectations;
+- credentials, tokens, secret references, or secret-bearing configuration;
+- a private bucket, repository, path, endpoint, runner, or other placement/access mechanism;
+- free-form failure payloads that could reconstruct private cases.
+
+The private placement/access decision remains a separately approved least-privilege concern. This Phase 3 slice does not invent it.
+
+## Receipt contract
+
+Canonical public schema:
+
+`contracts/holdout/aggregate-receipt-v1.schema.json`
+
+Schema version:
+
+`fossil.hidden-acceptance-aggregate.v1`
+
+A receipt names a public logical `suite_id`, exact public software commit, one or more public property IDs, a result (`PASS`, `FAIL`, or `BLOCKED`), aggregate case counts, and enumerated aggregate failure classes. Disclosure flags are required and fixed to `false`.
+
+The public validator additionally requires every referenced property to be present in the property catalog with `hidden_acceptance_required: true`, enforces count/result consistency, and rejects unclassified failures.
+
+Validator:
+
+`python scripts/check_holdout_aggregate_receipt.py <receipt.json>`
+
+## Result semantics
+
+`PASS` means at least one sealed case was evaluated, all evaluated cases passed, and the aggregate failure count is zero. It is not evidence about any property outside `property_ids`.
+
+`FAIL` means at least one sealed case failed. The receipt may expose only counts grouped into the schema's coarse public failure classes; it must not expose case-level material.
+
+`BLOCKED` means no sealed cases were evaluated and a safe public blocker class explains why. A blocked receipt is never success and cannot contain case failure classes.
+
+## Security and authority
+
+The aggregate receipt is operational acceptance evidence, not a new source of semantic authority. Architecture and accepted FOSSIL property/contracts remain authoritative. A green receipt cannot weaken deterministic public oracles, mutation gates, live integration gates, or any other required acceptance surface.
+
+The schema intentionally uses `additionalProperties: false` and has no free-form notes field. This makes accidental insertion of case IDs, prompts, exact expected answers, private locations, or credential references fail closed at the public boundary.
+
+## Phase separation
+
+This foundation is intentionally independent from mutation testing, TLA+, and Lean. It adds no production runtime behavior and does not authorize promotion work while #111 remains unresolved.
+
+A future private executor may consume this public contract only after its placement/access mechanism is separately approved. That executor should emit the aggregate receipt without copying sealed suite material into this repository, GitHub issue comments, PR discussions, logs, or public artifacts.

--- a/scripts/check_holdout_aggregate_receipt.py
+++ b/scripts/check_holdout_aggregate_receipt.py
@@ -36,7 +36,8 @@ def evaluate(
     hidden_properties = {
         item["property_id"]
         for item in catalog["properties"]
-        if item.get("hidden_acceptance_required") is True
+        if item.get("status") == "active"
+        and item.get("hidden_acceptance_required") is True
     }
     unknown = sorted(set(receipt["property_ids"]) - hidden_properties)
     if unknown:
@@ -108,7 +109,6 @@ def main() -> int:
                 "counts": receipt["counts"],
                 "failure_classes": receipt["failure_classes"],
                 "blocker_class": receipt.get("blocker_class"),
-                "public_run_ref": receipt.get("public_run_ref"),
             },
             indent=2,
         )

--- a/scripts/check_holdout_aggregate_receipt.py
+++ b/scripts/check_holdout_aggregate_receipt.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SCHEMA = ROOT / "contracts/holdout/aggregate-receipt-v1.schema.json"
+DEFAULT_CATALOG = ROOT / "contracts/properties/fossil-properties-v1.json"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def evaluate(
+    receipt: dict[str, Any],
+    *,
+    schema: dict[str, Any],
+    catalog: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+
+    validator = Draft202012Validator(schema)
+    for error in sorted(validator.iter_errors(receipt), key=lambda item: list(item.path)):
+        location = ".".join(str(part) for part in error.path) or "<root>"
+        failures.append(f"schema {location}: {error.message}")
+
+    if failures:
+        return failures
+
+    hidden_properties = {
+        item["property_id"]
+        for item in catalog["properties"]
+        if item.get("hidden_acceptance_required") is True
+    }
+    unknown = sorted(set(receipt["property_ids"]) - hidden_properties)
+    if unknown:
+        failures.append(
+            "receipt property_ids are not active hidden-acceptance properties: "
+            + ", ".join(unknown)
+        )
+
+    counts = receipt["counts"]
+    total = counts["total"]
+    passed = counts["passed"]
+    failed = counts["failed"]
+    if total != passed + failed:
+        failures.append(
+            f"counts total {total} must equal passed+failed ({passed + failed})"
+        )
+
+    classified_failures = sum(item["count"] for item in receipt["failure_classes"])
+    if classified_failures != failed:
+        failures.append(
+            "failure_classes count total "
+            f"{classified_failures} must equal counts.failed {failed}"
+        )
+
+    result = receipt["result"]
+    if result == "PASS":
+        if total <= 0:
+            failures.append("PASS requires at least one evaluated holdout case")
+        if failed != 0 or passed != total:
+            failures.append("PASS requires failed=0 and passed=total")
+    elif result == "FAIL":
+        if failed <= 0:
+            failures.append("FAIL requires at least one failed holdout case")
+    elif result == "BLOCKED":
+        if total != 0 or passed != 0 or failed != 0:
+            failures.append("BLOCKED requires zero evaluated cases")
+        if receipt["failure_classes"]:
+            failures.append("BLOCKED cannot report case failure classes")
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("receipt", type=Path)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    args = parser.parse_args()
+
+    schema = _load(args.schema)
+    Draft202012Validator.check_schema(schema)
+    catalog = _load(args.catalog)
+    receipt = _load(args.receipt)
+
+    failures = evaluate(receipt, schema=schema, catalog=catalog)
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}")
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "schema_version": receipt["schema_version"],
+                "suite_id": receipt["suite_id"],
+                "software_commit": receipt["software_commit"],
+                "property_ids": receipt["property_ids"],
+                "result": receipt["result"],
+                "counts": receipt["counts"],
+                "failure_classes": receipt["failure_classes"],
+                "blocker_class": receipt.get("blocker_class"),
+                "public_run_ref": receipt.get("public_run_ref"),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_holdout_aggregate_receipt.py
+++ b/scripts/check_holdout_aggregate_receipt.py
@@ -55,6 +55,10 @@ def evaluate(
             f"counts total {total} must equal passed+failed ({passed + failed})"
         )
 
+    class_ids = [item["class_id"] for item in receipt["failure_classes"]]
+    if len(class_ids) != len(set(class_ids)):
+        failures.append("failure_classes must contain each class_id at most once")
+
     classified_failures = sum(item["count"] for item in receipt["failure_classes"])
     if classified_failures != failed:
         failures.append(

--- a/tests/test_holdout_aggregate_receipt.py
+++ b/tests/test_holdout_aggregate_receipt.py
@@ -30,7 +30,6 @@ def _pass_receipt() -> dict:
         "sealed_material_disclosed": False,
         "private_oracle_disclosed": False,
         "credentials_disclosed": False,
-        "public_run_ref": "github-run:example-public-ref",
     }
 
 
@@ -72,7 +71,7 @@ def test_blocked_receipt_exposes_only_public_blocker_class() -> None:
     assert evaluate(receipt, schema=schema, catalog=catalog) == []
 
 
-def test_unknown_or_non_hidden_property_ids_are_rejected() -> None:
+def test_unknown_non_hidden_or_inactive_property_ids_are_rejected() -> None:
     schema = _load(SCHEMA_PATH)
     catalog = _load(CATALOG_PATH)
 
@@ -83,6 +82,16 @@ def test_unknown_or_non_hidden_property_ids_are_rejected() -> None:
     public_only = _pass_receipt()
     public_only["property_ids"] = ["FOSSIL-PROP-IDEMPOTENCY-001"]
     assert any("not active hidden-acceptance" in item for item in evaluate(public_only, schema=schema, catalog=catalog))
+
+    inactive_catalog = deepcopy(catalog)
+    for item in inactive_catalog["properties"]:
+        if item["property_id"] == "FOSSIL-PROP-CITATION-INTEGRITY-001":
+            item["status"] = "retired"
+            break
+    assert any(
+        "not active hidden-acceptance" in item
+        for item in evaluate(_pass_receipt(), schema=schema, catalog=inactive_catalog)
+    )
 
 
 def test_count_and_result_consistency_fail_closed() -> None:
@@ -107,7 +116,7 @@ def test_count_and_result_consistency_fail_closed() -> None:
     )
 
 
-def test_private_case_oracle_credential_and_location_fields_are_rejected() -> None:
+def test_private_case_oracle_credential_location_and_freeform_refs_are_rejected() -> None:
     schema = _load(SCHEMA_PATH)
     catalog = _load(CATALOG_PATH)
 
@@ -117,6 +126,8 @@ def test_private_case_oracle_credential_and_location_fields_are_rejected() -> No
         "credential_ref": "secret://holdout-token",
         "storage_location": "private://sealed-suite/path",
         "case_failures": [{"input": "secret adversarial fixture"}],
+        "public_run_ref": "private://could-leak-placement",
+        "notes": "free-form receipt text is intentionally forbidden",
     }
 
     for field, value in forbidden_examples.items():

--- a/tests/test_holdout_aggregate_receipt.py
+++ b/tests/test_holdout_aggregate_receipt.py
@@ -116,6 +116,25 @@ def test_count_and_result_consistency_fail_closed() -> None:
     )
 
 
+def test_duplicate_failure_classes_are_rejected() -> None:
+    schema = _load(SCHEMA_PATH)
+    catalog = _load(CATALOG_PATH)
+    receipt = _pass_receipt()
+    receipt.update(
+        result="FAIL",
+        counts={"total": 12, "passed": 9, "failed": 3},
+        failure_classes=[
+            {"class_id": "property_violation", "count": 1},
+            {"class_id": "property_violation", "count": 2},
+        ],
+    )
+
+    assert any(
+        "each class_id at most once" in item
+        for item in evaluate(receipt, schema=schema, catalog=catalog)
+    )
+
+
 def test_private_case_oracle_credential_location_and_freeform_refs_are_rejected() -> None:
     schema = _load(SCHEMA_PATH)
     catalog = _load(CATALOG_PATH)

--- a/tests/test_holdout_aggregate_receipt.py
+++ b/tests/test_holdout_aggregate_receipt.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from scripts.check_holdout_aggregate_receipt import evaluate
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "contracts/holdout/aggregate-receipt-v1.schema.json"
+CATALOG_PATH = ROOT / "contracts/properties/fossil-properties-v1.json"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _pass_receipt() -> dict:
+    return {
+        "schema_version": "fossil.hidden-acceptance-aggregate.v1",
+        "suite_id": "holdout_citation-integrity-v1",
+        "software_commit": "a" * 40,
+        "property_ids": ["FOSSIL-PROP-CITATION-INTEGRITY-001"],
+        "result": "PASS",
+        "counts": {"total": 12, "passed": 12, "failed": 0},
+        "failure_classes": [],
+        "sealed_material_disclosed": False,
+        "private_oracle_disclosed": False,
+        "credentials_disclosed": False,
+        "public_run_ref": "github-run:example-public-ref",
+    }
+
+
+def test_holdout_aggregate_schema_is_valid_and_pass_receipt_is_accepted() -> None:
+    schema = _load(SCHEMA_PATH)
+    catalog = _load(CATALOG_PATH)
+
+    Draft202012Validator.check_schema(schema)
+    assert evaluate(_pass_receipt(), schema=schema, catalog=catalog) == []
+
+
+def test_fail_receipt_allows_only_aggregate_failure_classes() -> None:
+    schema = _load(SCHEMA_PATH)
+    catalog = _load(CATALOG_PATH)
+    receipt = _pass_receipt()
+    receipt.update(
+        result="FAIL",
+        counts={"total": 12, "passed": 9, "failed": 3},
+        failure_classes=[
+            {"class_id": "property_violation", "count": 2},
+            {"class_id": "missing_evidence", "count": 1},
+        ],
+    )
+
+    assert evaluate(receipt, schema=schema, catalog=catalog) == []
+
+
+def test_blocked_receipt_exposes_only_public_blocker_class() -> None:
+    schema = _load(SCHEMA_PATH)
+    catalog = _load(CATALOG_PATH)
+    receipt = _pass_receipt()
+    receipt.update(
+        result="BLOCKED",
+        counts={"total": 0, "passed": 0, "failed": 0},
+        failure_classes=[],
+        blocker_class="policy_not_approved",
+    )
+
+    assert evaluate(receipt, schema=schema, catalog=catalog) == []
+
+
+def test_unknown_or_non_hidden_property_ids_are_rejected() -> None:
+    schema = _load(SCHEMA_PATH)
+    catalog = _load(CATALOG_PATH)
+
+    unknown = _pass_receipt()
+    unknown["property_ids"] = ["FOSSIL-PROP-NOT-REAL-001"]
+    assert any("not active hidden-acceptance" in item for item in evaluate(unknown, schema=schema, catalog=catalog))
+
+    public_only = _pass_receipt()
+    public_only["property_ids"] = ["FOSSIL-PROP-IDEMPOTENCY-001"]
+    assert any("not active hidden-acceptance" in item for item in evaluate(public_only, schema=schema, catalog=catalog))
+
+
+def test_count_and_result_consistency_fail_closed() -> None:
+    schema = _load(SCHEMA_PATH)
+    catalog = _load(CATALOG_PATH)
+
+    mismatch = _pass_receipt()
+    mismatch["counts"] = {"total": 12, "passed": 10, "failed": 1}
+    failures = evaluate(mismatch, schema=schema, catalog=catalog)
+    assert any("must equal passed+failed" in item for item in failures)
+    assert any("PASS requires failed=0 and passed=total" in item for item in failures)
+
+    unclassified = _pass_receipt()
+    unclassified.update(
+        result="FAIL",
+        counts={"total": 12, "passed": 10, "failed": 2},
+        failure_classes=[{"class_id": "property_violation", "count": 1}],
+    )
+    assert any(
+        "must equal counts.failed" in item
+        for item in evaluate(unclassified, schema=schema, catalog=catalog)
+    )
+
+
+def test_private_case_oracle_credential_and_location_fields_are_rejected() -> None:
+    schema = _load(SCHEMA_PATH)
+    catalog = _load(CATALOG_PATH)
+
+    forbidden_examples = {
+        "case_ids": ["sealed-case-17"],
+        "private_oracle": "exact expected answer",
+        "credential_ref": "secret://holdout-token",
+        "storage_location": "private://sealed-suite/path",
+        "case_failures": [{"input": "secret adversarial fixture"}],
+    }
+
+    for field, value in forbidden_examples.items():
+        receipt = deepcopy(_pass_receipt())
+        receipt[field] = value
+        failures = evaluate(receipt, schema=schema, catalog=catalog)
+        assert failures, field
+        assert any("schema <root>" in item for item in failures), field
+
+
+def test_disclosure_flags_cannot_be_set_true() -> None:
+    schema = _load(SCHEMA_PATH)
+    catalog = _load(CATALOG_PATH)
+
+    for field in (
+        "sealed_material_disclosed",
+        "private_oracle_disclosed",
+        "credentials_disclosed",
+    ):
+        receipt = deepcopy(_pass_receipt())
+        receipt[field] = True
+        failures = evaluate(receipt, schema=schema, catalog=catalog)
+        assert failures, field


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Start Phase 3 with the smallest public-only hidden-acceptance foundation. Define a versioned aggregate receipt contract that a separately approved sealed holdout executor may emit without exposing sealed cases or private oracle details.

## Scope

- add `contracts/holdout/aggregate-receipt-v1.schema.json`
- add `scripts/check_holdout_aggregate_receipt.py`
- add deterministic public contract tests in `tests/test_holdout_aggregate_receipt.py`
- document the public/private boundary in `docs/architecture/hidden-acceptance-interface.md`

## Property traceability

Properties: public `FOSSIL-PROP-*` entries with `hidden_acceptance_required: true`
Property impact: PRESERVE / ASSURANCE-INTERFACE

## Security boundary

- no sealed/adversarial case contents or identifiers
- no exact private oracle expectations
- no credentials or secret references
- no private bucket/repository/path/endpoint/runner selection
- no invented private placement/access mechanism
- aggregate counts and coarse enumerated failure classes only
- disclosure flags fail closed to `false`

## Scope exclusions

- no production/runtime semantic changes
- no mutation changes
- no TLA+ or Lean work
- no promotion work while #111 remains unresolved
- no acceptance weakening

Verification target: exact-head DKG plus targeted hidden-acceptance contract tests; review changed-file/diff/review/main fences before any merge.