### PR TITLE
[ASSURANCE] Add location-free public holdout manifest

### DIFF
--- a/contracts/holdout/fossil-holdout-suites-v1.json
+++ b/contracts/holdout/fossil-holdout-suites-v1.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": "fossil.hidden-acceptance-manifest.v1",
+  "receipt_schema_version": "fossil.hidden-acceptance-aggregate.v1",
+  "suites": [
+    {
+      "suite_id": "holdout_pack-context-authority-v1",
+      "property_ids": [
+        "FOSSIL-PROP-PACK-ISOLATION-001",
+        "FOSSIL-PROP-UNTRUSTED-CONTEXT-001"
+      ],
+      "priority": "critical",
+      "status": "planned"
+    },
+    {
+      "suite_id": "holdout_redaction-nonresurrection-v1",
+      "property_ids": [
+        "FOSSIL-PROP-REDACTION-NONRESURRECTION-001"
+      ],
+      "priority": "critical",
+      "status": "planned"
+    }
+  ],
+  "sealed_material_in_public_repo": false,
+  "private_placement_disclosed": false,
+  "credentials_disclosed": false
+}

--- a/contracts/holdout/public-suite-manifest-v1.schema.json
+++ b/contracts/holdout/public-suite-manifest-v1.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fossil.local/contracts/holdout/public-suite-manifest-v1.schema.json",
+  "title": "FOSSIL public hidden-acceptance suite manifest v1",
+  "description": "Location-free public registry of logical sealed holdout suites and the public properties they cover. It contains no case identifiers/counts/content, private oracle details, credentials, executor identity, or private placement/access information.",
+  "type": "object",
+  "required": [
+    "manifest_version",
+    "receipt_schema_version",
+    "suites",
+    "sealed_material_in_public_repo",
+    "private_placement_disclosed",
+    "credentials_disclosed"
+  ],
+  "properties": {
+    "manifest_version": {"const": "fossil.hidden-acceptance-manifest.v1"},
+    "receipt_schema_version": {"const": "fossil.hidden-acceptance-aggregate.v1"},
+    "suites": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["suite_id", "property_ids", "priority", "status"],
+        "properties": {
+          "suite_id": {
+            "type": "string",
+            "pattern": "^holdout_[a-z0-9][a-z0-9._-]{0,63}$"
+          },
+          "property_ids": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^FOSSIL-PROP-[A-Z0-9-]+$"
+            }
+          },
+          "priority": {"enum": ["critical", "high"]},
+          "status": {"enum": ["planned", "active", "blocked"]}
+        },
+        "additionalProperties": false
+      }
+    },
+    "sealed_material_in_public_repo": {"const": false},
+    "private_placement_disclosed": {"const": false},
+    "credentials_disclosed": {"const": false}
+  },
+  "additionalProperties": false
+}

--- a/docs/architecture/hidden-acceptance-interface.md
+++ b/docs/architecture/hidden-acceptance-interface.md
@@ -7,19 +7,33 @@ Status: Phase 3 public foundation for #176. This document defines only the non-s
 Public FOSSIL source may define:
 
 - which active public `FOSSIL-PROP-*` properties require hidden acceptance;
+- a versioned, location-free manifest of logical suite IDs and public property coverage;
 - a versioned aggregate receipt schema;
-- deterministic validation of that receipt;
+- deterministic validation of those public contracts;
 - safe aggregate result counts and coarse failure classes.
 
 Public FOSSIL source must not contain or require:
 
-- sealed/adversarial case contents or identifiers;
+- sealed/adversarial case contents, identifiers, or counts;
 - exact private oracle expectations;
 - credentials, tokens, secret references, or secret-bearing configuration;
-- a private bucket, repository, path, endpoint, runner, or other placement/access mechanism;
+- a private bucket, repository, path, endpoint, runner, executor, or other placement/access mechanism;
 - free-form notes, execution references, or failure payloads that could reconstruct private cases or leak placement.
 
-The private placement/access decision remains a separately approved least-privilege concern. This Phase 3 slice does not invent it.
+The private placement/access decision remains a separately approved least-privilege concern. These Phase 3 public contracts do not invent it.
+
+## Public suite manifest
+
+Canonical public manifest schema and instance:
+
+- `contracts/holdout/public-suite-manifest-v1.schema.json`
+- `contracts/holdout/fossil-holdout-suites-v1.json`
+
+Manifest version: `fossil.hidden-acceptance-manifest.v1`.
+
+The manifest is only a location-free public registry. Each suite has a logical `suite_id`, active hidden-acceptance property IDs, coarse priority, and public lifecycle status. The initial entries remain `planned`; this does not claim that a private suite, executor, placement, credential, or access mechanism already exists.
+
+The manifest intentionally omits suite size, case identifiers, case contents, private oracle details, execution references, and placement/access fields. Its receipt schema version is mechanically cross-checked against the aggregate receipt contract.
 
 ## Receipt contract
 
@@ -33,7 +47,7 @@ Schema version:
 
 A receipt names a public logical `suite_id`, exact public software commit, one or more public property IDs, a result (`PASS`, `FAIL`, or `BLOCKED`), aggregate case counts, and enumerated aggregate failure classes. Disclosure flags are required and fixed to `false`.
 
-The public validator additionally requires every referenced property to be active in the property catalog with `hidden_acceptance_required: true`, enforces count/result consistency, and rejects unclassified failures.
+The public validator additionally requires every referenced property to be active in the property catalog with `hidden_acceptance_required: true`, enforces count/result consistency, rejects duplicate failure classes, and rejects unclassified failures.
 
 Validator:
 
@@ -49,12 +63,12 @@ Validator:
 
 ## Security and authority
 
-The aggregate receipt is operational acceptance evidence, not a new source of semantic authority. Architecture and accepted FOSSIL property/contracts remain authoritative. A green receipt cannot weaken deterministic public oracles, mutation gates, live integration gates, or any other required acceptance surface.
+The public manifest and aggregate receipt are operational assurance metadata, not new sources of semantic authority. Architecture and accepted FOSSIL property/contracts remain authoritative. A planned manifest entry or green receipt cannot weaken deterministic public oracles, mutation gates, live integration gates, or any other required acceptance surface.
 
-The schema intentionally uses `additionalProperties: false` and has no free-form notes or execution-reference field. This makes accidental insertion of case IDs, prompts, exact expected answers, private locations, credential references, or arbitrary text fail closed at the public boundary.
+The schemas intentionally use `additionalProperties: false` and have no free-form notes or execution-reference fields. This makes accidental insertion of case IDs, prompts, exact expected answers, private locations, credential references, or arbitrary text fail closed at the public boundary.
 
 ## Phase separation
 
 This foundation is intentionally independent from mutation testing, TLA+, and Lean. It adds no production runtime behavior and does not authorize promotion work while #111 remains unresolved.
 
-A future private executor may consume this public contract only after its placement/access mechanism is separately approved. That executor should emit the aggregate receipt without copying sealed suite material into this repository, GitHub issue comments, PR discussions, logs, or public artifacts.
+A future private executor may consume these public contracts only after its placement/access mechanism is separately approved. That executor should emit the aggregate receipt without copying sealed suite material into this repository, GitHub issue comments, PR discussions, logs, or public artifacts.

--- a/tests/test_holdout_manifest.py
+++ b/tests/test_holdout_manifest.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_SCHEMA_PATH = ROOT / "contracts/holdout/public-suite-manifest-v1.schema.json"
+MANIFEST_PATH = ROOT / "contracts/holdout/fossil-holdout-suites-v1.json"
+RECEIPT_SCHEMA_PATH = ROOT / "contracts/holdout/aggregate-receipt-v1.schema.json"
+CATALOG_PATH = ROOT / "contracts/properties/fossil-properties-v1.json"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_public_holdout_manifest_validates_and_matches_receipt_version() -> None:
+    schema = _load(MANIFEST_SCHEMA_PATH)
+    manifest = _load(MANIFEST_PATH)
+    receipt_schema = _load(RECEIPT_SCHEMA_PATH)
+
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    assert manifest["receipt_schema_version"] == receipt_schema["properties"][
+        "schema_version"
+    ]["const"]
+
+
+def test_public_holdout_manifest_suite_ids_are_unique_and_location_free() -> None:
+    manifest = _load(MANIFEST_PATH)
+    suite_ids = [item["suite_id"] for item in manifest["suites"]]
+
+    assert len(suite_ids) == len(set(suite_ids))
+    assert manifest["sealed_material_in_public_repo"] is False
+    assert manifest["private_placement_disclosed"] is False
+    assert manifest["credentials_disclosed"] is False
+    assert all(item["status"] == "planned" for item in manifest["suites"])
+
+
+def test_manifest_references_only_active_hidden_acceptance_properties() -> None:
+    manifest = _load(MANIFEST_PATH)
+    catalog = _load(CATALOG_PATH)
+    allowed = {
+        item["property_id"]
+        for item in catalog["properties"]
+        if item.get("status") == "active"
+        and item.get("hidden_acceptance_required") is True
+    }
+
+    referenced = {
+        property_id
+        for suite in manifest["suites"]
+        for property_id in suite["property_ids"]
+    }
+    assert referenced
+    assert referenced <= allowed
+
+
+def test_manifest_schema_rejects_private_case_execution_and_location_fields() -> None:
+    schema = _load(MANIFEST_SCHEMA_PATH)
+    manifest = _load(MANIFEST_PATH)
+    validator = Draft202012Validator(schema)
+
+    forbidden_top_level = {
+        "case_count": 12,
+        "storage_location": "private://sealed-suite/path",
+        "executor": "private-runner",
+        "credential_ref": "secret://holdout-token",
+        "notes": "free-form text is intentionally absent",
+    }
+    for field, value in forbidden_top_level.items():
+        candidate = deepcopy(manifest)
+        candidate[field] = value
+        assert list(validator.iter_errors(candidate)), field
+
+    forbidden_suite_fields = {
+        "case_ids": ["sealed-case-1"],
+        "case_count": 12,
+        "oracle": "private expected answer",
+        "endpoint": "https://private.invalid",
+        "runner": "private-runner",
+    }
+    for field, value in forbidden_suite_fields.items():
+        candidate = deepcopy(manifest)
+        candidate["suites"][0][field] = value
+        assert list(validator.iter_errors(candidate)), field


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Continue Phase 3 with a bounded public-only suite manifest. Register logical hidden-acceptance suite IDs and their public property coverage without exposing or inventing any private execution placement/access mechanism.

## Scope

- add `contracts/holdout/public-suite-manifest-v1.schema.json`
- add `contracts/holdout/fossil-holdout-suites-v1.json`
- add deterministic manifest validation in `tests/test_holdout_manifest.py`
- update `docs/architecture/hidden-acceptance-interface.md`

## Security boundary

The manifest contains only logical suite IDs, active public hidden-acceptance property IDs, coarse priority, and public lifecycle status. Initial suites are `planned` only.

Explicitly absent: case IDs/counts/content, private exact oracles, credentials/secret refs, private bucket/repository/path/endpoint/runner/executor, execution references, private placement/access mechanism, and free-form notes.

## Scope exclusions

- no production/runtime semantic changes
- no private holdout execution
- no mutation, TLA+, or Lean work
- no promotion work while #111 remains unresolved
- no acceptance weakening

Verification target: exact-head DKG, deterministic schema/manifest/catalog/receipt-version consistency, and final diff/review/main/coordination fences.