### PR TITLE
[ASSURANCE] Add bounded DurableStore TLA+ model

### DIFF
--- a/.github/workflows/tla-durable-store.yml
+++ b/.github/workflows/tla-durable-store.yml
@@ -24,8 +24,15 @@ jobs:
   durable-store:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      FOSSIL_SOFTWARE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact target checkout
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "${FOSSIL_SOFTWARE_COMMIT}"
       - name: Set up Java 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/tla-durable-store.yml
+++ b/.github/workflows/tla-durable-store.yml
@@ -1,0 +1,46 @@
+name: DurableStore TLA+ assurance
+
+on:
+  pull_request:
+    paths:
+      - "formal/tla/DurableStore.tla"
+      - "formal/tla/DurableStore.cfg"
+      - "formal/tla/README.md"
+      - "contracts/properties/fossil-properties-v1.json"
+      - ".github/workflows/tla-durable-store.yml"
+  push:
+    branches: [main]
+    paths:
+      - "formal/tla/DurableStore.tla"
+      - "formal/tla/DurableStore.cfg"
+      - "formal/tla/README.md"
+      - "contracts/properties/fossil-properties-v1.json"
+      - ".github/workflows/tla-durable-store.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  durable-store:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Download pinned TLA+ tools
+        shell: bash
+        run: |
+          curl --fail --silent --show-error --location \
+            --output /tmp/tla2tools.jar \
+            https://github.com/tlaplus/tlaplus/releases/download/v1.7.2/tla2tools.jar
+          echo "7f21faa2cdae3189e7d5fadb4488f0dfcc658407  /tmp/tla2tools.jar" \
+            | sha1sum --check --strict
+      - name: Parse DurableStore model
+        run: java -cp /tmp/tla2tools.jar tla2sany.SANY formal/tla/DurableStore.tla
+      - name: Model-check bounded DurableStore protocol
+        working-directory: formal/tla
+        run: java -jar /tmp/tla2tools.jar -config DurableStore.cfg DurableStore.tla

--- a/formal/tla/DurableStore.cfg
+++ b/formal/tla/DurableStore.cfg
@@ -1,0 +1,15 @@
+CONSTANTS
+    Identities = {i1, i2}
+    Values = {v1, v2}
+    NoValue = none
+
+SPECIFICATION Spec
+
+INVARIANT TypeOK
+INVARIANT ImmutableFirstValue
+INVARIANT TombstoneRequiresHistory
+INVARIANT DeleteRequiresTombstone
+INVARIANT DeletedRedactedIdentityAbsent
+INVARIANT SuccessfulAttemptWasAvailable
+
+CHECK_DEADLOCK FALSE

--- a/formal/tla/DurableStore.tla
+++ b/formal/tla/DurableStore.tla
@@ -1,0 +1,251 @@
+---- MODULE DurableStore ----
+EXTENDS Naturals, FiniteSets
+
+(***************************************************************************
+ * Bounded abstract model of the durable immutable-store laws used by      *
+ * FOSSIL filesystem and S3-compatible event/artifact storage.             *
+ *                                                                         *
+ * This model is assurance evidence for the protocol. It is not a proof    *
+ * of the Python implementation and does not authorize multi-writer        *
+ * semantics.                                                              *
+ *************************************************************************** )
+
+CONSTANTS Identities, Values, NoValue
+
+ASSUME NoValue \notin Values
+ASSUME Identities # {}
+ASSUME Values # {}
+
+ResultValues == {
+    "None",
+    "Created",
+    "Replay",
+    "Conflict",
+    "Redacted",
+    "TombstonePublished",
+    "TombstoneReplay",
+    "Deleted",
+    "Unavailable",
+    "Restarted"
+}
+
+SuccessResults == {
+    "Created",
+    "Replay",
+    "TombstonePublished",
+    "TombstoneReplay",
+    "Deleted"
+}
+
+VARIABLES
+    live,
+    firstValue,
+    tombstoned,
+    deletedAfterRedaction,
+    available,
+    lastResult,
+    lastAttemptAvailable
+
+vars == <<
+    live,
+    firstValue,
+    tombstoned,
+    deletedAfterRedaction,
+    available,
+    lastResult,
+    lastAttemptAvailable
+>>
+
+Init ==
+    /\ live = [id \in Identities |-> NoValue]
+    /\ firstValue = [id \in Identities |-> NoValue]
+    /\ tombstoned = {}
+    /\ deletedAfterRedaction = {}
+    /\ available = TRUE
+    /\ lastResult = "None"
+    /\ lastAttemptAvailable = TRUE
+
+CreateFresh(id, val) ==
+    /\ available
+    /\ id \in Identities
+    /\ val \in Values
+    /\ id \notin tombstoned
+    /\ live[id] = NoValue
+    /\ firstValue[id] = NoValue
+    /\ live' = [live EXCEPT ![id] = val]
+    /\ firstValue' = [firstValue EXCEPT ![id] = val]
+    /\ UNCHANGED <<tombstoned, deletedAfterRedaction, available>>
+    /\ lastResult' = "Created"
+    /\ lastAttemptAvailable' = TRUE
+
+Replay(id, val) ==
+    /\ available
+    /\ id \in Identities
+    /\ val \in Values
+    /\ id \notin tombstoned
+    /\ live[id] = val
+    /\ UNCHANGED <<
+        live,
+        firstValue,
+        tombstoned,
+        deletedAfterRedaction,
+        available
+       >>
+    /\ lastResult' = "Replay"
+    /\ lastAttemptAvailable' = TRUE
+
+Conflict(id, val) ==
+    /\ available
+    /\ id \in Identities
+    /\ val \in Values
+    /\ id \notin tombstoned
+    /\ live[id] # NoValue
+    /\ live[id] # val
+    /\ UNCHANGED <<
+        live,
+        firstValue,
+        tombstoned,
+        deletedAfterRedaction,
+        available
+       >>
+    /\ lastResult' = "Conflict"
+    /\ lastAttemptAvailable' = TRUE
+
+RedactedCreateRejected(id, val) ==
+    /\ available
+    /\ id \in Identities
+    /\ val \in Values
+    /\ id \in tombstoned
+    /\ UNCHANGED <<
+        live,
+        firstValue,
+        tombstoned,
+        deletedAfterRedaction,
+        available
+       >>
+    /\ lastResult' = "Redacted"
+    /\ lastAttemptAvailable' = TRUE
+
+PublishTombstone(id) ==
+    /\ available
+    /\ id \in Identities
+    /\ id \notin tombstoned
+    /\ live[id] # NoValue
+    /\ tombstoned' = tombstoned \cup {id}
+    /\ UNCHANGED <<live, firstValue, deletedAfterRedaction, available>>
+    /\ lastResult' = "TombstonePublished"
+    /\ lastAttemptAvailable' = TRUE
+
+ReplayTombstone(id) ==
+    /\ available
+    /\ id \in Identities
+    /\ id \in tombstoned
+    /\ UNCHANGED <<
+        live,
+        firstValue,
+        tombstoned,
+        deletedAfterRedaction,
+        available
+       >>
+    /\ lastResult' = "TombstoneReplay"
+    /\ lastAttemptAvailable' = TRUE
+
+DeletePayload(id) ==
+    /\ available
+    /\ id \in Identities
+    /\ id \in tombstoned
+    /\ live[id] # NoValue
+    /\ live' = [live EXCEPT ![id] = NoValue]
+    /\ deletedAfterRedaction' = deletedAfterRedaction \cup {id}
+    /\ UNCHANGED <<firstValue, tombstoned, available>>
+    /\ lastResult' = "Deleted"
+    /\ lastAttemptAvailable' = TRUE
+
+UnavailableAttempt ==
+    /\ ~available
+    /\ UNCHANGED <<
+        live,
+        firstValue,
+        tombstoned,
+        deletedAfterRedaction,
+        available
+       >>
+    /\ lastResult' = "Unavailable"
+    /\ lastAttemptAvailable' = FALSE
+
+Outage ==
+    /\ available
+    /\ available' = FALSE
+    /\ UNCHANGED <<
+        live,
+        firstValue,
+        tombstoned,
+        deletedAfterRedaction,
+        lastResult,
+        lastAttemptAvailable
+       >>
+
+Restore ==
+    /\ ~available
+    /\ available' = TRUE
+    /\ UNCHANGED <<
+        live,
+        firstValue,
+        tombstoned,
+        deletedAfterRedaction,
+        lastResult,
+        lastAttemptAvailable
+       >>
+
+Restart ==
+    /\ UNCHANGED <<
+        live,
+        firstValue,
+        tombstoned,
+        deletedAfterRedaction,
+        available
+       >>
+    /\ lastResult' = "Restarted"
+    /\ lastAttemptAvailable' = available
+
+Next ==
+    \/ \E id \in Identities, val \in Values : CreateFresh(id, val)
+    \/ \E id \in Identities, val \in Values : Replay(id, val)
+    \/ \E id \in Identities, val \in Values : Conflict(id, val)
+    \/ \E id \in Identities, val \in Values : RedactedCreateRejected(id, val)
+    \/ \E id \in Identities : PublishTombstone(id)
+    \/ \E id \in Identities : ReplayTombstone(id)
+    \/ \E id \in Identities : DeletePayload(id)
+    \/ UnavailableAttempt
+    \/ Outage
+    \/ Restore
+    \/ Restart
+
+Spec == Init /\ [][Next]_vars
+
+TypeOK ==
+    /\ live \in [Identities -> Values \cup {NoValue}]
+    /\ firstValue \in [Identities -> Values \cup {NoValue}]
+    /\ tombstoned \subseteq Identities
+    /\ deletedAfterRedaction \subseteq Identities
+    /\ available \in BOOLEAN
+    /\ lastResult \in ResultValues
+    /\ lastAttemptAvailable \in BOOLEAN
+
+ImmutableFirstValue ==
+    \A id \in Identities :
+        live[id] # NoValue => live[id] = firstValue[id]
+
+TombstoneRequiresHistory ==
+    \A id \in tombstoned : firstValue[id] # NoValue
+
+DeleteRequiresTombstone ==
+    deletedAfterRedaction \subseteq tombstoned
+
+DeletedRedactedIdentityAbsent ==
+    \A id \in deletedAfterRedaction : live[id] = NoValue
+
+SuccessfulAttemptWasAvailable ==
+    lastResult \in SuccessResults => lastAttemptAvailable
+
+=============================================================================

--- a/formal/tla/DurableStore.tla
+++ b/formal/tla/DurableStore.tla
@@ -8,7 +8,7 @@ EXTENDS Naturals, FiniteSets
  * This model is assurance evidence for the protocol. It is not a proof    *
  * of the Python implementation and does not authorize multi-writer        *
  * semantics.                                                              *
- *************************************************************************** )
+ *************************************************************************)
 
 CONSTANTS Identities, Values, NoValue
 

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -1,0 +1,46 @@
+# FOSSIL TLA+ models
+
+These models are protocol-assurance artifacts for #176. They do not prove the Python implementation and do not replace deterministic, mutation, live-provider, rebuild, security, or semantic acceptance gates.
+
+## DurableStore
+
+`DurableStore.tla` abstracts the provider-neutral laws shared by the filesystem and S3-compatible durable stores:
+
+- an identity is created with one immutable first value;
+- byte-identical replay is accepted without changing durable state;
+- a different value under the same live identity conflicts;
+- a redaction tombstone becomes durable before payload deletion;
+- once an identity is redacted, create attempts are rejected and a deleted payload cannot reappear;
+- unavailable durable storage produces no successful durable mutation;
+- restart preserves durable live/tombstone/history state.
+
+Property traceability:
+
+- `FOSSIL-PROP-IDEMPOTENCY-001`
+- `FOSSIL-PROP-REDACTION-NONRESURRECTION-001`
+
+The model intentionally does **not** specify provider APIs, filesystem paths, S3 keys, payload schemas, multi-writer concurrency, or promotion semantics.
+
+### Bounded configuration
+
+`DurableStore.cfg` checks two abstract identities and two abstract values. The bounded state space is intended to expose protocol/interleaving mistakes, not to establish unbounded correctness.
+
+Checked invariants:
+
+- `TypeOK`
+- `ImmutableFirstValue`
+- `TombstoneRequiresHistory`
+- `DeleteRequiresTombstone`
+- `DeletedRedactedIdentityAbsent`
+- `SuccessfulAttemptWasAvailable`
+
+### Local checking
+
+CI pins the TLA+ tools jar and verifies its published checksum before parsing and running TLC. Equivalent local invocation from this directory is:
+
+```sh
+java -cp /path/to/tla2tools.jar tla2sany.SANY DurableStore.tla
+java -jar /path/to/tla2tools.jar -config DurableStore.cfg DurableStore.tla
+```
+
+Implementation conformance remains established by the existing Python storage/redaction tests and live durability evidence, not by this model alone.


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Start Phase 4 with the bounded provider-neutral DurableStore protocol model already planned by the property catalog.

## Scope

- add `formal/tla/DurableStore.tla`
- add bounded `formal/tla/DurableStore.cfg`
- document abstraction/conformance limits in `formal/tla/README.md`
- add secretless path-triggered `.github/workflows/tla-durable-store.yml`

## Property traceability

Properties: `FOSSIL-PROP-IDEMPOTENCY-001`, `FOSSIL-PROP-REDACTION-NONRESURRECTION-001`
Property impact: PRESERVE / FORMAL-MODEL

## Model boundary

Abstracts immutable create, byte-identical replay, conflicting stable identity, durable tombstone before delete, redacted-identity non-resurrection, outage/restore, and restart-preserves-durable-state behavior. Bounded TLC checks two identities and two values.

This model is protocol assurance only. It does not prove the Python implementation, model provider APIs, or authorize multi-writer semantics.

## Scope exclusions

- no Python/runtime semantic changes
- no holdout or mutation changes
- no Lean work
- no promotion work while #111 remains unresolved
- no private credentials/secrets
- no acceptance weakening

Verification target: exact-head DKG plus exact-head secretless SANY/TLC workflow; then final diff/review/main/coordination fences.