### PR TITLE
[ASSURANCE] Add bounded ProjectionLifecycle TLA+ model

### DIFF
--- a/.github/workflows/tla-projection-lifecycle.yml
+++ b/.github/workflows/tla-projection-lifecycle.yml
@@ -1,0 +1,53 @@
+name: ProjectionLifecycle TLA+ assurance
+
+on:
+  pull_request:
+    paths:
+      - "formal/tla/ProjectionLifecycle.tla"
+      - "formal/tla/ProjectionLifecycle.cfg"
+      - "formal/tla/README.md"
+      - "contracts/properties/fossil-properties-v1.json"
+      - ".github/workflows/tla-projection-lifecycle.yml"
+  push:
+    branches: [main]
+    paths:
+      - "formal/tla/ProjectionLifecycle.tla"
+      - "formal/tla/ProjectionLifecycle.cfg"
+      - "formal/tla/README.md"
+      - "contracts/properties/fossil-properties-v1.json"
+      - ".github/workflows/tla-projection-lifecycle.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  projection-lifecycle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      FOSSIL_SOFTWARE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact target checkout
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "${FOSSIL_SOFTWARE_COMMIT}"
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Download pinned TLA+ tools
+        shell: bash
+        run: |
+          curl --fail --silent --show-error --location \
+            --output /tmp/tla2tools.jar \
+            https://github.com/tlaplus/tlaplus/releases/download/v1.7.2/tla2tools.jar
+          echo "7f21faa2cdae3189e7d5fadb4488f0dfcc658407  /tmp/tla2tools.jar" \
+            | sha1sum --check --strict
+      - name: Parse ProjectionLifecycle model
+        run: java -cp /tmp/tla2tools.jar tla2sany.SANY formal/tla/ProjectionLifecycle.tla
+      - name: Model-check bounded ProjectionLifecycle protocol
+        working-directory: formal/tla
+        run: java -jar /tmp/tla2tools.jar -config ProjectionLifecycle.cfg ProjectionLifecycle.tla

--- a/formal/tla/ProjectionLifecycle.cfg
+++ b/formal/tla/ProjectionLifecycle.cfg
@@ -1,0 +1,15 @@
+CONSTANTS
+    Events = {eventA, eventB}
+    Slots = {slotA, slotB, slotC}
+    NoSlot = noSlot
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    ProjectionCannotManufactureAuthority
+    FreshCandidateIdentity
+    RedactionDoesNotRestoreAuthority
+
+PROPERTIES
+    RedactionEventuallySuppressed

--- a/formal/tla/ProjectionLifecycle.tla
+++ b/formal/tla/ProjectionLifecycle.tla
@@ -1,0 +1,124 @@
+--------------------------- MODULE ProjectionLifecycle ---------------------------
+EXTENDS Naturals, FiniteSets, TLC
+
+CONSTANTS Events, Slots, NoSlot
+ASSUME NoSlot \notin Slots
+
+VARIABLES durable, redacted, projections, activeSlot, candidateSlot, usedSlots, workerUp
+
+vars == <<durable, redacted, projections, activeSlot, candidateSlot, usedSlots, workerUp>>
+
+Canonical == durable \ redacted
+
+ActiveProjection ==
+    IF activeSlot = NoSlot THEN {}
+    ELSE projections[activeSlot]
+
+TypeOK ==
+    /\ durable \subseteq Events
+    /\ redacted \subseteq durable
+    /\ projections \in [Slots -> SUBSET Events]
+    /\ activeSlot \in Slots \cup {NoSlot}
+    /\ candidateSlot \in Slots \cup {NoSlot}
+    /\ usedSlots \subseteq Slots
+    /\ activeSlot # NoSlot => activeSlot \in usedSlots
+    /\ candidateSlot # NoSlot => candidateSlot \in usedSlots
+    /\ workerUp \in BOOLEAN
+
+ProjectionCannotManufactureAuthority ==
+    \A slot \in Slots : projections[slot] \subseteq durable
+
+FreshCandidateIdentity ==
+    candidateSlot = NoSlot \/ candidateSlot # activeSlot
+
+RedactionDoesNotRestoreAuthority ==
+    redacted \subseteq durable
+
+Init ==
+    /\ durable = {}
+    /\ redacted = {}
+    /\ projections = [slot \in Slots |-> {}]
+    /\ activeSlot = NoSlot
+    /\ candidateSlot = NoSlot
+    /\ usedSlots = {}
+    /\ workerUp = TRUE
+
+Commit(event) ==
+    /\ event \in Events \ durable
+    /\ event \notin redacted
+    /\ durable' = durable \cup {event}
+    /\ UNCHANGED <<redacted, projections, activeSlot, candidateSlot, usedSlots, workerUp>>
+
+Redact(event) ==
+    /\ event \in durable \ redacted
+    /\ redacted' = redacted \cup {event}
+    /\ UNCHANGED <<durable, projections, activeSlot, candidateSlot, usedSlots, workerUp>>
+
+BeginRebuild(slot) ==
+    /\ slot \in Slots \ usedSlots
+    /\ slot # activeSlot
+    /\ candidateSlot = NoSlot
+    /\ candidateSlot' = slot
+    /\ usedSlots' = usedSlots \cup {slot}
+    /\ projections' = [projections EXCEPT ![slot] = {}]
+    /\ UNCHANGED <<durable, redacted, activeSlot, workerUp>>
+
+ReplayCandidate(event) ==
+    /\ workerUp
+    /\ candidateSlot # NoSlot
+    /\ event \in Canonical
+    /\ event \notin projections[candidateSlot]
+    /\ projections' = [projections EXCEPT ![candidateSlot] = @ \cup {event}]
+    /\ UNCHANGED <<durable, redacted, activeSlot, candidateSlot, usedSlots, workerUp>>
+
+ActivateCandidate ==
+    /\ workerUp
+    /\ candidateSlot # NoSlot
+    /\ projections[candidateSlot] = Canonical
+    /\ activeSlot' = candidateSlot
+    /\ candidateSlot' = NoSlot
+    /\ UNCHANGED <<durable, redacted, projections, usedSlots, workerUp>>
+
+SweepRedactions ==
+    /\ workerUp
+    /\ \E slot \in Slots : projections[slot] \cap redacted # {}
+    /\ projections' = [slot \in Slots |-> projections[slot] \ redacted]
+    /\ UNCHANGED <<durable, redacted, activeSlot, candidateSlot, usedSlots, workerUp>>
+
+WorkerDown ==
+    /\ workerUp
+    /\ workerUp' = FALSE
+    /\ UNCHANGED <<durable, redacted, projections, activeSlot, candidateSlot, usedSlots>>
+
+WorkerUp ==
+    /\ ~workerUp
+    /\ workerUp' = TRUE
+    /\ UNCHANGED <<durable, redacted, projections, activeSlot, candidateSlot, usedSlots>>
+
+Restart == UNCHANGED vars
+
+Next ==
+    \/ \E event \in Events : Commit(event)
+    \/ \E event \in Events : Redact(event)
+    \/ \E slot \in Slots : BeginRebuild(slot)
+    \/ \E event \in Events : ReplayCandidate(event)
+    \/ ActivateCandidate
+    \/ SweepRedactions
+    \/ WorkerDown
+    \/ WorkerUp
+    \/ Restart
+
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ WF_vars(WorkerUp)
+    /\ SF_vars(SweepRedactions)
+
+NoRedactedProjection ==
+    \A slot \in Slots : projections[slot] \cap redacted = {}
+
+RedactionEventuallySuppressed ==
+    \A event \in Events :
+        (event \in redacted /\ workerUp) ~> (event \notin ActiveProjection)
+
+=============================================================================

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -34,13 +34,46 @@ Checked invariants:
 - `DeletedRedactedIdentityAbsent`
 - `SuccessfulAttemptWasAvailable`
 
-### Local checking
+## ProjectionLifecycle
+
+`ProjectionLifecycle.tla` abstracts the replaceable projection/rebuild lifecycle around durable FOSSIL events:
+
+- projection state can contain only identities already present in durable canonical history;
+- worker failure or restart cannot delete durable truth;
+- rebuilds start in a fresh projection slot rather than destructively reusing the active build identity;
+- only a candidate whose replay exactly matches the currently live durable set may become active;
+- redaction first changes durable authority, after which a functioning worker fairly suppresses the redacted identity from replaceable projection state;
+- projection state never becomes canonical authority by itself.
+
+Property traceability:
+
+- `FOSSIL-PROP-PROJECTION-NONAUTHORITY-001`
+- `FOSSIL-PROP-REBUILD-001`
+- `FOSSIL-PROP-REDACTION-NONRESURRECTION-001`
+
+The model intentionally does **not** specify Graphiti/provider APIs, physical graph IDs, ranking behavior, multi-writer concurrency, event payload schemas, holdout cases, promotion semantics, or a new projection architecture.
+
+### Bounded configuration
+
+`ProjectionLifecycle.cfg` checks two abstract durable events and three abstract rebuild slots. The extra slot permits multiple fresh rebuild/activation cycles within one bounded run. It checks projection non-authority and fresh-candidate safety plus a fair redaction-suppression temporal property under worker recovery.
+
+Checked invariants/properties:
+
+- `TypeOK`
+- `ProjectionCannotManufactureAuthority`
+- `FreshCandidateIdentity`
+- `RedactionDoesNotRestoreAuthority`
+- `RedactionEventuallySuppressed`
+
+## Local checking
 
 CI pins the TLA+ tools jar and verifies its published checksum before parsing and running TLC. Equivalent local invocation from this directory is:
 
 ```sh
 java -cp /path/to/tla2tools.jar tla2sany.SANY DurableStore.tla
 java -jar /path/to/tla2tools.jar -config DurableStore.cfg DurableStore.tla
+java -cp /path/to/tla2tools.jar tla2sany.SANY ProjectionLifecycle.tla
+java -jar /path/to/tla2tools.jar -config ProjectionLifecycle.cfg ProjectionLifecycle.tla
 ```
 
-Implementation conformance remains established by the existing Python storage/redaction tests and live durability evidence, not by this model alone.
+Implementation conformance remains established by the existing Python projection, rebuild, redaction, and live durability evidence, not by these models alone.


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Add the second bounded Phase 4 TLA+ protocol model for replaceable projection/rebuild lifecycle behavior.

## Properties

- `FOSSIL-PROP-PROJECTION-NONAUTHORITY-001`
- `FOSSIL-PROP-REBUILD-001`
- `FOSSIL-PROP-REDACTION-NONRESURRECTION-001`

Property impact: PRESERVE / FORMAL-MODEL

## Scope

- add `formal/tla/ProjectionLifecycle.tla`
- add bounded `formal/tla/ProjectionLifecycle.cfg`
- extend the existing formal README
- add a secretless exact-head path-triggered SANY/TLC workflow

The model abstracts durable-event-before-projection authority, fresh rebuild slot identity, guarded candidate activation, worker failure/recovery/restart, projection non-authority, and fair redaction suppression under a functioning/recovering worker.

## Exclusions

- no Python/runtime semantic changes
- no Graphiti/provider API or ranking model
- no multi-writer architecture
- no holdout or mutation work
- no Lean work
- no promotion changes while #111 remains unresolved
- no acceptance weakening

TLA+ evidence is model evidence only and is not a proof of the Python implementation.

Verification target: exact-head DKG plus ProjectionLifecycle SANY and bounded TLC; final four-file diff/review/main fence before merge.