### PR TITLE
[ASSURANCE] Add bounded lifecycle Lean kernel

### DIFF
--- a/.github/workflows/lean-lifecycle.yml
+++ b/.github/workflows/lean-lifecycle.yml
@@ -1,0 +1,57 @@
+name: Lifecycle Lean assurance
+
+on:
+  pull_request:
+    paths:
+      - "lean-toolchain"
+      - "formal/lean/Fossil/Lifecycle.lean"
+      - "formal/lean/README.md"
+      - "contracts/properties/fossil-properties-v1.json"
+      - ".github/workflows/lean-lifecycle.yml"
+  push:
+    branches: [main]
+    paths:
+      - "lean-toolchain"
+      - "formal/lean/Fossil/Lifecycle.lean"
+      - "formal/lean/README.md"
+      - "contracts/properties/fossil-properties-v1.json"
+      - ".github/workflows/lean-lifecycle.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lifecycle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      FOSSIL_SOFTWARE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact target checkout
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "${FOSSIL_SOFTWARE_COMMIT}"
+      - name: Set up pinned Lean toolchain
+        uses: leanprover/lean-action@v1
+        with:
+          auto-config: false
+          build: false
+          test: false
+          lint: false
+          use-github-cache: false
+      - name: Verify Lean toolchain identity
+        shell: bash
+        run: |
+          lean --version | tee /tmp/lean-version.txt
+          grep -F "version 4.30.0" /tmp/lean-version.txt
+      - name: Reject incomplete theorem placeholders
+        shell: bash
+        run: |
+          if grep -En '\b(sorry|admit)\b' formal/lean/Fossil/Lifecycle.lean; then
+            echo "incomplete Lean proof placeholder detected" >&2
+            exit 1
+          fi
+      - name: Check lifecycle semantic kernel
+        run: lean formal/lean/Fossil/Lifecycle.lean

--- a/.github/workflows/lean-lifecycle.yml
+++ b/.github/workflows/lean-lifecycle.yml
@@ -33,14 +33,14 @@ jobs:
       - name: Verify exact target checkout
         shell: bash
         run: test "$(git rev-parse HEAD)" = "${FOSSIL_SOFTWARE_COMMIT}"
-      - name: Set up pinned Lean toolchain
-        uses: leanprover/lean-action@v1
-        with:
-          auto-config: false
-          build: false
-          test: false
-          lint: false
-          use-github-cache: false
+      - name: Install pinned elan and Lean toolchain
+        shell: bash
+        run: |
+          curl --fail --silent --show-error --location \
+            https://raw.githubusercontent.com/leanprover/elan/464c9d28395000a2a0128e07081e4956d50eced2/elan-init.sh \
+            --output /tmp/elan-init.sh
+          sh /tmp/elan-init.sh -y --default-toolchain "$(cat lean-toolchain)"
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       - name: Verify Lean toolchain identity
         shell: bash
         run: |

--- a/formal/lean/Fossil/Lifecycle.lean
+++ b/formal/lean/Fossil/Lifecycle.lean
@@ -1,0 +1,68 @@
+namespace Fossil.Lifecycle
+
+inductive ClaimState where
+  | proposed
+  | open
+  | supported
+  | disputed
+  | rejected
+  | superseded
+  | retracted
+  | stalePendingReview
+  deriving DecidableEq, Repr
+
+
+def isTerminal : ClaimState → Bool
+  | .rejected => true
+  | .superseded => true
+  | .retracted => true
+  | _ => false
+
+
+def markDependentAfterPremiseSuperseded (dependent : ClaimState) : ClaimState :=
+  if isTerminal dependent then dependent else .stalePendingReview
+
+
+def appendHistory (history : List ClaimState) (next : ClaimState) : List ClaimState :=
+  history ++ [next]
+
+
+theorem superseded_is_terminal : isTerminal .superseded = true := rfl
+
+theorem rejected_is_terminal : isTerminal .rejected = true := rfl
+
+theorem retracted_is_terminal : isTerminal .retracted = true := rfl
+
+theorem stale_pending_review_is_nonterminal :
+    isTerminal .stalePendingReview = false := rfl
+
+
+theorem terminal_dependent_is_preserved
+    (dependent : ClaimState)
+    (h : isTerminal dependent = true) :
+    markDependentAfterPremiseSuperseded dependent = dependent := by
+  simp [markDependentAfterPremiseSuperseded, h]
+
+
+theorem nonterminal_dependent_becomes_stale
+    (dependent : ClaimState)
+    (h : isTerminal dependent = false) :
+    markDependentAfterPremiseSuperseded dependent = .stalePendingReview := by
+  simp [markDependentAfterPremiseSuperseded, h]
+
+
+theorem append_history_preserves_prior_states
+    (history : List ClaimState)
+    (next : ClaimState) :
+    ∃ suffix, appendHistory history next = history ++ suffix := by
+  exact ⟨[next], rfl⟩
+
+
+theorem superseding_premise_does_not_revive_terminal_dependent
+    (dependent : ClaimState)
+    (h : isTerminal dependent = true) :
+    isTerminal (markDependentAfterPremiseSuperseded dependent) = true := by
+  rw [terminal_dependent_is_preserved dependent h]
+  exact h
+
+end Fossil.Lifecycle

--- a/formal/lean/README.md
+++ b/formal/lean/README.md
@@ -1,0 +1,36 @@
+# FOSSIL Lean semantic kernel
+
+These theorem files are Phase 5 assurance artifacts for #176. They formalize small semantic laws; they do **not** prove the Python implementation and do not replace deterministic/property tests, mutation testing, TLA+, hidden holdouts, live-provider checks, or semantic acceptance.
+
+## Toolchain
+
+The repository pins `leanprover/lean4:v4.30.0` in the root `lean-toolchain` file. Lean is an assurance-only development dependency and is not a runtime dependency of `fossil-core`.
+
+## Lifecycle
+
+`Fossil/Lifecycle.lean` defines a small claim-state model corresponding to stable lifecycle laws already enforced by `src/fossil_core/domain/lifecycle.py` and its Python oracles.
+
+Property traceability:
+
+- `FOSSIL-PROP-HISTORY-001`
+- `FOSSIL-PROP-LIFECYCLE-DEPENDENCY-001`
+
+Current theorem surface:
+
+- terminal claim states are explicitly classified;
+- terminal dependents remain unchanged when a premise is superseded;
+- nonterminal dependents become `stalePendingReview` under that dependency-staleness operation;
+- state-history updates are append-only in the formal model;
+- premise supersession cannot revive a terminal dependent through the dependency-staleness operation.
+
+The theorem file intentionally does not model event schemas, providers, storage, projection behavior, pack authority, promotion, or arbitrary lifecycle transitions beyond this bounded stable kernel. Python conformance remains established by the existing lifecycle deterministic/property tests.
+
+## Checking
+
+From the repository root with the pinned Lean toolchain active:
+
+```sh
+lean formal/lean/Fossil/Lifecycle.lean
+```
+
+The spec-triggered CI lane performs the same check on the exact pull-request head and rejects `sorry`/`admit` placeholders in the bounded theorem file.

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.30.0


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Begin Phase 5 with the smallest stable lifecycle-only Lean semantic kernel.

## Properties

- `FOSSIL-PROP-HISTORY-001`
- `FOSSIL-PROP-LIFECYCLE-DEPENDENCY-001`

Property impact: PRESERVE / FORMAL-PROOF

## Scope

- pin Lean 4 in `lean-toolchain`
- add `formal/lean/Fossil/Lifecycle.lean`
- document theorem scope/toolchain identity
- add secretless exact-head lifecycle Lean CI

The formal model proves bounded laws for terminal-state classification, dependency staleness after premise supersession, append-only formal history, and no revival of terminal dependents through that dependency-staleness operation.

## Exclusions

- no Python/runtime semantic changes
- no PackAccess theorem in this slice
- no Promotion theorem while #111 remains unresolved
- no TLA+, mutation, or holdout changes
- no provider/storage/projection model
- no acceptance weakening

Lean proves these formal definitions/theorems only; Python conformance remains in existing lifecycle deterministic/property tests.

Verification target: exact-head DKG plus pinned Lean compile with no `sorry`/`admit`, then final four-file diff/review/main fence.