### PR TITLE
[ASSURANCE] Add bounded PackAccess Lean kernel

### DIFF
--- a/.github/workflows/lean-packaccess.yml
+++ b/.github/workflows/lean-packaccess.yml
@@ -1,0 +1,57 @@
+name: PackAccess Lean assurance
+
+on:
+  pull_request:
+    paths:
+      - "lean-toolchain"
+      - "formal/lean/Fossil/PackAccess.lean"
+      - "formal/lean/README.md"
+      - "contracts/properties/fossil-properties-v1.json"
+      - ".github/workflows/lean-packaccess.yml"
+  push:
+    branches: [main]
+    paths:
+      - "lean-toolchain"
+      - "formal/lean/Fossil/PackAccess.lean"
+      - "formal/lean/README.md"
+      - "contracts/properties/fossil-properties-v1.json"
+      - ".github/workflows/lean-packaccess.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  packaccess:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      FOSSIL_SOFTWARE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact target checkout
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "${FOSSIL_SOFTWARE_COMMIT}"
+      - name: Install pinned elan and Lean toolchain
+        shell: bash
+        run: |
+          curl --fail --silent --show-error --location \
+            https://raw.githubusercontent.com/leanprover/elan/464c9d28395000a2a0128e07081e4956d50eced2/elan-init.sh \
+            --output /tmp/elan-init.sh
+          sh /tmp/elan-init.sh -y --default-toolchain "$(cat lean-toolchain)"
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: Verify Lean toolchain identity
+        shell: bash
+        run: |
+          lean --version | tee /tmp/lean-version.txt
+          grep -F "version 4.30.0" /tmp/lean-version.txt
+      - name: Reject incomplete theorem placeholders
+        shell: bash
+        run: |
+          if grep -En '\b(sorry|admit)\b' formal/lean/Fossil/PackAccess.lean; then
+            echo "incomplete Lean proof placeholder detected" >&2
+            exit 1
+          fi
+      - name: Check PackAccess semantic kernel
+        run: lean formal/lean/Fossil/PackAccess.lean

--- a/formal/lean/Fossil/PackAccess.lean
+++ b/formal/lean/Fossil/PackAccess.lean
@@ -1,0 +1,73 @@
+namespace Fossil.PackAccess
+
+universe u
+
+abbrev Authority (PackId : Type u) := PackId → Prop
+
+def Subset {PackId : Type u} (left right : Authority PackId) : Prop :=
+  ∀ pack, left pack → right pack
+
+structure AccessPolicy (PackId : Type u) where
+  readMounts : Authority PackId
+  writeTargets : Authority PackId
+  writeTargetsReadable : Subset writeTargets readMounts
+
+
+def requestedWithinMounts {PackId : Type u}
+    (requested mounted : Authority PackId) : Authority PackId :=
+  fun pack => requested pack ∧ mounted pack
+
+
+theorem write_authority_implies_read_authority
+    {PackId : Type u}
+    (policy : AccessPolicy PackId)
+    (pack : PackId)
+    (hwrite : policy.writeTargets pack) :
+    policy.readMounts pack := by
+  exact policy.writeTargetsReadable pack hwrite
+
+
+theorem requested_scope_cannot_widen_mounts
+    {PackId : Type u}
+    (requested mounted : Authority PackId) :
+    Subset (requestedWithinMounts requested mounted) mounted := by
+  intro pack h
+  exact h.2
+
+
+theorem requested_scope_cannot_add_unrequested_pack
+    {PackId : Type u}
+    (requested mounted : Authority PackId) :
+    Subset (requestedWithinMounts requested mounted) requested := by
+  intro pack h
+  exact h.1
+
+
+theorem returned_scope_preserves_mount_authority
+    {PackId : Type u}
+    (requested mounted returned : Authority PackId)
+    (hreturned : Subset returned (requestedWithinMounts requested mounted)) :
+    Subset returned mounted := by
+  intro pack h
+  exact (hreturned pack h).2
+
+
+theorem returned_scope_preserves_request_authority
+    {PackId : Type u}
+    (requested mounted returned : Authority PackId)
+    (hreturned : Subset returned (requestedWithinMounts requested mounted)) :
+    Subset returned requested := by
+  intro pack h
+  exact (hreturned pack h).1
+
+
+theorem authority_subset_transitive
+    {PackId : Type u}
+    (first second third : Authority PackId)
+    (h12 : Subset first second)
+    (h23 : Subset second third) :
+    Subset first third := by
+  intro pack h
+  exact h23 pack (h12 pack h)
+
+end Fossil.PackAccess

--- a/formal/lean/README.md
+++ b/formal/lean/README.md
@@ -25,12 +25,31 @@ Current theorem surface:
 
 The theorem file intentionally does not model event schemas, providers, storage, projection behavior, pack authority, promotion, or arbitrary lifecycle transitions beyond this bounded stable kernel. Python conformance remains established by the existing lifecycle deterministic/property tests.
 
+## PackAccess
+
+`Fossil/PackAccess.lean` defines provider-free authority sets corresponding to the stable pack-access boundary in `src/fossil_core/domain/pack.py` and the composed scope laws tracked by #174.
+
+Property traceability:
+
+- `FOSSIL-PROP-PACK-ISOLATION-001`
+- `FOSSIL-PROP-PACK-MANIFEST-001`
+
+Current theorem surface:
+
+- every permitted write target is readable when the policy carries the `writeTargets ⊆ readMounts` invariant;
+- intersecting a requested scope with mounted authority cannot widen either the mounts or the original request;
+- returned scope constrained to that intersection preserves both caller request authority and mounted read authority;
+- authority containment is transitive.
+
+The theorem file intentionally does not define manifests, dependency resolution, pack locks, retrieval ranking, provider APIs, promotion semantics, or Python enforcement mechanics. Python conformance remains established by pack, authorization, and property tests.
+
 ## Checking
 
 From the repository root with the pinned Lean toolchain active:
 
 ```sh
 lean formal/lean/Fossil/Lifecycle.lean
+lean formal/lean/Fossil/PackAccess.lean
 ```
 
-The spec-triggered CI lane performs the same check on the exact pull-request head and rejects `sorry`/`admit` placeholders in the bounded theorem file.
+The spec-triggered CI lanes perform the corresponding checks on the exact pull-request head and reject `sorry`/`admit` placeholders in the bounded theorem files.


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Continue Phase 5 with a separate bounded PackAccess Lean semantic kernel after lifecycle proof landed.

## Properties

- `FOSSIL-PROP-PACK-ISOLATION-001`
- `FOSSIL-PROP-PACK-MANIFEST-001`

Property impact: PRESERVE / FORMAL-PROOF

## Scope

- add `formal/lean/Fossil/PackAccess.lean`
- extend `formal/lean/README.md`
- add secretless exact-head PackAccess Lean CI
- reuse the already pinned root Lean 4.30.0 toolchain

The formal definitions/theorems cover write-target readability under `writeTargets ⊆ readMounts`, requested/mounted scope intersection non-widening, returned-scope containment, and authority-subset transitivity.

## Exclusions

- no lifecycle theorem changes
- no Promotion theorem while #111 remains unresolved
- no Python/runtime semantic changes
- no manifest dependency/pack-lock semantics
- no TLA+, mutation, or holdout changes
- no provider/retrieval implementation model
- no acceptance weakening

Lean proves these formal definitions/theorems only; Python conformance remains in existing pack/authorization/property tests.

Verification target: exact-head DKG plus pinned Lean compile with no `sorry`/`admit`, then final three-file diff/review/main fence.