### PR TITLE
[ASSURANCE] Integrate property catalog into engineering kernel

### DIFF
--- a/.github/workflows/engineering-assurance.yml
+++ b/.github/workflows/engineering-assurance.yml
@@ -4,22 +4,28 @@ on:
   pull_request:
     paths:
       - "contracts/engineering/**"
+      - "contracts/properties/**"
+      - "docs/architecture/property-driven-assurance.md"
       - "src/fossil_core/engineering_preflight.py"
       - "src/fossil_core/engineering_assurance.py"
       - "scripts/validate_engineering_assurance.py"
       - "tests/test_engineering_preflight.py"
       - "tests/test_engineering_assurance.py"
+      - "tests/test_property_catalog.py"
       - ".github/workflows/engineering-assurance.yml"
       - "pyproject.toml"
   push:
     branches: [main]
     paths:
       - "contracts/engineering/**"
+      - "contracts/properties/**"
+      - "docs/architecture/property-driven-assurance.md"
       - "src/fossil_core/engineering_preflight.py"
       - "src/fossil_core/engineering_assurance.py"
       - "scripts/validate_engineering_assurance.py"
       - "tests/test_engineering_preflight.py"
       - "tests/test_engineering_assurance.py"
+      - "tests/test_property_catalog.py"
       - ".github/workflows/engineering-assurance.yml"
       - "pyproject.toml"
 
@@ -30,8 +36,15 @@ jobs:
   engineering-contracts:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      FOSSIL_SOFTWARE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact target checkout
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "${FOSSIL_SOFTWARE_COMMIT}"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -43,22 +56,29 @@ jobs:
           python -m pip check
       - name: Validate preflight, closeout, and cross-repository contracts
         run: python scripts/validate_engineering_assurance.py
-      - name: Run risk-triggered semantic and security fixtures
-        run: python -m pytest -q tests/test_engineering_preflight.py tests/test_engineering_assurance.py
+      - name: Run engineering and property contract fixtures
+        run: >-
+          python -m pytest -q
+          tests/test_engineering_preflight.py
+          tests/test_engineering_assurance.py
+          tests/test_property_catalog.py
       - name: Emit compact secretless receipt
         shell: bash
         run: |
           {
             echo "## Engineering assurance receipt"
             echo "- project_issue_id: #88"
+            echo "- pdd_issue_id: #176"
             echo "- work_order_id: not_applicable"
             echo "- task_id: FOSSIL-04"
             echo "- attempt_id: ${{ github.run_id }}.${{ github.run_attempt }}"
             echo "- generation: not_applicable"
             echo "- request_id: not_applicable"
             echo "- trace_id: not_applicable"
-            echo "- checkpoint_id: ${{ github.sha }}"
-            echo "- commit_sha: ${{ github.sha }}"
+            echo "- checkpoint_id: ${FOSSIL_SOFTWARE_COMMIT}"
+            echo "- commit_sha: ${FOSSIL_SOFTWARE_COMMIT}"
             echo "- deployment_id: not_applicable"
+            echo "- property_catalog: schema + catalog + public-reference validation"
+            echo "- heavy_assurance: mutation/TLA+/Lean remain independently path-triggered"
             echo "- security: secretless; contents:read; privileged PR trigger absent"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Tracking: #176
Control plane: #88 / #89
Coordination: #94

## Purpose

Complete the smallest Phase 6 integration by routing the cheap property-catalog contract check through the existing engineering assurance kernel instead of creating a second control plane.

## Scope

Single workflow file only: `.github/workflows/engineering-assurance.yml`.

- trigger the existing kernel on property catalog/schema/docs/test changes
- exact-head checkout and verification
- run `tests/test_property_catalog.py` alongside existing engineering contract fixtures
- extend the compact secretless receipt with #176/property-catalog evidence

## Heavy assurance boundary

Mutation, TLA+, and Lean remain independently path-triggered. This PR does not call or duplicate those workflows and does not make them always-on.

## Exclusions

- no Python/runtime semantic changes
- no second assurance/control-plane workflow
- no mutation/TLA+/Lean implementation changes
- no hidden holdout/private mechanism changes
- no Promotion work while #111 remains unresolved
- no acceptance weakening

Verification target: exact-head DKG plus Engineering assurance, then final one-file diff/review/main fence.