### PR TITLE
[ASSURANCE] Link TLA invariants to property catalog

### DIFF
--- a/contracts/properties/fossil-properties-v1.json
+++ b/contracts/properties/fossil-properties-v1.json
@@ -58,12 +58,12 @@
       "deterministic_oracles": ["tests/test_event_store.py", "tests/test_s3_storage_adapter.py"],
       "property_oracles": ["tests/test_identity_properties.py", "tests/test_storage_contract_properties.py"],
       "mutation_scope": ["src/fossil_core/domain/identity.py", "src/fossil_core/adapters/filesystem/event_store.py", "src/fossil_core/adapters/s3/storage.py"],
-      "tla_refs": ["formal/tla/DurableStore.tla"],
+      "tla_refs": ["formal/tla/DurableStore.tla::ImmutableFirstValue"],
       "lean_refs": [],
       "hidden_acceptance_required": false,
       "status": "active",
       "source_refs": ["ARCHITECTURE.md"],
-      "notes": "TLA+ reference is planned; the file is intentionally absent until Phase 4."
+      "notes": "Bounded DurableStore TLA+ model checks immutable first-value behavior across create/replay/conflict interleavings; this is protocol-model evidence, not proof of the Python implementation."
     },
     {
       "property_id": "FOSSIL-PROP-LIFECYCLE-DEPENDENCY-001",
@@ -122,12 +122,12 @@
       "deterministic_oracles": ["tests/test_graphiti_projection.py", "tests/test_projection_migration.py"],
       "property_oracles": [],
       "mutation_scope": ["src/fossil_core/projection"],
-      "tla_refs": ["formal/tla/ProjectionLifecycle.tla"],
+      "tla_refs": ["formal/tla/ProjectionLifecycle.tla::ProjectionCannotManufactureAuthority"],
       "lean_refs": [],
       "hidden_acceptance_required": false,
       "status": "active",
       "source_refs": ["ARCHITECTURE.md"],
-      "notes": "TLA+ reference is planned; the file is intentionally absent until Phase 4."
+      "notes": "Bounded ProjectionLifecycle TLA+ model checks that projection slots remain subsets of durable events; this is protocol-model evidence, not proof of the Python implementation."
     },
     {
       "property_id": "FOSSIL-PROP-PROMOTION-001",
@@ -170,12 +170,12 @@
       "deterministic_oracles": ["tests/test_disposable_rebuild_proof.py", "tests/test_projection_migration.py", "tests/test_pack_corpus.py", "scripts/live_object_store_rebuild_proof.py"],
       "property_oracles": ["tests/test_rebuild_temporal_properties.py"],
       "mutation_scope": ["src/fossil_core/application/rebuild/pack_corpus.py", "src/fossil_core/projection"],
-      "tla_refs": ["formal/tla/ProjectionLifecycle.tla"],
+      "tla_refs": ["formal/tla/ProjectionLifecycle.tla::FreshCandidateIdentity", "formal/tla/ProjectionLifecycle.tla::ProjectionCannotManufactureAuthority"],
       "lean_refs": [],
       "hidden_acceptance_required": false,
       "status": "active",
       "source_refs": ["ARCHITECTURE.md"],
-      "notes": "TLA+ reference is planned; the file is intentionally absent until Phase 4."
+      "notes": "Bounded ProjectionLifecycle TLA+ model checks fresh rebuild candidate identity and non-authoritative projection state; this is protocol-model evidence, not proof of the Python implementation."
     },
     {
       "property_id": "FOSSIL-PROP-REDACTION-NONRESURRECTION-001",
@@ -186,12 +186,12 @@
       "deterministic_oracles": ["tests/test_event_redaction.py", "tests/test_s3_storage_adapter.py", "scripts/live_redaction_smoke.py"],
       "property_oracles": ["tests/test_storage_contract_properties.py"],
       "mutation_scope": ["src/fossil_core/adapters/filesystem/artifact_store.py", "src/fossil_core/adapters/filesystem/event_store.py", "src/fossil_core/adapters/s3/storage.py"],
-      "tla_refs": ["formal/tla/DurableStore.tla"],
+      "tla_refs": ["formal/tla/DurableStore.tla::TombstoneRequiresHistory", "formal/tla/DurableStore.tla::DeleteRequiresTombstone", "formal/tla/DurableStore.tla::DeletedRedactedIdentityAbsent"],
       "lean_refs": [],
       "hidden_acceptance_required": true,
       "status": "active",
       "source_refs": ["ARCHITECTURE.md"],
-      "notes": "TLA+ reference is planned; the file is intentionally absent until Phase 4."
+      "notes": "Bounded DurableStore TLA+ model checks tombstone-before-delete and deleted redacted identity absence; this is protocol-model evidence, not proof of the Python implementation."
     },
     {
       "property_id": "FOSSIL-PROP-STABLE-ID-001",


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Close the remaining Phase 4 TLA+ traceability gap without changing any model or runtime semantics.

## Scope

One property-catalog file only:

- replace stale “planned/absent” TLA notes for already-landed models
- link modeled properties to explicit `formal/tla/*.tla::InvariantName` references
- retain explicit wording that TLA+ is bounded protocol-model evidence, not proof of the Python implementation

Mapped invariants include DurableStore immutable-first-value and redaction/tombstone invariants, plus ProjectionLifecycle non-authority and fresh-candidate invariants.

## Exclusions

- no TLA+ model/config changes
- no Lean theorem-name traceability in this slice
- no mutation or holdout changes
- no Python/runtime semantic changes
- no Promotion work while #111 remains unresolved
- no acceptance weakening

Verification target: exact-head DKG, Engineering assurance/property catalog validation, both relevant TLA+ workflows, then final one-file diff/review/main fence.