### PR TITLE
[ASSURANCE] Link TLA invariants to property catalog

### DIFF
--- a/contracts/properties/fossil-properties-v1.json
+++ b/contracts/properties/fossil-properties-v1.json
@@ -58,12 +58,12 @@
       "deterministic_oracles": ["tests/test_event_store.py", "tests/test_s3_storage_adapter.py"],
       "property_oracles": ["tests/test_identity_properties.py", "tests/test_storage_contract_properties.py"],
       "mutation_scope": ["src/fossil_core/domain/identity.py", "src/fossil_core/adapters/filesystem/event_store.py", "src/fossil_core/adapters/s3/storage.py"],
-      "tla_refs": ["formal/tla/DurableStore.tla"],
+      "tla_refs": ["formal/tla/DurableStore.tla::ImmutableFirstValue"],
       "lean_refs": [],
       "hidden_acceptance_required": false,
       "status": "active",
       "source_refs": ["ARCHITECTURE.md"],
-      "notes": "TLA+ reference is planned; the file is intentionally absent until Phase 4."
+      "notes": "Phase 4 DurableStore model checks immutable first-value behavior across create/replay/conflict interleavings; implementation conformance remains covered by Python storage oracles."
     },
     {
       "property_id": "FOSSIL-PROP-LIFECYCLE-DEPENDENCY-001",
@@ -122,12 +122,12 @@
       "deterministic_oracles": ["tests/test_graphiti_projection.py", "tests/test_projection_migration.py"],
       "property_oracles": [],
       "mutation_scope": ["src/fossil_core/projection"],
-      "tla_refs": ["formal/tla/ProjectionLifecycle.tla"],
+      "tla_refs": ["formal/tla/ProjectionLifecycle.tla::ProjectionCannotManufactureAuthority"],
       "lean_refs": [],
       "hidden_acceptance_required": false,
       "status": "active",
       "source_refs": ["ARCHITECTURE.md"],
-      "notes": "TLA+ reference is planned; the file is intentionally absent until Phase 4."
+      "notes": "Phase 4 ProjectionLifecycle model checks that every projection slot remains a subset of durable authority; implementation conformance remains covered by projection tests."
     },
     {
       "property_id": "FOSSIL-PROP-PROMOTION-001",
@@ -170,12 +170,12 @@
       "deterministic_oracles": ["tests/test_disposable_rebuild_proof.py", "tests/test_projection_migration.py", "tests/test_pack_corpus.py", "scripts/live_object_store_rebuild_proof.py"],
       "property_oracles": ["tests/test_rebuild_temporal_properties.py"],
       "mutation_scope": ["src/fossil_core/application/rebuild/pack_corpus.py", "src/fossil_core/projection"],
-      "tla_refs": ["formal/tla/ProjectionLifecycle.tla"],
+      "tla_refs": ["formal/tla/ProjectionLifecycle.tla::FreshCandidateIdentity"],
       "lean_refs": [],
       "hidden_acceptance_required": false,
       "status": "active",
       "source_refs": ["ARCHITECTURE.md"],
-      "notes": "TLA+ reference is planned; the file is intentionally absent until Phase 4."
+      "notes": "Phase 4 ProjectionLifecycle model checks that an in-progress rebuild candidate cannot reuse the active projection identity; Python/live rebuild evidence remains authoritative for implementation conformance."
     },
     {
       "property_id": "FOSSIL-PROP-REDACTION-NONRESURRECTION-001",
@@ -186,12 +186,12 @@
       "deterministic_oracles": ["tests/test_event_redaction.py", "tests/test_s3_storage_adapter.py", "scripts/live_redaction_smoke.py"],
       "property_oracles": ["tests/test_storage_contract_properties.py"],
       "mutation_scope": ["src/fossil_core/adapters/filesystem/artifact_store.py", "src/fossil_core/adapters/filesystem/event_store.py", "src/fossil_core/adapters/s3/storage.py"],
-      "tla_refs": ["formal/tla/DurableStore.tla"],
+      "tla_refs": ["formal/tla/DurableStore.tla::TombstoneRequiresHistory", "formal/tla/DurableStore.tla::DeleteRequiresTombstone", "formal/tla/DurableStore.tla::DeletedRedactedIdentityAbsent"],
       "lean_refs": [],
       "hidden_acceptance_required": true,
       "status": "active",
       "source_refs": ["ARCHITECTURE.md"],
-      "notes": "TLA+ reference is planned; the file is intentionally absent until Phase 4."
+      "notes": "Phase 4 DurableStore model checks tombstone-before-delete and post-redaction absence/non-resurrection invariants; Python/live storage tests remain implementation conformance evidence."
     },
     {
       "property_id": "FOSSIL-PROP-STABLE-ID-001",

--- a/tests/test_property_catalog.py
+++ b/tests/test_property_catalog.py
@@ -48,10 +48,22 @@ def test_property_catalog_is_unique_sorted_and_grounded_in_public_oracles() -> N
             for ref in item[field]:
                 assert _repo_path(ref).exists(), f"{item['property_id']}: missing {field} ref {ref}"
 
-        # Formal references are intentionally allowed to point to future Phase 4/5
-        # artifacts. They are traceability targets, not claims that proofs exist now.
-        for ref in [*item["tla_refs"], *item["lean_refs"]]:
-            assert ref.startswith("formal/"), f"{item['property_id']}: invalid formal ref {ref}"
+        # Phase 4 TLA+ references are executable traceability links: every ref
+        # names both a checked spec file and a concrete model operator/invariant.
+        for ref in item["tla_refs"]:
+            assert ref.startswith("formal/tla/"), f"{item['property_id']}: invalid TLA+ ref {ref}"
+            path_ref, separator, symbol = ref.partition("::")
+            assert separator and symbol, f"{item['property_id']}: TLA+ ref must name a symbol: {ref}"
+            path = ROOT / path_ref
+            assert path.exists(), f"{item['property_id']}: missing TLA+ spec {path_ref}"
+            spec = path.read_text(encoding="utf-8")
+            assert f"{symbol} ==" in spec, f"{item['property_id']}: missing TLA+ symbol {symbol} in {path_ref}"
+
+        # Lean references may still point to later Phase 5 artifacts where the
+        # corresponding semantic law is intentionally deferred (for example
+        # Promotion while #111 remains unresolved).
+        for ref in item["lean_refs"]:
+            assert ref.startswith("formal/lean/"), f"{item['property_id']}: invalid Lean ref {ref}"
 
         # Hidden acceptance cases remain outside this public repository. The
         # catalog records only whether sealed acceptance is required.


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Close the Phase 4 property-catalog traceability gap by binding existing TLA+ model references to concrete checked operators/invariants.

## Scope

- update `contracts/properties/fossil-properties-v1.json` only to replace file-only TLA refs with existing `path::symbol` refs for DurableStore and ProjectionLifecycle properties
- strengthen `tests/test_property_catalog.py` so every TLA ref must name an existing `formal/tla/*` file and concrete symbol present in that spec
- refresh stale Phase 0 notes for the now-landed Phase 4 model evidence

Properties: `FOSSIL-PROP-IDEMPOTENCY-001`, `FOSSIL-PROP-PROJECTION-NONAUTHORITY-001`, `FOSSIL-PROP-REBUILD-001`, `FOSSIL-PROP-REDACTION-NONRESURRECTION-001`
Property impact: PRESERVE / TRACEABILITY
Oracle: `tests/test_property_catalog.py`
TLA+ impact: traceability only; `DurableStore.tla`, `ProjectionLifecycle.tla`, and their configurations are unchanged

## Exclusions

- no Python/runtime semantic changes
- no TLA+ model/config changes
- no mutation, Lean, or holdout changes
- no Promotion work while #111 remains unresolved
- no acceptance weakening
