### PR TITLE
[ASSURANCE] Link Lean theorems to property catalog

### DIFF
--- a/contracts/properties/fossil-properties-v1.json
+++ b/contracts/properties/fossil-properties-v1.json
@@ -43,11 +43,11 @@
       "property_oracles": ["tests/test_lifecycle_properties.py"],
       "mutation_scope": ["src/fossil_core/domain/lifecycle.py"],
       "tla_refs": [],
-      "lean_refs": ["formal/lean/Fossil/Lifecycle.lean"],
+      "lean_refs": ["formal/lean/Fossil/Lifecycle.lean::append_history_preserves_prior_states"],
       "hidden_acceptance_required": false,
       "status": "active",
       "source_refs": ["ARCHITECTURE.md"],
-      "notes": "Lean reference is planned; the file is intentionally absent until Phase 5."
+      "notes": "Phase 5 Lifecycle theorem checks that appending a later state preserves the prior history prefix; this is formal-model evidence, not proof of the Python implementation."
     },
     {
       "property_id": "FOSSIL-PROP-IDEMPOTENCY-001",
@@ -75,11 +75,11 @@
       "property_oracles": ["tests/test_lifecycle_properties.py"],
       "mutation_scope": ["src/fossil_core/domain/lifecycle.py"],
       "tla_refs": [],
-      "lean_refs": ["formal/lean/Fossil/Lifecycle.lean"],
+      "lean_refs": ["formal/lean/Fossil/Lifecycle.lean::terminal_dependent_is_preserved", "formal/lean/Fossil/Lifecycle.lean::nonterminal_dependent_becomes_stale", "formal/lean/Fossil/Lifecycle.lean::superseding_premise_does_not_revive_terminal_dependent"],
       "hidden_acceptance_required": false,
       "status": "active",
       "source_refs": ["ARCHITECTURE.md"],
-      "notes": "Lean reference is planned; the file is intentionally absent until Phase 5."
+      "notes": "Phase 5 Lifecycle theorems check terminal dependent preservation, nonterminal staleness, and no terminal revival after premise supersession; this is formal-model evidence, not proof of the Python implementation."
     },
     {
       "property_id": "FOSSIL-PROP-PACK-ISOLATION-001",
@@ -91,11 +91,11 @@
       "property_oracles": ["tests/test_agent_query_composition_properties.py", "tests/test_pack_properties.py"],
       "mutation_scope": ["src/fossil_core/domain/pack.py", "src/fossil_core/agent.py", "src/fossil_core/application/query/security.py"],
       "tla_refs": [],
-      "lean_refs": ["formal/lean/Fossil/PackAccess.lean"],
+      "lean_refs": ["formal/lean/Fossil/PackAccess.lean::requested_scope_cannot_widen_mounts", "formal/lean/Fossil/PackAccess.lean::requested_scope_cannot_add_unrequested_pack", "formal/lean/Fossil/PackAccess.lean::returned_scope_preserves_mount_authority", "formal/lean/Fossil/PackAccess.lean::returned_scope_preserves_request_authority"],
       "hidden_acceptance_required": true,
       "status": "active",
       "source_refs": ["ARCHITECTURE.md"],
-      "notes": "Composed rich retrieval/context scope is exercised through the agent-facing CorpusService boundary; provider leakage fails closed."
+      "notes": "Phase 5 PackAccess theorems check requested/returned authority subset laws. Composed provider behavior remains covered by Python oracles and sealed holdout requirements; theorem evidence is not proof of the Python implementation."
     },
     {
       "property_id": "FOSSIL-PROP-PACK-MANIFEST-001",
@@ -107,11 +107,11 @@
       "property_oracles": ["tests/test_pack_properties.py"],
       "mutation_scope": ["src/fossil_core/application/ingest/pack_validation.py"],
       "tla_refs": [],
-      "lean_refs": ["formal/lean/Fossil/PackAccess.lean"],
+      "lean_refs": ["formal/lean/Fossil/PackAccess.lean::write_authority_implies_read_authority"],
       "hidden_acceptance_required": false,
       "status": "active",
       "source_refs": ["ARCHITECTURE.md", "schemas/knowledge-pack/v1.schema.json"],
-      "notes": "Dependency-cycle and exact pack-set lock semantics remain owned by #111 and are not asserted here yet."
+      "notes": "Phase 5 PackAccess proves write-target readability only. Dependency-cycle and exact pack-set lock semantics remain owned by #111 and are not asserted here; theorem evidence is not proof of the Python implementation."
     },
     {
       "property_id": "FOSSIL-PROP-PROJECTION-NONAUTHORITY-001",


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Close the bounded Phase 5 theorem-traceability gap for the already-landed Lifecycle and PackAccess Lean kernels.

## Scope

- `contracts/properties/fossil-properties-v1.json` only
- replace file-only Lifecycle/PackAccess Lean refs with concrete `path::theorem` refs
- refresh stale planned/absent notes with bounded theorem-evidence wording
- preserve Promotion and optional Identity future refs unchanged

Properties: `FOSSIL-PROP-HISTORY-001`, `FOSSIL-PROP-LIFECYCLE-DEPENDENCY-001`, `FOSSIL-PROP-PACK-ISOLATION-001`, `FOSSIL-PROP-PACK-MANIFEST-001`
Property impact: PRESERVE / FORMAL TRACEABILITY
Oracle: existing Lifecycle/PackAccess Lean exact-head CI plus property catalog validation

## Exclusions

- no Lean theorem/source changes
- no Lean workflow/toolchain changes
- no schema/test changes
- no TLA+, mutation, holdout, Python/runtime changes
- no Promotion theorem or semantic change while #111 remains unresolved
- theorem evidence is not proof of the Python implementation
- no acceptance weakening
