### PR TITLE
[ASSURANCE] Validate Lean catalog theorem refs

### DIFF
--- a/tests/test_property_catalog.py
+++ b/tests/test_property_catalog.py
@@ -59,11 +59,25 @@ def test_property_catalog_is_unique_sorted_and_grounded_in_public_oracles() -> N
             spec = path.read_text(encoding="utf-8")
             assert f"{symbol} ==" in spec, f"{item['property_id']}: missing TLA+ symbol {symbol} in {path_ref}"
 
-        # Lean references may still point to later Phase 5 artifacts where the
-        # corresponding semantic law is intentionally deferred (for example
-        # Promotion while #111 remains unresolved).
+        # Landed Phase 5 Lean references are executable traceability links too.
+        # Bare refs remain valid only for genuinely future theorem files whose
+        # semantic law is intentionally deferred (for example Promotion while
+        # #111 remains unresolved, or the optional Identity proof).
         for ref in item["lean_refs"]:
             assert ref.startswith("formal/lean/"), f"{item['property_id']}: invalid Lean ref {ref}"
+            path_ref, separator, theorem = ref.partition("::")
+            path = ROOT / path_ref
+            if separator:
+                assert theorem, f"{item['property_id']}: Lean ref must name a theorem: {ref}"
+                assert path.exists(), f"{item['property_id']}: missing Lean file {path_ref}"
+                source = path.read_text(encoding="utf-8")
+                assert f"theorem {theorem}" in source, (
+                    f"{item['property_id']}: missing Lean theorem {theorem} in {path_ref}"
+                )
+            else:
+                assert not path.exists(), (
+                    f"{item['property_id']}: landed Lean ref must name a theorem: {ref}"
+                )
 
         # Hidden acceptance cases remain outside this public repository. The
         # catalog records only whether sealed acceptance is required.


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Make the landed Phase 5 Lean property traceability mechanically fail closed after #217 linked catalog entries to theorem names.

## Scope

- `tests/test_property_catalog.py` only
- require every landed Lean ref to resolve to an existing `formal/lean/*` file and concrete `theorem` declaration
- allow a bare Lean file ref only while the referenced future theorem file does not yet exist, preserving the explicit Promotion/#111 and optional Identity deferrals
- keep existing TLA symbol validation unchanged

## Exclusions

- no catalog content changes
- no Lean theorem/toolchain changes
- no TLA+ model/config changes
- no Python/runtime semantic changes
- no mutation, holdout, or Promotion work
- no acceptance weakening

Verification target: exact-head DKG and Engineering assurance, plus formal regressions triggered by the catalog test surface, then final one-file diff/review/main fence.