### PR TITLE
[ASSURANCE] Validate Lean catalog theorem refs

### DIFF
--- a/tests/test_property_catalog.py
+++ b/tests/test_property_catalog.py
@@ -8,6 +8,8 @@ from jsonschema import Draft202012Validator
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_PATH = ROOT / "contracts/properties/property-catalog-v1.schema.json"
 CATALOG_PATH = ROOT / "contracts/properties/fossil-properties-v1.json"
+LEAN_TOOLCHAIN_PATH = ROOT / "lean-toolchain"
+PINNED_LEAN_TOOLCHAIN = "leanprover/lean4:v4.30.0"
 
 
 def _load(path: Path) -> dict:
@@ -59,11 +61,29 @@ def test_property_catalog_is_unique_sorted_and_grounded_in_public_oracles() -> N
             spec = path.read_text(encoding="utf-8")
             assert f"{symbol} ==" in spec, f"{item['property_id']}: missing TLA+ symbol {symbol} in {path_ref}"
 
-        # Lean references may still point to later Phase 5 artifacts where the
-        # corresponding semantic law is intentionally deferred (for example
-        # Promotion while #111 remains unresolved).
+        # Existing Phase 5 Lean kernels use concrete theorem refs. File-only
+        # refs remain valid only for intentionally future formal targets whose
+        # source file has not landed yet (for example Promotion while #111 is
+        # unresolved and the optional lower-priority Identity proof).
         for ref in item["lean_refs"]:
             assert ref.startswith("formal/lean/"), f"{item['property_id']}: invalid Lean ref {ref}"
+            path_ref, separator, theorem = ref.partition("::")
+            path = ROOT / path_ref
+            if path.exists():
+                assert separator and theorem, (
+                    f"{item['property_id']}: landed Lean ref must name a theorem: {ref}"
+                )
+                source = path.read_text(encoding="utf-8")
+                assert f"theorem {theorem}" in source, (
+                    f"{item['property_id']}: missing Lean theorem {theorem} in {path_ref}"
+                )
+                assert "Lean 4.30.0" in item.get("notes", ""), (
+                    f"{item['property_id']}: landed Lean evidence must record toolchain identity"
+                )
+            else:
+                assert not separator, (
+                    f"{item['property_id']}: future Lean ref cannot claim an absent theorem: {ref}"
+                )
 
         # Hidden acceptance cases remain outside this public repository. The
         # catalog records only whether sealed acceptance is required.
@@ -72,3 +92,7 @@ def test_property_catalog_is_unique_sorted_and_grounded_in_public_oracles() -> N
                 "hidden" in ref.lower() or "holdout" in ref.lower()
                 for ref in [*item["deterministic_oracles"], *item["property_oracles"]]
             )
+
+
+def test_landed_lean_evidence_uses_pinned_toolchain() -> None:
+    assert LEAN_TOOLCHAIN_PATH.read_text(encoding="utf-8").strip() == PINNED_LEAN_TOOLCHAIN


### PR DESCRIPTION
Tracking: #176
Coordination: #94

## Purpose

Make the landed Phase 5 Lean property traceability mechanically fail closed while preserving explicitly future formal refs.

## Scope

- `tests/test_property_catalog.py` only
- for landed Lean files, require `path::theorem` refs and verify the theorem declaration exists
- require landed Lean evidence notes to record Lean 4.30.0
- verify `lean-toolchain` remains pinned to `leanprover/lean4:v4.30.0`
- allow file-only Lean refs only when that formal source file has not landed yet

Property impact: PRESERVE / FORMAL TRACEABILITY VALIDATION
Oracle: `tests/test_property_catalog.py`

## Exclusions

- no property catalog content changes
- no Lean theorem/workflow/toolchain changes
- no TLA+, mutation, holdout, Python/runtime changes
- no Promotion theorem or semantic changes while #111 remains unresolved
- no acceptance weakening
