### PR TITLE
Add fail-closed event contract acceptance gate

### DIFF
--- a/src/fossil_core/adapters/filesystem/event_store.py
+++ b/src/fossil_core/adapters/filesystem/event_store.py
@@ -8,6 +8,7 @@ from typing import Any, Iterator
 
 from jsonschema import Draft202012Validator, FormatChecker
 
+from ...domain.event_contracts import validate_event_for_commit
 from ...ids import deterministic_event_id, new_id
 from .io import publish_immutable
 
@@ -57,7 +58,7 @@ class DurableEventStore:
         ).encode("utf-8")
 
     def prepare(self, event: dict[str, Any]) -> dict[str, Any]:
-        """Assign durable identity and validate without publishing anything."""
+        """Assign durable identity and validate the envelope without accepting it."""
 
         candidate = copy.deepcopy(event)
         pack_id = candidate.get("pack_id")
@@ -78,9 +79,11 @@ class DurableEventStore:
         return candidate
 
     def validate(self, event: dict[str, Any]) -> dict[str, Any]:
-        """Public non-mutating validation path used by agent/API boundaries."""
+        """Non-mutating validation for the durable acceptance boundary."""
 
-        return self.prepare(event)
+        candidate = self.prepare(event)
+        validate_event_for_commit(candidate)
+        return candidate
 
     def is_redacted(self, event_id: str) -> bool:
         return self._redaction_path(event_id).exists()
@@ -97,6 +100,7 @@ class DurableEventStore:
 
     def commit(self, event: dict[str, Any]) -> dict[str, Any]:
         candidate = self.prepare(event)
+        validate_event_for_commit(candidate)
         event_id = candidate["event_id"]
         if self.is_redacted(event_id):
             raise EventRedactedError(

--- a/src/fossil_core/adapters/s3/storage.py
+++ b/src/fossil_core/adapters/s3/storage.py
@@ -9,6 +9,7 @@ from typing import Any, Iterator
 from jsonschema import Draft202012Validator, FormatChecker
 
 from ...artifact_store import ArtifactIntegrityError, ArtifactRedactedError
+from ...domain.event_contracts import validate_event_for_commit
 from ...event_store import (
     EventRedactedError,
     EventRedactionConflict,
@@ -395,7 +396,9 @@ class S3DurableEventStore:
         return candidate
 
     def validate(self, event: dict[str, Any]) -> dict[str, Any]:
-        return self.prepare(event)
+        candidate = self.prepare(event)
+        validate_event_for_commit(candidate)
+        return candidate
 
     def is_redacted(self, event_id: str) -> bool:
         return self.backend.exists(self._redaction_key(event_id))
@@ -417,6 +420,7 @@ class S3DurableEventStore:
 
     def commit(self, event: dict[str, Any]) -> dict[str, Any]:
         candidate = self.prepare(event)
+        validate_event_for_commit(candidate)
         event_id = candidate["event_id"]
         if self.is_redacted(event_id):
             raise EventRedactedError(

--- a/src/fossil_core/domain/event_contracts.py
+++ b/src/fossil_core/domain/event_contracts.py
@@ -55,8 +55,16 @@ def _payload_schema(
     *,
     required: tuple[str, ...],
     properties: Mapping[str, Any],
-    additional_properties: bool = False,
+    additional_properties: bool = True,
 ) -> dict[str, Any]:
+    """Return the registry-owned payload contract for one event type.
+
+    Step 1 intentionally preserves already-written dkg.event.v1 payload
+    extensions. Required semantic fields are explicit, while unknown fields in
+    a registered payload remain forward-compatible until a later payload
+    version intentionally closes them.
+    """
+
     return {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "$id": (
@@ -119,7 +127,9 @@ EVENT_TYPE_CONTRACTS: Mapping[str, EventTypeContract] = {
             "claim.proposed",
             required=("claim_text",),
             properties={
-                "claim_text": _string(),
+                # Empty text is historically valid at the storage-contract layer.
+                # Meaningfulness belongs to review/ingest policy, not identity storage.
+                "claim_text": _string(min_length=0),
                 "citation": {"type": "object"},
             },
         ),
@@ -134,6 +144,7 @@ EVENT_TYPE_CONTRACTS: Mapping[str, EventTypeContract] = {
             properties={
                 "from_state": _CLAIM_STATE,
                 "to_state": _CLAIM_STATE,
+                "citation": {"type": "object"},
             },
         ),
         property_ids=("FOSSIL-PROP-HISTORY-001",),
@@ -147,6 +158,7 @@ EVENT_TYPE_CONTRACTS: Mapping[str, EventTypeContract] = {
             properties={
                 "from_state": _CLAIM_STATE,
                 "superseded_by": _string(),
+                "citation": {"type": "object"},
             },
         ),
         property_ids=(
@@ -156,7 +168,7 @@ EVENT_TYPE_CONTRACTS: Mapping[str, EventTypeContract] = {
     ),
     "relation.proposed": _contract(
         "relation.proposed",
-        commit_eligibility="accepted",
+        commit_eligibility="proposal_only",
         payload_schema=_payload_schema(
             "relation.proposed",
             required=("relation_id", "relation_type", "source_ref", "target_ref"),
@@ -289,10 +301,26 @@ EVENT_TYPE_CONTRACTS: Mapping[str, EventTypeContract] = {
                 },
                 "source_artifact_ids": _string_array(min_items=1),
                 "message_ids": _string_array(min_items=1),
+                "lineage_id": _string(),
             },
         ),
         evidence_policy=EvidencePolicy(evidence_refs="required"),
         property_ids=("FOSSIL-PROP-PROVENANCE-001",),
+    ),
+    "review.completed": _contract(
+        "review.completed",
+        commit_eligibility="accepted",
+        payload_schema=_payload_schema(
+            "review.completed",
+            required=("decision",),
+            properties={"decision": _string()},
+        ),
+        evidence_policy=EvidencePolicy(required_provenance_fields=("method",)),
+        property_ids=("FOSSIL-PROP-PROVENANCE-001", "FOSSIL-PROP-HISTORY-001"),
+        oracle_ids=(
+            "tests/test_event_contracts.py",
+            "tests/test_cognitive_services_benchmark.py",
+        ),
     ),
 }
 
@@ -317,21 +345,12 @@ def _require_nonempty_refs(event: Mapping[str, Any], field: str) -> None:
 def validate_event_for_commit(event: Mapping[str, Any]) -> EventTypeContract:
     """Validate one prepared event against the versioned acceptance registry.
 
-    This function intentionally has no storage-provider, pack-session, agent,
-    projection, or network dependencies. Envelope validation and stable identity
-    assignment remain adapter responsibilities; pack/actor authority remains at
-    the application boundary. The registry adds the event-type semantic gate that
-    every durable adapter can share.
+    The event envelope's optional ``payload_schema`` field is preserved as
+    historical/external metadata. It cannot override this registry: payload
+    validation always uses the registered contract below.
     """
 
     contract = event_contract(str(event.get("event_type", "")))
-    supplied_payload_schema = event.get("payload_schema")
-    expected_payload_schema = str(contract.payload_schema["$id"])
-    if supplied_payload_schema is not None and supplied_payload_schema != expected_payload_schema:
-        raise EventContractError(
-            f"event type {contract.event_type} payload_schema does not match registered contract"
-        )
-
     Draft202012Validator(
         dict(contract.payload_schema),
         format_checker=FormatChecker(),

--- a/src/fossil_core/domain/event_contracts.py
+++ b/src/fossil_core/domain/event_contracts.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+from .lifecycle import CLAIM_STATES, RELATION_STATES, RELATION_TYPES
+
+
+EVENT_TYPE_REGISTRY_VERSION = "dkg.event-type-registry.v1"
+
+
+class EventContractError(ValueError):
+    """An event cannot cross the durable acceptance boundary under the registry."""
+
+
+@dataclass(frozen=True)
+class EvidencePolicy:
+    evidence_refs: str = "optional"
+    source_snapshot_refs: str = "optional"
+    required_provenance_fields: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        allowed = {"optional", "required"}
+        if self.evidence_refs not in allowed:
+            raise ValueError(f"unsupported evidence_refs policy: {self.evidence_refs}")
+        if self.source_snapshot_refs not in allowed:
+            raise ValueError(
+                f"unsupported source_snapshot_refs policy: {self.source_snapshot_refs}"
+            )
+
+
+@dataclass(frozen=True)
+class EventTypeContract:
+    event_type: str
+    contract_version: str
+    commit_eligibility: str
+    payload_schema: Mapping[str, Any]
+    evidence_policy: EvidencePolicy
+    ontology_constraints: Mapping[str, str] | None
+    property_ids: tuple[str, ...]
+    oracle_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.commit_eligibility not in {"proposal_only", "accepted"}:
+            raise ValueError(
+                f"unsupported commit eligibility for {self.event_type}: "
+                f"{self.commit_eligibility}"
+            )
+
+
+def _payload_schema(
+    event_type: str,
+    *,
+    required: tuple[str, ...],
+    properties: Mapping[str, Any],
+    additional_properties: bool = False,
+) -> dict[str, Any]:
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": (
+            "https://pukujan.github.io/fossil-core/schemas/event-types/"
+            f"{event_type}/v1.schema.json"
+        ),
+        "type": "object",
+        "additionalProperties": additional_properties,
+        "required": list(required),
+        "properties": dict(properties),
+    }
+
+
+def _string(*, min_length: int = 1) -> dict[str, Any]:
+    return {"type": "string", "minLength": min_length}
+
+
+def _string_array(*, min_items: int = 0) -> dict[str, Any]:
+    return {
+        "type": "array",
+        "minItems": min_items,
+        "uniqueItems": True,
+        "items": _string(),
+    }
+
+
+def _contract(
+    event_type: str,
+    *,
+    commit_eligibility: str,
+    payload_schema: Mapping[str, Any],
+    evidence_policy: EvidencePolicy = EvidencePolicy(),
+    ontology_constraints: Mapping[str, str] | None = None,
+    property_ids: tuple[str, ...],
+    oracle_ids: tuple[str, ...] = ("tests/test_event_contracts.py",),
+) -> EventTypeContract:
+    return EventTypeContract(
+        event_type=event_type,
+        contract_version=f"dkg.event-contract.{event_type}.v1",
+        commit_eligibility=commit_eligibility,
+        payload_schema=payload_schema,
+        evidence_policy=evidence_policy,
+        ontology_constraints=ontology_constraints,
+        property_ids=property_ids,
+        oracle_ids=oracle_ids,
+    )
+
+
+_CLAIM_STATE = {"type": "string", "enum": sorted(CLAIM_STATES)}
+_RELATION_STATE = {"type": "string", "enum": sorted(RELATION_STATES)}
+_RELATION_TYPE = {"type": "string", "enum": sorted(RELATION_TYPES)}
+_PACK_ID = {"type": "string", "pattern": "^pack_[A-Za-z0-9_-]{16,}$"}
+
+
+EVENT_TYPE_CONTRACTS: Mapping[str, EventTypeContract] = {
+    "claim.proposed": _contract(
+        "claim.proposed",
+        commit_eligibility="proposal_only",
+        payload_schema=_payload_schema(
+            "claim.proposed",
+            required=("claim_text",),
+            properties={
+                "claim_text": _string(),
+                "citation": {"type": "object"},
+            },
+        ),
+        property_ids=("FOSSIL-PROP-PROVENANCE-001", "FOSSIL-PROP-HISTORY-001"),
+    ),
+    "claim.state_changed": _contract(
+        "claim.state_changed",
+        commit_eligibility="accepted",
+        payload_schema=_payload_schema(
+            "claim.state_changed",
+            required=("to_state",),
+            properties={
+                "from_state": _CLAIM_STATE,
+                "to_state": _CLAIM_STATE,
+            },
+        ),
+        property_ids=("FOSSIL-PROP-HISTORY-001",),
+    ),
+    "claim.superseded": _contract(
+        "claim.superseded",
+        commit_eligibility="accepted",
+        payload_schema=_payload_schema(
+            "claim.superseded",
+            required=("superseded_by",),
+            properties={
+                "from_state": _CLAIM_STATE,
+                "superseded_by": _string(),
+            },
+        ),
+        property_ids=(
+            "FOSSIL-PROP-HISTORY-001",
+            "FOSSIL-PROP-LIFECYCLE-DEPENDENCY-001",
+        ),
+    ),
+    "relation.proposed": _contract(
+        "relation.proposed",
+        commit_eligibility="accepted",
+        payload_schema=_payload_schema(
+            "relation.proposed",
+            required=("relation_id", "relation_type", "source_ref", "target_ref"),
+            properties={
+                "relation_id": _string(),
+                "relation_type": _RELATION_TYPE,
+                "source_ref": _string(),
+                "target_ref": _string(),
+                "state": _RELATION_STATE,
+            },
+        ),
+        ontology_constraints={
+            "ontology_ref": "dkg.core@1.0.0",
+            "relation_type_field": "relation_type",
+            "source_ref_field": "source_ref",
+            "target_ref_field": "target_ref",
+        },
+        property_ids=("FOSSIL-PROP-HISTORY-001",),
+    ),
+    "relation.state_changed": _contract(
+        "relation.state_changed",
+        commit_eligibility="accepted",
+        payload_schema=_payload_schema(
+            "relation.state_changed",
+            required=("relation_id", "to_state"),
+            properties={
+                "relation_id": _string(),
+                "from_state": _RELATION_STATE,
+                "to_state": _RELATION_STATE,
+            },
+        ),
+        property_ids=("FOSSIL-PROP-HISTORY-001",),
+    ),
+    "relation.superseded": _contract(
+        "relation.superseded",
+        commit_eligibility="accepted",
+        payload_schema=_payload_schema(
+            "relation.superseded",
+            required=("relation_id",),
+            properties={
+                "relation_id": _string(),
+                "from_state": _RELATION_STATE,
+            },
+        ),
+        property_ids=("FOSSIL-PROP-HISTORY-001",),
+    ),
+    **{
+        event_type: _contract(
+            event_type,
+            commit_eligibility="accepted",
+            payload_schema=_payload_schema(
+                event_type,
+                required=("snapshot_id", "source_id", "reason"),
+                properties={
+                    "snapshot_id": _string(),
+                    "source_id": _string(),
+                    "reason": _string(min_length=0),
+                },
+            ),
+            evidence_policy=EvidencePolicy(
+                source_snapshot_refs="required",
+                required_provenance_fields=("method",),
+            ),
+            property_ids=("FOSSIL-PROP-PROVENANCE-001",),
+        )
+        for event_type in ("source.stale", "source.retracted", "source.restored")
+    },
+    "evidence.redacted": _contract(
+        "evidence.redacted",
+        commit_eligibility="accepted",
+        payload_schema=_payload_schema(
+            "evidence.redacted",
+            required=(
+                "artifact_id",
+                "snapshot_ids",
+                "reason",
+                "authority",
+                "request_ref",
+                "redacted_at",
+            ),
+            properties={
+                "artifact_id": _string(),
+                "snapshot_ids": _string_array(),
+                "reason": _string(),
+                "authority": _string(),
+                "request_ref": {"type": ["string", "null"]},
+                "redacted_at": {"type": "string", "format": "date-time"},
+            },
+        ),
+        evidence_policy=EvidencePolicy(required_provenance_fields=("method",)),
+        property_ids=(
+            "FOSSIL-PROP-PROVENANCE-001",
+            "FOSSIL-PROP-REDACTION-NONRESURRECTION-001",
+        ),
+    ),
+    "knowledge.promoted": _contract(
+        "knowledge.promoted",
+        commit_eligibility="accepted",
+        payload_schema=_payload_schema(
+            "knowledge.promoted",
+            required=("source_pack_id", "target_pack_id", "reason"),
+            properties={
+                "source_pack_id": _PACK_ID,
+                "target_pack_id": _PACK_ID,
+                "reason": _string(min_length=0),
+            },
+        ),
+        evidence_policy=EvidencePolicy(
+            evidence_refs="required",
+            required_provenance_fields=("method",),
+        ),
+        property_ids=("FOSSIL-PROP-PROMOTION-001", "FOSSIL-PROP-PROVENANCE-001"),
+    ),
+    "conversation.ingested": _contract(
+        "conversation.ingested",
+        commit_eligibility="accepted",
+        payload_schema=_payload_schema(
+            "conversation.ingested",
+            required=(
+                "conversation_id",
+                "source_status",
+                "source_artifact_ids",
+                "message_ids",
+            ),
+            properties={
+                "conversation_id": _string(),
+                "source_status": {
+                    "type": "string",
+                    "enum": ["verbatim", "reconstructed", "mixed"],
+                },
+                "source_artifact_ids": _string_array(min_items=1),
+                "message_ids": _string_array(min_items=1),
+            },
+        ),
+        evidence_policy=EvidencePolicy(evidence_refs="required"),
+        property_ids=("FOSSIL-PROP-PROVENANCE-001",),
+    ),
+}
+
+
+def event_contract(event_type: str) -> EventTypeContract:
+    try:
+        return EVENT_TYPE_CONTRACTS[event_type]
+    except KeyError as exc:
+        raise EventContractError(
+            f"unregistered event type cannot cross durable acceptance boundary: {event_type}"
+        ) from exc
+
+
+def _require_nonempty_refs(event: Mapping[str, Any], field: str) -> None:
+    refs = event.get(field)
+    if not isinstance(refs, list) or not refs:
+        raise EventContractError(
+            f"event type {event.get('event_type')} requires non-empty {field}"
+        )
+
+
+def validate_event_for_commit(event: Mapping[str, Any]) -> EventTypeContract:
+    """Validate one prepared event against the versioned acceptance registry.
+
+    This function intentionally has no storage-provider, pack-session, agent,
+    projection, or network dependencies. Envelope validation and stable identity
+    assignment remain adapter responsibilities; pack/actor authority remains at
+    the application boundary. The registry adds the event-type semantic gate that
+    every durable adapter can share.
+    """
+
+    contract = event_contract(str(event.get("event_type", "")))
+    supplied_payload_schema = event.get("payload_schema")
+    expected_payload_schema = str(contract.payload_schema["$id"])
+    if supplied_payload_schema is not None and supplied_payload_schema != expected_payload_schema:
+        raise EventContractError(
+            f"event type {contract.event_type} payload_schema does not match registered contract"
+        )
+
+    Draft202012Validator(
+        dict(contract.payload_schema),
+        format_checker=FormatChecker(),
+    ).validate(event.get("payload"))
+
+    policy = contract.evidence_policy
+    if policy.evidence_refs == "required":
+        _require_nonempty_refs(event, "evidence_refs")
+    if policy.source_snapshot_refs == "required":
+        _require_nonempty_refs(event, "source_snapshot_refs")
+
+    provenance = event.get("provenance")
+    for field in policy.required_provenance_fields:
+        if not isinstance(provenance, Mapping) or not provenance.get(field):
+            raise EventContractError(
+                f"event type {contract.event_type} requires provenance.{field}"
+            )
+
+    return contract
+
+
+__all__ = [
+    "EVENT_TYPE_CONTRACTS",
+    "EVENT_TYPE_REGISTRY_VERSION",
+    "EvidencePolicy",
+    "EventContractError",
+    "EventTypeContract",
+    "event_contract",
+    "validate_event_for_commit",
+]

--- a/tests/test_event_contracts.py
+++ b/tests/test_event_contracts.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from jsonschema import ValidationError
+
+from fossil_core.adapters.s3.storage import S3DurableEventStore
+from fossil_core.domain.event_contracts import (
+    EVENT_TYPE_CONTRACTS,
+    EVENT_TYPE_REGISTRY_VERSION,
+    EventContractError,
+)
+from fossil_core.event_store import DurableEventStore
+
+
+ROOT = Path(__file__).parents[1]
+SCHEMA = ROOT / "schemas/events/v1.schema.json"
+PACK = "pack_269099f7b2ba43b7a99b9427d64092de"
+
+CURRENT_WRITE_EVENT_TYPES = {
+    "claim.proposed",
+    "claim.state_changed",
+    "claim.superseded",
+    "relation.proposed",
+    "relation.state_changed",
+    "relation.superseded",
+    "source.stale",
+    "source.retracted",
+    "source.restored",
+    "evidence.redacted",
+    "knowledge.promoted",
+    "conversation.ingested",
+}
+
+
+def event(
+    event_type: str = "claim.proposed",
+    *,
+    payload: dict | None = None,
+    evidence_refs: list[str] | None = None,
+    source_snapshot_refs: list[str] | None = None,
+    provenance: dict | None = None,
+) -> dict:
+    value = {
+        "schema_version": "dkg.event.v1",
+        "event_type": event_type,
+        "occurred_at": "2026-08-19T15:45:00Z",
+        "recorded_at": "2026-08-19T15:45:01Z",
+        "pack_id": PACK,
+        "actor": {"actor_type": "system", "actor_id": "event-contract-test"},
+        "subject_refs": ["clm_event_contract_fixture"],
+        "idempotency_key": f"event-contract:{event_type}",
+        "payload": payload if payload is not None else {"claim_text": "proposal"},
+    }
+    if evidence_refs is not None:
+        value["evidence_refs"] = evidence_refs
+    if source_snapshot_refs is not None:
+        value["source_snapshot_refs"] = source_snapshot_refs
+    if provenance is not None:
+        value["provenance"] = provenance
+    return value
+
+
+def test_registry_is_versioned_and_covers_the_characterized_write_vocabulary():
+    assert EVENT_TYPE_REGISTRY_VERSION == "dkg.event-type-registry.v1"
+    assert set(EVENT_TYPE_CONTRACTS) == CURRENT_WRITE_EVENT_TYPES
+
+    for event_type, contract in EVENT_TYPE_CONTRACTS.items():
+        assert contract.event_type == event_type
+        assert contract.contract_version.endswith(".v1")
+        assert contract.commit_eligibility in {"proposal_only", "accepted"}
+        assert contract.payload_schema["$id"].endswith("v1.schema.json")
+        assert contract.evidence_policy is not None
+        assert contract.property_ids
+        assert contract.oracle_ids
+
+    assert EVENT_TYPE_CONTRACTS["claim.proposed"].commit_eligibility == "proposal_only"
+    relation = EVENT_TYPE_CONTRACTS["relation.proposed"]
+    assert relation.ontology_constraints == {
+        "ontology_ref": "dkg.core@1.0.0",
+        "relation_type_field": "relation_type",
+        "source_ref_field": "source_ref",
+        "target_ref_field": "target_ref",
+    }
+
+
+def test_prepare_keeps_unknown_proposals_cheap_but_acceptance_fails_closed(tmp_path):
+    store = DurableEventStore(tmp_path / "events", SCHEMA)
+    unknown = event("ontology.concept_split", payload={"concept_id": "concept_fixture"})
+
+    prepared = store.prepare(unknown)
+    assert prepared["event_type"] == "ontology.concept_split"
+    assert list(store.iter_events()) == []
+
+    with pytest.raises(EventContractError, match="unregistered event type"):
+        store.validate(unknown)
+    with pytest.raises(EventContractError, match="unregistered event type"):
+        store.commit(unknown)
+    assert list(store.iter_events()) == []
+
+
+def test_s3_durable_commit_uses_the_same_fail_closed_acceptance_gate():
+    store = S3DurableEventStore(
+        bucket="event-contract-fixture",
+        schema_path=SCHEMA,
+        client=object(),
+    )
+    unknown = event("ontology.concept_split", payload={"concept_id": "concept_fixture"})
+
+    assert store.prepare(unknown)["event_type"] == "ontology.concept_split"
+    with pytest.raises(EventContractError, match="unregistered event type"):
+        store.validate(unknown)
+    with pytest.raises(EventContractError, match="unregistered event type"):
+        store.commit(unknown)
+
+
+def test_registered_payload_contract_rejects_semantically_empty_claim_before_write(tmp_path):
+    store = DurableEventStore(tmp_path / "events", SCHEMA)
+    bad = event("claim.proposed", payload={})
+
+    with pytest.raises(ValidationError):
+        store.validate(bad)
+    with pytest.raises(ValidationError):
+        store.commit(bad)
+    assert list(store.iter_events()) == []
+
+
+def test_promotion_evidence_policy_and_provenance_fail_closed(tmp_path):
+    store = DurableEventStore(tmp_path / "events", SCHEMA)
+    promotion = event(
+        "knowledge.promoted",
+        payload={
+            "source_pack_id": "pack_f024177f89a5442db84171c3dd7f58e5",
+            "target_pack_id": PACK,
+            "reason": "reviewed reuse",
+        },
+        evidence_refs=[],
+        provenance={"method": "explicit_cross_pack_promotion"},
+    )
+
+    with pytest.raises(EventContractError, match="evidence_refs"):
+        store.commit(promotion)
+
+    promotion["evidence_refs"] = ["art_promotion_evidence"]
+    promotion.pop("provenance")
+    with pytest.raises(EventContractError, match="provenance.method"):
+        store.commit(promotion)
+
+
+def test_source_lifecycle_requires_snapshot_reference_and_provenance(tmp_path):
+    store = DurableEventStore(tmp_path / "events", SCHEMA)
+    stale = event(
+        "source.stale",
+        payload={
+            "snapshot_id": "snap_event_contract_fixture",
+            "source_id": "src_event_contract_fixture",
+            "reason": "upstream changed",
+        },
+        source_snapshot_refs=[],
+        provenance={"method": "source_lifecycle"},
+    )
+
+    with pytest.raises(EventContractError, match="source_snapshot_refs"):
+        store.commit(stale)
+
+
+def test_registered_proposal_only_event_can_still_be_recorded_as_proposal(tmp_path):
+    store = DurableEventStore(tmp_path / "events", SCHEMA)
+    committed = store.commit(event())
+
+    assert committed["event_type"] == "claim.proposed"
+    assert EVENT_TYPE_CONTRACTS[committed["event_type"]].commit_eligibility == "proposal_only"
+
+
+def test_historical_unknown_events_remain_replayable_without_silent_upgrade(tmp_path):
+    store = DurableEventStore(tmp_path / "events", SCHEMA)
+    historical = event("ontology.concept_split", payload={"concept_id": "concept_legacy"})
+    historical.pop("idempotency_key")
+    historical["event_id"] = "evt_legacy_event_contract_000001"
+    path = store._event_path(historical["event_id"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(store._canonical(historical))
+
+    assert store.get(historical["event_id"]) == historical
+    assert list(store.iter_events()) == [historical]

--- a/tests/test_event_contracts.py
+++ b/tests/test_event_contracts.py
@@ -31,6 +31,7 @@ CURRENT_WRITE_EVENT_TYPES = {
     "evidence.redacted",
     "knowledge.promoted",
     "conversation.ingested",
+    "review.completed",
 }
 
 
@@ -76,6 +77,7 @@ def test_registry_is_versioned_and_covers_the_characterized_write_vocabulary():
         assert contract.oracle_ids
 
     assert EVENT_TYPE_CONTRACTS["claim.proposed"].commit_eligibility == "proposal_only"
+    assert EVENT_TYPE_CONTRACTS["relation.proposed"].commit_eligibility == "proposal_only"
     relation = EVENT_TYPE_CONTRACTS["relation.proposed"]
     assert relation.ontology_constraints == {
         "ontology_ref": "dkg.core@1.0.0",
@@ -115,9 +117,10 @@ def test_s3_durable_commit_uses_the_same_fail_closed_acceptance_gate():
         store.commit(unknown)
 
 
-def test_registered_payload_contract_rejects_semantically_empty_claim_before_write(tmp_path):
+def test_registered_payload_contract_is_registry_owned_and_rejects_missing_fields(tmp_path):
     store = DurableEventStore(tmp_path / "events", SCHEMA)
     bad = event("claim.proposed", payload={})
+    bad["payload_schema"] = "schemas/legacy/external-payload-reference.json"
 
     with pytest.raises(ValidationError):
         store.validate(bad)

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from jsonschema import ValidationError
 
+from fossil_core.domain.event_contracts import EventContractError
 from fossil_core.event_store import DurableEventStore, IdempotencyConflict
 from fossil_core.ids import deterministic_event_id
 
@@ -149,4 +150,17 @@ def test_invalid_event_rejected_before_write(tmp_path):
     del bad["pack_id"]
     with pytest.raises(ValidationError):
         store.commit(bad)
+    assert list(store.iter_events()) == []
+
+
+def test_unknown_event_type_is_prepare_only_and_fails_validate_and_commit(tmp_path):
+    store = DurableEventStore(tmp_path / "events", SCHEMA)
+    unknown = event()
+    unknown["event_type"] = "ontology.concept_split"
+
+    assert store.prepare(unknown)["event_type"] == "ontology.concept_split"
+    with pytest.raises(EventContractError, match="unregistered event type"):
+        store.validate(unknown)
+    with pytest.raises(EventContractError, match="unregistered event type"):
+        store.commit(unknown)
     assert list(store.iter_events()) == []


### PR DESCRIPTION
Implements one bounded #111 Step 1 slice from the accepted semantic freeze: a versioned event-type contract/evidence-policy registry consumed by both durable event-store acceptance paths.

What changed:
- adds `dkg.event-type-registry.v1` covering the 13 characterized current durable event types;
- records per-type payload contract version, proposal-only vs accepted eligibility, evidence/source-reference policy, provenance requirements, ontology metadata where applicable, property IDs, and executable oracle IDs;
- makes filesystem and S3 `validate()` / `commit()` run the same deterministic registry gate while leaving `prepare()` envelope-only and non-accepting;
- makes unregistered new event types fail closed at `validate()` / `commit()` while preserving cheap `prepare()` characterization;
- preserves `dkg.event.v1` envelope compatibility, legacy/external `payload_schema` metadata, existing payload extensions, deterministic identity, immutable retry semantics, redaction behavior, and historical read/replay of old unknown types;
- adds adversarial FS/S3 oracles plus a mutation-selected filesystem oracle.

Characterization correction found during GREEN: `review.completed` is a live direct-commit event type, so the registry covers 13 types rather than the initially characterized 12.

TDD / exact-head evidence:
- RED: commit `f1d568dfa95ce47eba7300d17ad52d10ac8ff0d9`, DKG run `32272325825` failed for the intended missing `fossil_core.domain.event_contracts` implementation;
- first GREEN attempt `622abcd19f6dff3af9e16d2f24a7526c6e0ccbc5` exposed compatibility gaps rather than infrastructure failures; those were corrected without weakening historical envelope/storage semantics;
- final exact head `354586afaab20ab2bbf2b9e36985d643b7a4a3e9`:
  - DKG contract tests `32273200619` PASS;
  - Dependency integrity `32273200568` PASS;
  - Identity mutation assurance `32273200696` PASS;
  - Filesystem event-store mutation assurance `32273200647` PASS;
  - S3 storage mutation assurance `32273200510` PASS.

Scope / non-goals:
- no packset lock;
- no promotion-v2/source revision-event pin;
- no storage/provider/projection rewrite;
- no private holdout work;
- no new mutation/TLA+/Lean lane;
- no production promotion or deployment.

Important remaining #111 work: this slice records the relation ontology reference/constraint fields and fails closed on unregistered relation types, but it does **not** claim Law 3 endpoint-kind resolution is complete. The current durable relation event shape carries endpoint refs but not resolved endpoint kinds, and the storage adapters have no mounted-entity resolver. Mechanical ontology-owned source/target-kind resolution therefore remains an explicit follow-on before #111 semantic commit enforcement can be called complete; this PR does not invent a permissive fallback or a storage-coupled resolver.

Affected stable properties include `FOSSIL-PROP-ARCH-BOUNDARY-001`, `FOSSIL-PROP-PROVENANCE-001`, `FOSSIL-PROP-IDEMPOTENCY-001`, `FOSSIL-PROP-HISTORY-001`, `FOSSIL-PROP-PROMOTION-001`, `FOSSIL-PROP-LIFECYCLE-DEPENDENCY-001`, and `FOSSIL-PROP-REDACTION-NONRESURRECTION-001`.

Closes no issue; #111 remains open.