### PR TITLE
Enforce ontology-owned relation endpoint validity

### DIFF
--- a/src/fossil_core/adapters/filesystem/event_store.py
+++ b/src/fossil_core/adapters/filesystem/event_store.py
@@ -9,6 +9,7 @@ from typing import Any, Iterator
 from jsonschema import Draft202012Validator, FormatChecker
 
 from ...domain.event_contracts import validate_event_for_commit
+from ...domain.ontology import EndpointTypeResolver
 from ...ids import deterministic_event_id, new_id
 from .io import publish_immutable
 
@@ -34,13 +35,20 @@ class DurableEventStore:
     subjects, evidence refs, and provenance are not copied into the tombstone.
     """
 
-    def __init__(self, root: Path, schema_path: Path):
+    def __init__(
+        self,
+        root: Path,
+        schema_path: Path,
+        *,
+        endpoint_type_resolver: EndpointTypeResolver | None = None,
+    ):
         self.root = Path(root)
         self.root.mkdir(parents=True, exist_ok=True)
         self.redactions = self.root / "_redactions"
         self.redactions.mkdir(parents=True, exist_ok=True)
         schema = json.loads(Path(schema_path).read_text(encoding="utf-8"))
         self.validator = Draft202012Validator(schema, format_checker=FormatChecker())
+        self.endpoint_type_resolver = endpoint_type_resolver
 
     def _event_path(self, event_id: str) -> Path:
         suffix = event_id.removeprefix("evt_")
@@ -82,7 +90,10 @@ class DurableEventStore:
         """Non-mutating validation for the durable acceptance boundary."""
 
         candidate = self.prepare(event)
-        validate_event_for_commit(candidate)
+        validate_event_for_commit(
+            candidate,
+            endpoint_type_resolver=self.endpoint_type_resolver,
+        )
         return candidate
 
     def is_redacted(self, event_id: str) -> bool:
@@ -100,7 +111,10 @@ class DurableEventStore:
 
     def commit(self, event: dict[str, Any]) -> dict[str, Any]:
         candidate = self.prepare(event)
-        validate_event_for_commit(candidate)
+        validate_event_for_commit(
+            candidate,
+            endpoint_type_resolver=self.endpoint_type_resolver,
+        )
         event_id = candidate["event_id"]
         if self.is_redacted(event_id):
             raise EventRedactedError(

--- a/src/fossil_core/adapters/s3/storage.py
+++ b/src/fossil_core/adapters/s3/storage.py
@@ -10,6 +10,7 @@ from jsonschema import Draft202012Validator, FormatChecker
 
 from ...artifact_store import ArtifactIntegrityError, ArtifactRedactedError
 from ...domain.event_contracts import validate_event_for_commit
+from ...domain.ontology import EndpointTypeResolver
 from ...event_store import (
     EventRedactedError,
     EventRedactionConflict,
@@ -350,6 +351,7 @@ class S3DurableEventStore:
         client: Any | None = None,
         endpoint_url: str | None = None,
         region_name: str | None = None,
+        endpoint_type_resolver: EndpointTypeResolver | None = None,
     ):
         self.backend = _S3ObjectBackend(
             bucket=bucket,
@@ -360,6 +362,7 @@ class S3DurableEventStore:
         )
         schema = json.loads(Path(schema_path).read_text(encoding="utf-8"))
         self.validator = Draft202012Validator(schema, format_checker=FormatChecker())
+        self.endpoint_type_resolver = endpoint_type_resolver
 
     @staticmethod
     def _canonical(event: dict[str, Any]) -> bytes:
@@ -397,7 +400,10 @@ class S3DurableEventStore:
 
     def validate(self, event: dict[str, Any]) -> dict[str, Any]:
         candidate = self.prepare(event)
-        validate_event_for_commit(candidate)
+        validate_event_for_commit(
+            candidate,
+            endpoint_type_resolver=self.endpoint_type_resolver,
+        )
         return candidate
 
     def is_redacted(self, event_id: str) -> bool:
@@ -420,7 +426,10 @@ class S3DurableEventStore:
 
     def commit(self, event: dict[str, Any]) -> dict[str, Any]:
         candidate = self.prepare(event)
-        validate_event_for_commit(candidate)
+        validate_event_for_commit(
+            candidate,
+            endpoint_type_resolver=self.endpoint_type_resolver,
+        )
         event_id = candidate["event_id"]
         if self.is_redacted(event_id):
             raise EventRedactedError(

--- a/src/fossil_core/domain/event_contracts.py
+++ b/src/fossil_core/domain/event_contracts.py
@@ -10,8 +10,10 @@ from .ontology import (
     CORE_ONTOLOGY_REF,
     ENTITY_TYPES,
     RELATION_TYPES,
+    EndpointTypeResolver,
     OntologyConstraintError,
     validate_relation_endpoints,
+    validate_resolved_relation_endpoints,
 )
 
 
@@ -378,7 +380,12 @@ def _require_nonempty_refs(event: Mapping[str, Any], field: str) -> None:
         )
 
 
-def _validate_relation_semantics(event_type: str, payload: Mapping[str, Any]) -> None:
+def _validate_relation_semantics(
+    event_type: str,
+    payload: Mapping[str, Any],
+    *,
+    endpoint_type_resolver: EndpointTypeResolver | None,
+) -> None:
     if event_type == "relation.proposed":
         if payload.get("state", "proposed") != "proposed":
             raise EventContractError(
@@ -394,24 +401,43 @@ def _validate_relation_semantics(event_type: str, payload: Mapping[str, Any]) ->
                 "relation.proposed ontology metadata must be complete when supplied: "
                 + ", ".join(missing)
             )
+        try:
+            validate_relation_endpoints(
+                relation_type=str(payload["relation_type"]),
+                source_type=str(payload["source_type"]),
+                target_type=str(payload["target_type"]),
+                ontology_ref=str(payload["ontology_ref"]),
+            )
+        except OntologyConstraintError as exc:
+            raise EventContractError(str(exc)) from exc
+        return
 
     try:
-        validate_relation_endpoints(
+        validate_resolved_relation_endpoints(
             relation_type=str(payload["relation_type"]),
+            source_ref=str(payload["source_ref"]),
             source_type=str(payload["source_type"]),
+            target_ref=str(payload["target_ref"]),
             target_type=str(payload["target_type"]),
             ontology_ref=str(payload["ontology_ref"]),
+            resolver=endpoint_type_resolver,
         )
     except OntologyConstraintError as exc:
         raise EventContractError(str(exc)) from exc
 
 
-def validate_event_for_commit(event: Mapping[str, Any]) -> EventTypeContract:
+def validate_event_for_commit(
+    event: Mapping[str, Any],
+    *,
+    endpoint_type_resolver: EndpointTypeResolver | None = None,
+) -> EventTypeContract:
     """Validate one prepared event against the versioned acceptance registry.
 
     The event envelope's optional ``payload_schema`` field is preserved as
     historical/external metadata. It cannot override this registry: payload
-    validation always uses the registered contract below.
+    validation always uses the registered contract below. Accepted relation
+    events additionally require an independently configured endpoint resolver;
+    self-declared endpoint kinds are never sufficient for acceptance.
     """
 
     contract = event_contract(str(event.get("event_type", "")))
@@ -422,7 +448,11 @@ def validate_event_for_commit(event: Mapping[str, Any]) -> EventTypeContract:
 
     payload = event.get("payload")
     if contract.ontology_constraints is not None and isinstance(payload, Mapping):
-        _validate_relation_semantics(contract.event_type, payload)
+        _validate_relation_semantics(
+            contract.event_type,
+            payload,
+            endpoint_type_resolver=endpoint_type_resolver,
+        )
 
     policy = contract.evidence_policy
     if policy.evidence_refs == "required":

--- a/src/fossil_core/domain/event_contracts.py
+++ b/src/fossil_core/domain/event_contracts.py
@@ -5,7 +5,14 @@ from typing import Any, Mapping
 
 from jsonschema import Draft202012Validator, FormatChecker
 
-from .lifecycle import CLAIM_STATES, RELATION_STATES, RELATION_TYPES
+from .lifecycle import CLAIM_STATES, RELATION_STATES
+from .ontology import (
+    CORE_ONTOLOGY_REF,
+    ENTITY_TYPES,
+    RELATION_TYPES,
+    OntologyConstraintError,
+    validate_relation_endpoints,
+)
 
 
 EVENT_TYPE_REGISTRY_VERSION = "dkg.event-type-registry.v1"
@@ -38,7 +45,7 @@ class EventTypeContract:
     commit_eligibility: str
     payload_schema: Mapping[str, Any]
     evidence_policy: EvidencePolicy
-    ontology_constraints: Mapping[str, str] | None
+    ontology_constraints: Mapping[str, Any] | None
     property_ids: tuple[str, ...]
     oracle_ids: tuple[str, ...]
 
@@ -97,7 +104,7 @@ def _contract(
     commit_eligibility: str,
     payload_schema: Mapping[str, Any],
     evidence_policy: EvidencePolicy = EvidencePolicy(),
-    ontology_constraints: Mapping[str, str] | None = None,
+    ontology_constraints: Mapping[str, Any] | None = None,
     property_ids: tuple[str, ...],
     oracle_ids: tuple[str, ...] = ("tests/test_event_contracts.py",),
 ) -> EventTypeContract:
@@ -116,7 +123,32 @@ def _contract(
 _CLAIM_STATE = {"type": "string", "enum": sorted(CLAIM_STATES)}
 _RELATION_STATE = {"type": "string", "enum": sorted(RELATION_STATES)}
 _RELATION_TYPE = {"type": "string", "enum": sorted(RELATION_TYPES)}
+_ENTITY_TYPE = {"type": "string", "enum": sorted(ENTITY_TYPES)}
 _PACK_ID = {"type": "string", "pattern": "^pack_[A-Za-z0-9_-]{16,}$"}
+_RELATION_ENDPOINT_REQUIRED = (
+    "ontology_ref",
+    "relation_type",
+    "source_ref",
+    "source_type",
+    "target_ref",
+    "target_type",
+)
+_RELATION_ENDPOINT_PROPERTIES: Mapping[str, Any] = {
+    "ontology_ref": _string(),
+    "relation_type": _RELATION_TYPE,
+    "source_ref": _string(),
+    "source_type": _ENTITY_TYPE,
+    "target_ref": _string(),
+    "target_type": _ENTITY_TYPE,
+}
+_RELATION_ONTOLOGY_CONSTRAINTS: Mapping[str, Any] = {
+    "ontology_ref": CORE_ONTOLOGY_REF,
+    "relation_type_field": "relation_type",
+    "source_ref_field": "source_ref",
+    "source_type_field": "source_type",
+    "target_ref_field": "target_ref",
+    "target_type_field": "target_type",
+}
 
 
 EVENT_TYPE_CONTRACTS: Mapping[str, EventTypeContract] = {
@@ -174,46 +206,50 @@ EVENT_TYPE_CONTRACTS: Mapping[str, EventTypeContract] = {
             required=("relation_id", "relation_type", "source_ref", "target_ref"),
             properties={
                 "relation_id": _string(),
-                "relation_type": _RELATION_TYPE,
-                "source_ref": _string(),
-                "target_ref": _string(),
+                **_RELATION_ENDPOINT_PROPERTIES,
                 "state": _RELATION_STATE,
             },
         ),
-        ontology_constraints={
-            "ontology_ref": "dkg.core@1.0.0",
-            "relation_type_field": "relation_type",
-            "source_ref_field": "source_ref",
-            "target_ref_field": "target_ref",
-        },
-        property_ids=("FOSSIL-PROP-HISTORY-001",),
+        ontology_constraints=_RELATION_ONTOLOGY_CONSTRAINTS,
+        property_ids=("FOSSIL-PROP-HISTORY-001", "FOSSIL-PROP-LIFECYCLE-DEPENDENCY-001"),
+        oracle_ids=(
+            "tests/test_event_contracts.py",
+            "tests/test_ontology_contracts.py",
+            "tests/test_relation_acceptance.py",
+        ),
     ),
     "relation.state_changed": _contract(
         "relation.state_changed",
         commit_eligibility="accepted",
         payload_schema=_payload_schema(
             "relation.state_changed",
-            required=("relation_id", "to_state"),
+            required=("relation_id", "to_state", *_RELATION_ENDPOINT_REQUIRED),
             properties={
                 "relation_id": _string(),
                 "from_state": _RELATION_STATE,
                 "to_state": _RELATION_STATE,
+                **_RELATION_ENDPOINT_PROPERTIES,
             },
         ),
-        property_ids=("FOSSIL-PROP-HISTORY-001",),
+        ontology_constraints=_RELATION_ONTOLOGY_CONSTRAINTS,
+        property_ids=("FOSSIL-PROP-HISTORY-001", "FOSSIL-PROP-LIFECYCLE-DEPENDENCY-001"),
+        oracle_ids=("tests/test_relation_acceptance.py", "tests/test_ontology_contracts.py"),
     ),
     "relation.superseded": _contract(
         "relation.superseded",
         commit_eligibility="accepted",
         payload_schema=_payload_schema(
             "relation.superseded",
-            required=("relation_id",),
+            required=("relation_id", *_RELATION_ENDPOINT_REQUIRED),
             properties={
                 "relation_id": _string(),
                 "from_state": _RELATION_STATE,
+                **_RELATION_ENDPOINT_PROPERTIES,
             },
         ),
-        property_ids=("FOSSIL-PROP-HISTORY-001",),
+        ontology_constraints=_RELATION_ONTOLOGY_CONSTRAINTS,
+        property_ids=("FOSSIL-PROP-HISTORY-001", "FOSSIL-PROP-LIFECYCLE-DEPENDENCY-001"),
+        oracle_ids=("tests/test_relation_acceptance.py", "tests/test_ontology_contracts.py"),
     ),
     **{
         event_type: _contract(
@@ -342,6 +378,34 @@ def _require_nonempty_refs(event: Mapping[str, Any], field: str) -> None:
         )
 
 
+def _validate_relation_semantics(event_type: str, payload: Mapping[str, Any]) -> None:
+    if event_type == "relation.proposed":
+        if payload.get("state", "proposed") != "proposed":
+            raise EventContractError(
+                "relation.proposed must remain proposed; use an accepted relation state transition"
+            )
+
+        optional_endpoint_fields = ("ontology_ref", "source_type", "target_type")
+        if not any(field in payload for field in optional_endpoint_fields):
+            return
+        missing = [field for field in optional_endpoint_fields if not payload.get(field)]
+        if missing:
+            raise EventContractError(
+                "relation.proposed ontology metadata must be complete when supplied: "
+                + ", ".join(missing)
+            )
+
+    try:
+        validate_relation_endpoints(
+            relation_type=str(payload["relation_type"]),
+            source_type=str(payload["source_type"]),
+            target_type=str(payload["target_type"]),
+            ontology_ref=str(payload["ontology_ref"]),
+        )
+    except OntologyConstraintError as exc:
+        raise EventContractError(str(exc)) from exc
+
+
 def validate_event_for_commit(event: Mapping[str, Any]) -> EventTypeContract:
     """Validate one prepared event against the versioned acceptance registry.
 
@@ -355,6 +419,10 @@ def validate_event_for_commit(event: Mapping[str, Any]) -> EventTypeContract:
         dict(contract.payload_schema),
         format_checker=FormatChecker(),
     ).validate(event.get("payload"))
+
+    payload = event.get("payload")
+    if contract.ontology_constraints is not None and isinstance(payload, Mapping):
+        _validate_relation_semantics(contract.event_type, payload)
 
     policy = contract.evidence_policy
     if policy.evidence_refs == "required":

--- a/src/fossil_core/domain/lifecycle.py
+++ b/src/fossil_core/domain/lifecycle.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Iterable
 
+from .ontology import RELATION_TYPES
+
+
 CLAIM_STATES = frozenset({
     "proposed",
     "open",
@@ -14,20 +17,6 @@ CLAIM_STATES = frozenset({
     "stale_pending_review",
 })
 RELATION_STATES = frozenset({"proposed", "active", "disputed", "superseded", "invalidated"})
-RELATION_TYPES = frozenset({
-    "SUPPORTS",
-    "CHALLENGES",
-    "CONTRADICTS",
-    "REFINES",
-    "DEPENDS_ON",
-    "ASSUMES",
-    "DERIVED_FROM",
-    "EXEMPLIFIES",
-    "SUPERSEDES",
-    "RELATED_TO",
-    "BROADER_THAN",
-    "NARROWER_THAN",
-})
 
 
 class LifecycleError(ValueError):

--- a/src/fossil_core/domain/ontology.py
+++ b/src/fossil_core/domain/ontology.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Mapping
 
 
 CORE_ONTOLOGY_REF = "dkg.core@1.0.0"
+EndpointTypeResolver = Callable[[str], str | None]
 
 ENTITY_TYPES = frozenset(
     {
@@ -93,7 +95,7 @@ def validate_relation_endpoints(
     target_type: str,
     ontology_ref: str,
 ) -> None:
-    """Fail closed unless one endpoint pair is legal in the pinned core ontology."""
+    """Fail closed unless one endpoint-kind pair is legal in the pinned ontology."""
 
     if ontology_ref != CORE_ONTOLOGY_REF:
         raise OntologyConstraintError(
@@ -117,11 +119,70 @@ def validate_relation_endpoints(
         )
 
 
+def _resolve_endpoint(
+    endpoint_ref: str,
+    *,
+    role: str,
+    resolver: EndpointTypeResolver | None,
+) -> str:
+    if resolver is None:
+        raise OntologyConstraintError(
+            "accepted relation endpoint identity cannot be resolved without an endpoint type resolver"
+        )
+    try:
+        endpoint_type = resolver(endpoint_ref)
+    except Exception as exc:
+        raise OntologyConstraintError(
+            f"{role} endpoint identity {endpoint_ref!r} could not be resolved"
+        ) from exc
+    if not endpoint_type:
+        raise OntologyConstraintError(
+            f"{role} endpoint identity {endpoint_ref!r} could not be resolved"
+        )
+    if endpoint_type not in ENTITY_TYPES:
+        raise OntologyConstraintError(
+            f"{role} endpoint identity {endpoint_ref!r} resolved to unknown entity type {endpoint_type!r}"
+        )
+    return endpoint_type
+
+
+def validate_resolved_relation_endpoints(
+    *,
+    relation_type: str,
+    source_ref: str,
+    source_type: str,
+    target_ref: str,
+    target_type: str,
+    ontology_ref: str,
+    resolver: EndpointTypeResolver | None,
+) -> None:
+    """Resolve endpoint identities independently, then enforce the ontology pair."""
+
+    resolved_source_type = _resolve_endpoint(source_ref, role="source", resolver=resolver)
+    resolved_target_type = _resolve_endpoint(target_ref, role="target", resolver=resolver)
+    if source_type != resolved_source_type:
+        raise OntologyConstraintError(
+            f"source_type {source_type!r} does not match resolved endpoint type {resolved_source_type!r}"
+        )
+    if target_type != resolved_target_type:
+        raise OntologyConstraintError(
+            f"target_type {target_type!r} does not match resolved endpoint type {resolved_target_type!r}"
+        )
+    validate_relation_endpoints(
+        relation_type=relation_type,
+        source_type=resolved_source_type,
+        target_type=resolved_target_type,
+        ontology_ref=ontology_ref,
+    )
+
+
 __all__ = [
     "CORE_ONTOLOGY_REF",
     "ENTITY_TYPES",
+    "EndpointTypeResolver",
     "RELATION_ENDPOINT_TYPES",
     "RELATION_TYPES",
     "OntologyConstraintError",
     "validate_relation_endpoints",
+    "validate_resolved_relation_endpoints",
 ]

--- a/src/fossil_core/domain/ontology.py
+++ b/src/fossil_core/domain/ontology.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+
+CORE_ONTOLOGY_REF = "dkg.core@1.0.0"
+
+ENTITY_TYPES = frozenset(
+    {
+        "Artifact",
+        "Episode",
+        "Source",
+        "Evidence",
+        "Claim",
+        "Assumption",
+        "Argument",
+        "Observation",
+        "Experiment",
+        "Decision",
+        "Question",
+        "Concept",
+        "Methodology",
+    }
+)
+
+# Runtime snapshot of ontology/core/v1.yaml. The canonical YAML remains the
+# authoring source; tests/test_ontology_contracts.py requires this snapshot to
+# match it exactly so lifecycle/commit code cannot drift independently.
+RELATION_ENDPOINT_TYPES: Mapping[str, Mapping[str, frozenset[str]]] = {
+    "SUPPORTS": {
+        "source_types": frozenset({"Evidence", "Claim", "Observation", "Experiment"}),
+        "target_types": frozenset({"Claim", "Assumption", "Decision"}),
+    },
+    "CHALLENGES": {
+        "source_types": frozenset({"Evidence", "Claim", "Observation", "Argument"}),
+        "target_types": frozenset({"Claim", "Assumption", "Decision"}),
+    },
+    "CONTRADICTS": {
+        "source_types": frozenset({"Claim", "Evidence", "Observation"}),
+        "target_types": frozenset({"Claim", "Assumption"}),
+    },
+    "REFINES": {
+        "source_types": frozenset({"Claim", "Concept", "Methodology"}),
+        "target_types": frozenset({"Claim", "Concept", "Methodology"}),
+    },
+    "DEPENDS_ON": {
+        "source_types": frozenset({"Claim", "Decision", "Argument", "Methodology"}),
+        "target_types": frozenset({"Claim", "Assumption", "Concept", "Source"}),
+    },
+    "ASSUMES": {
+        "source_types": frozenset({"Claim", "Argument", "Decision", "Methodology"}),
+        "target_types": frozenset({"Assumption", "Claim"}),
+    },
+    "DERIVED_FROM": {
+        "source_types": frozenset({"Claim", "Concept", "Decision", "Evidence", "Methodology"}),
+        "target_types": frozenset(
+            {"Artifact", "Episode", "Source", "Evidence", "Claim", "Observation"}
+        ),
+    },
+    "EXEMPLIFIES": {
+        "source_types": frozenset({"Observation", "Evidence", "Episode"}),
+        "target_types": frozenset({"Claim", "Concept", "Methodology"}),
+    },
+    "SUPERSEDES": {
+        "source_types": frozenset({"Claim", "Concept", "Decision", "Methodology"}),
+        "target_types": frozenset({"Claim", "Concept", "Decision", "Methodology"}),
+    },
+    "RELATED_TO": {
+        "source_types": frozenset({"Claim", "Concept", "Source", "Methodology"}),
+        "target_types": frozenset({"Claim", "Concept", "Source", "Methodology"}),
+    },
+    "BROADER_THAN": {
+        "source_types": frozenset({"Concept"}),
+        "target_types": frozenset({"Concept"}),
+    },
+    "NARROWER_THAN": {
+        "source_types": frozenset({"Concept"}),
+        "target_types": frozenset({"Concept"}),
+    },
+}
+
+RELATION_TYPES = frozenset(RELATION_ENDPOINT_TYPES)
+
+
+class OntologyConstraintError(ValueError):
+    """A relation cannot satisfy the pinned ontology endpoint contract."""
+
+
+def validate_relation_endpoints(
+    *,
+    relation_type: str,
+    source_type: str,
+    target_type: str,
+    ontology_ref: str,
+) -> None:
+    """Fail closed unless one endpoint pair is legal in the pinned core ontology."""
+
+    if ontology_ref != CORE_ONTOLOGY_REF:
+        raise OntologyConstraintError(
+            f"ontology_ref must resolve exactly to {CORE_ONTOLOGY_REF}; got {ontology_ref!r}"
+        )
+
+    try:
+        constraints = RELATION_ENDPOINT_TYPES[relation_type]
+    except KeyError as exc:
+        raise OntologyConstraintError(
+            f"unregistered relation type in {CORE_ONTOLOGY_REF}: {relation_type}"
+        ) from exc
+
+    if source_type not in constraints["source_types"]:
+        raise OntologyConstraintError(
+            f"source_type {source_type!r} is not valid for relation type {relation_type}"
+        )
+    if target_type not in constraints["target_types"]:
+        raise OntologyConstraintError(
+            f"target_type {target_type!r} is not valid for relation type {relation_type}"
+        )
+
+
+__all__ = [
+    "CORE_ONTOLOGY_REF",
+    "ENTITY_TYPES",
+    "RELATION_ENDPOINT_TYPES",
+    "RELATION_TYPES",
+    "OntologyConstraintError",
+    "validate_relation_endpoints",
+]

--- a/tests/test_event_contracts.py
+++ b/tests/test_event_contracts.py
@@ -83,7 +83,9 @@ def test_registry_is_versioned_and_covers_the_characterized_write_vocabulary():
         "ontology_ref": "dkg.core@1.0.0",
         "relation_type_field": "relation_type",
         "source_ref_field": "source_ref",
+        "source_type_field": "source_type",
         "target_ref_field": "target_ref",
+        "target_type_field": "target_type",
     }
 
 

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -13,6 +13,8 @@ from fossil_core.ids import deterministic_event_id
 
 ROOT = Path(__file__).parents[1]
 SCHEMA = ROOT / "schemas/events/v1.schema.json"
+SOURCE = "clm_event_store_source_000001"
+TARGET = "clm_event_store_target_000001"
 
 
 def event():
@@ -30,6 +32,31 @@ def event():
     }
 
 
+def accepted_relation(*, source_type: str = "Claim") -> dict:
+    return {
+        "schema_version": "dkg.event.v1",
+        "event_type": "relation.state_changed",
+        "occurred_at": "2026-08-19T16:25:00Z",
+        "recorded_at": "2026-08-19T16:25:01Z",
+        "pack_id": "pack_269099f7b2ba43b7a99b9427d64092de",
+        "actor": {"actor_type": "system", "actor_id": "event-store-oracle"},
+        "subject_refs": ["rel_event_store_000001"],
+        "idempotency_key": "event-store:accepted-relation",
+        "payload": {
+            "relation_id": "rel_event_store_000001",
+            "from_state": "proposed",
+            "to_state": "active",
+            "ontology_ref": "dkg.core@1.0.0",
+            "relation_type": "DEPENDS_ON",
+            "source_ref": SOURCE,
+            "source_type": source_type,
+            "target_ref": TARGET,
+            "target_type": "Claim",
+        },
+        "provenance": {"method": "event-store-oracle"},
+    }
+
+
 def test_constructor_creates_nested_store_and_stable_redaction_namespace(tmp_path):
     root = tmp_path / "nested" / "durable" / "events"
     first = DurableEventStore(root, SCHEMA)
@@ -38,10 +65,22 @@ def test_constructor_creates_nested_store_and_stable_redaction_namespace(tmp_pat
     assert root.is_dir()
     assert first.redactions == root / "_redactions"
     assert first.redactions.is_dir()
+    assert first.endpoint_type_resolver is None
 
     reopened = DurableEventStore(root, SCHEMA)
     assert reopened.root == root
     assert reopened.redactions == root / "_redactions"
+
+
+def test_constructor_preserves_exact_endpoint_resolver_identity(tmp_path):
+    resolver = {SOURCE: "Claim", TARGET: "Claim"}.get
+    store = DurableEventStore(
+        tmp_path / "events",
+        SCHEMA,
+        endpoint_type_resolver=resolver,
+    )
+
+    assert store.endpoint_type_resolver is resolver
 
 
 def test_validate_is_non_mutating_and_assigns_deterministic_identity(tmp_path):
@@ -57,6 +96,34 @@ def test_validate_is_non_mutating_and_assigns_deterministic_identity(tmp_path):
     assert validated["event_id"] == deterministic_event_id(
         candidate["pack_id"], candidate["idempotency_key"]
     )
+    assert list(store.iter_events()) == []
+
+
+def test_validate_forwards_endpoint_resolver_to_acceptance_gate(tmp_path):
+    resolver = {SOURCE: "Claim", TARGET: "Claim"}.get
+    store = DurableEventStore(
+        tmp_path / "events",
+        SCHEMA,
+        endpoint_type_resolver=resolver,
+    )
+
+    validated = store.validate(accepted_relation())
+    assert validated["payload"]["source_type"] == "Claim"
+
+    with pytest.raises(EventContractError, match="source_type.*does not match resolved"):
+        store.validate(accepted_relation(source_type="Concept"))
+
+
+def test_commit_forwards_endpoint_resolver_before_write(tmp_path):
+    resolver = {SOURCE: "Claim", TARGET: "Claim"}.get
+    store = DurableEventStore(
+        tmp_path / "events",
+        SCHEMA,
+        endpoint_type_resolver=resolver,
+    )
+
+    with pytest.raises(EventContractError, match="source_type.*does not match resolved"):
+        store.commit(accepted_relation(source_type="Concept"))
     assert list(store.iter_events()) == []
 
 

--- a/tests/test_ontology_contracts.py
+++ b/tests/test_ontology_contracts.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from fossil_core.domain.lifecycle import RELATION_TYPES
+from fossil_core.domain.ontology import (
+    CORE_ONTOLOGY_REF,
+    ENTITY_TYPES,
+    RELATION_ENDPOINT_TYPES,
+    OntologyConstraintError,
+    validate_relation_endpoints,
+)
+
+
+ROOT = Path(__file__).parents[1]
+ONTOLOGY = ROOT / "ontology/core/v1.yaml"
+
+
+def _inline_list(value: str) -> tuple[str, ...]:
+    match = re.fullmatch(r"\[(.*)\]", value.strip())
+    assert match is not None
+    body = match.group(1).strip()
+    return tuple(item.strip() for item in body.split(",") if item.strip())
+
+
+def _parse_core_ontology(path: Path) -> tuple[str, set[str], dict[str, dict[str, tuple[str, ...]]]]:
+    ontology_id = ""
+    version = ""
+    entity_types: set[str] = set()
+    relations: dict[str, dict[str, tuple[str, ...]]] = {}
+    section: str | None = None
+    relation: str | None = None
+
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        if not line.startswith(" "):
+            relation = None
+            if line.startswith("ontology_id:"):
+                ontology_id = line.split(":", 1)[1].strip()
+                section = None
+            elif line.startswith("version:"):
+                version = line.split(":", 1)[1].strip()
+                section = None
+            elif line == "entity_types:":
+                section = "entity_types"
+            elif line == "relation_types:":
+                section = "relation_types"
+            else:
+                section = None
+            continue
+
+        if section == "entity_types" and line.startswith("  ") and not line.startswith("    "):
+            entity_types.add(line.strip().removesuffix(":"))
+            continue
+
+        if section == "relation_types":
+            if line.startswith("  ") and not line.startswith("    "):
+                relation = line.strip().removesuffix(":")
+                relations[relation] = {}
+                continue
+            if relation is not None and line.startswith("    "):
+                key, value = line.strip().split(":", 1)
+                relations[relation][key] = _inline_list(value)
+
+    assert ontology_id and version
+    return f"{ontology_id}@{version}", entity_types, relations
+
+
+def test_runtime_ontology_snapshot_exactly_matches_canonical_yaml():
+    ontology_ref, entity_types, relations = _parse_core_ontology(ONTOLOGY)
+
+    assert CORE_ONTOLOGY_REF == ontology_ref
+    assert ENTITY_TYPES == frozenset(entity_types)
+    assert RELATION_ENDPOINT_TYPES == {
+        relation_type: {
+            "source_types": frozenset(values["source_types"]),
+            "target_types": frozenset(values["target_types"]),
+        }
+        for relation_type, values in relations.items()
+    }
+    assert RELATION_TYPES == frozenset(relations)
+
+
+def test_ontology_endpoint_validator_accepts_declared_pair():
+    validate_relation_endpoints(
+        relation_type="DEPENDS_ON",
+        source_type="Claim",
+        target_type="Claim",
+        ontology_ref=CORE_ONTOLOGY_REF,
+    )
+
+
+def test_ontology_endpoint_validator_rejects_wrong_pinned_ontology():
+    with pytest.raises(OntologyConstraintError, match="ontology_ref"):
+        validate_relation_endpoints(
+            relation_type="DEPENDS_ON",
+            source_type="Claim",
+            target_type="Claim",
+            ontology_ref="dkg.core@0.9.0",
+        )
+
+
+def test_ontology_endpoint_validator_rejects_invalid_source_kind():
+    with pytest.raises(OntologyConstraintError, match="source_type"):
+        validate_relation_endpoints(
+            relation_type="DEPENDS_ON",
+            source_type="Evidence",
+            target_type="Claim",
+            ontology_ref=CORE_ONTOLOGY_REF,
+        )
+
+
+def test_ontology_endpoint_validator_rejects_unregistered_relation_type():
+    with pytest.raises(OntologyConstraintError, match="relation type"):
+        validate_relation_endpoints(
+            relation_type="MENTIONS",
+            source_type="Claim",
+            target_type="Claim",
+            ontology_ref=CORE_ONTOLOGY_REF,
+        )

--- a/tests/test_pack_fixture.py
+++ b/tests/test_pack_fixture.py
@@ -257,7 +257,37 @@ def build_two_pack_fixture(tmp_path: Path):
                 "relation_type": "DEPENDS_ON",
                 "source_ref": ai_claim,
                 "target_ref": common_claim,
-                "state": "active",
+                "state": "proposed",
+            },
+            "provenance": {"method": "fixture"},
+        }
+    )
+    ai_store.commit(
+        {
+            "schema_version": "dkg.event.v1",
+            "event_type": "relation.state_changed",
+            "occurred_at": "2026-08-10T05:02:05Z",
+            "recorded_at": "2026-08-10T05:02:05Z",
+            "pack_id": AI,
+            "actor": {"actor_type": "importer", "actor_id": "fixture"},
+            "subject_refs": [relation_id, ai_claim, common_claim],
+            "caused_by_event_ids": [relation["event_id"]],
+            "idempotency_key": "ai:depends-common:active",
+            "evidence_refs": [ai_snapshot["artifact_id"], common_snapshot["artifact_id"]],
+            "source_snapshot_refs": [
+                ai_snapshot["snapshot_id"],
+                common_snapshot["snapshot_id"],
+            ],
+            "payload": {
+                "relation_id": relation_id,
+                "from_state": "proposed",
+                "to_state": "active",
+                "ontology_ref": "dkg.core@1.0.0",
+                "relation_type": "DEPENDS_ON",
+                "source_ref": ai_claim,
+                "source_type": "Claim",
+                "target_ref": common_claim,
+                "target_type": "Claim",
             },
             "provenance": {"method": "fixture"},
         }
@@ -284,7 +314,7 @@ def test_pack_fixture_audit_validates_content_identity_citations_mounts_and_repl
     assert report.pack_ids == (COMMON, AI)
     assert report.artifact_count == 2
     assert report.snapshot_count == 2
-    assert report.event_count == 5
+    assert report.event_count == 6
     assert report.citation_count == 4
     assert report.claim_count == 2
     assert report.relation_count == 1

--- a/tests/test_pack_fixture.py
+++ b/tests/test_pack_fixture.py
@@ -103,8 +103,16 @@ def write_artifact_index(root: Path) -> None:
     (root / "artifacts" / "manifest.jsonl").write_text(content, encoding="utf-8")
 
 
-def event_store(root: Path) -> DurableEventStore:
-    return DurableEventStore(root / "events", schemas_root() / "events" / "v1.schema.json")
+def event_store(
+    root: Path,
+    *,
+    endpoint_types: dict[str, str] | None = None,
+) -> DurableEventStore:
+    return DurableEventStore(
+        root / "events",
+        schemas_root() / "events" / "v1.schema.json",
+        endpoint_type_resolver=endpoint_types.get if endpoint_types is not None else None,
+    )
 
 
 def claim_event(
@@ -208,7 +216,10 @@ def build_two_pack_fixture(tmp_path: Path):
     )
 
     ai_claim = "clm_ai_candidate_authority_000001"
-    ai_store = event_store(ai)
+    ai_store = event_store(
+        ai,
+        endpoint_types={ai_claim: "Claim", common_claim: "Claim"},
+    )
     proposed_ai = ai_store.commit(
         claim_event(
             pack_id=AI,

--- a/tests/test_relation_acceptance.py
+++ b/tests/test_relation_acceptance.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from jsonschema import ValidationError
 
+from fossil_core.adapters.s3.storage import S3DurableEventStore
 from fossil_core.domain.event_contracts import EventContractError
 from fossil_core.domain.lifecycle import KnowledgeState
 from fossil_core.event_store import DurableEventStore
@@ -63,6 +64,14 @@ def _acceptance(**overrides: str) -> dict:
     return _event("relation.state_changed", payload, key="relation-acceptance")
 
 
+def _resolver(endpoint_types: dict[str, str]):
+    return endpoint_types.get
+
+
+def _claim_resolver():
+    return _resolver({SOURCE: "Claim", TARGET: "Claim"})
+
+
 def test_new_relation_proposal_cannot_smuggle_active_state_into_durable_projection(tmp_path):
     store = DurableEventStore(tmp_path / "events", SCHEMA)
 
@@ -81,7 +90,11 @@ def test_relation_proposal_remains_cheap_and_durable_as_proposed(tmp_path):
 
 
 def test_accepted_relation_transition_requires_self_contained_ontology_fields(tmp_path):
-    store = DurableEventStore(tmp_path / "events", SCHEMA)
+    store = DurableEventStore(
+        tmp_path / "events",
+        SCHEMA,
+        endpoint_type_resolver=_claim_resolver(),
+    )
     candidate = _acceptance()
     candidate["payload"].pop("source_type")
 
@@ -89,28 +102,82 @@ def test_accepted_relation_transition_requires_self_contained_ontology_fields(tm
         store.commit(candidate)
 
 
-def test_accepted_relation_transition_rejects_wrong_ontology_revision(tmp_path):
+def test_accepted_relation_transition_fails_closed_without_identity_resolver(tmp_path):
     store = DurableEventStore(tmp_path / "events", SCHEMA)
+
+    with pytest.raises(EventContractError, match="endpoint identity.*resolver"):
+        store.commit(_acceptance())
+    assert list(store.iter_events()) == []
+
+
+def test_accepted_relation_transition_fails_when_endpoint_identity_is_unresolved(tmp_path):
+    store = DurableEventStore(
+        tmp_path / "events",
+        SCHEMA,
+        endpoint_type_resolver=_resolver({SOURCE: "Claim"}),
+    )
+
+    with pytest.raises(EventContractError, match="target endpoint identity.*could not be resolved"):
+        store.commit(_acceptance())
+
+
+def test_accepted_relation_transition_rejects_wrong_ontology_revision(tmp_path):
+    store = DurableEventStore(
+        tmp_path / "events",
+        SCHEMA,
+        endpoint_type_resolver=_claim_resolver(),
+    )
 
     with pytest.raises(EventContractError, match="ontology_ref"):
         store.commit(_acceptance(ontology_ref="dkg.core@0.9.0"))
 
 
-def test_accepted_relation_transition_rejects_illegal_endpoint_kind(tmp_path):
-    store = DurableEventStore(tmp_path / "events", SCHEMA)
+def test_declared_endpoint_kind_must_match_independent_resolution(tmp_path):
+    store = DurableEventStore(
+        tmp_path / "events",
+        SCHEMA,
+        endpoint_type_resolver=_claim_resolver(),
+    )
 
-    with pytest.raises(EventContractError, match="source_type"):
+    with pytest.raises(EventContractError, match="source_type.*does not match resolved"):
+        store.commit(_acceptance(source_type="Concept"))
+
+
+def test_accepted_relation_transition_rejects_ontology_invalid_resolved_kind(tmp_path):
+    store = DurableEventStore(
+        tmp_path / "events",
+        SCHEMA,
+        endpoint_type_resolver=_resolver({SOURCE: "Evidence", TARGET: "Claim"}),
+    )
+
+    with pytest.raises(EventContractError, match="source_type.*not valid"):
         store.commit(_acceptance(source_type="Evidence"))
 
 
-def test_valid_accepted_relation_transition_is_self_contained_and_replayable(tmp_path):
-    store = DurableEventStore(tmp_path / "events", SCHEMA)
+def test_valid_accepted_relation_transition_is_resolved_and_replayable(tmp_path):
+    store = DurableEventStore(
+        tmp_path / "events",
+        SCHEMA,
+        endpoint_type_resolver=_claim_resolver(),
+    )
     proposed = store.commit(_proposal())
     accepted = store.commit(_acceptance())
 
     state = KnowledgeState.replay([proposed, accepted])
     assert state.relations[RELATION].state == "active"
     assert state.relation_history[RELATION] == ["proposed", "active"]
+
+
+def test_s3_validate_uses_the_same_endpoint_identity_resolver_seam():
+    store = S3DurableEventStore(
+        bucket="ontology-gate-fixture",
+        schema_path=SCHEMA,
+        client=object(),
+        endpoint_type_resolver=_claim_resolver(),
+    )
+
+    validated = store.validate(_acceptance())
+    assert validated["payload"]["to_state"] == "active"
 
 
 def test_historical_active_relation_proposal_remains_replayable_without_revalidation(tmp_path):

--- a/tests/test_relation_acceptance.py
+++ b/tests/test_relation_acceptance.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from jsonschema import ValidationError
+
+from fossil_core.domain.event_contracts import EventContractError
+from fossil_core.domain.lifecycle import KnowledgeState
+from fossil_core.event_store import DurableEventStore
+
+
+ROOT = Path(__file__).parents[1]
+SCHEMA = ROOT / "schemas/events/v1.schema.json"
+PACK = "pack_269099f7b2ba43b7a99b9427d64092de"
+RELATION = "rel_ontology_gate_fixture_000001"
+SOURCE = "clm_ontology_gate_source_000001"
+TARGET = "clm_ontology_gate_target_000001"
+
+
+def _event(event_type: str, payload: dict, *, key: str) -> dict:
+    return {
+        "schema_version": "dkg.event.v1",
+        "event_type": event_type,
+        "occurred_at": "2026-08-19T16:10:00Z",
+        "recorded_at": "2026-08-19T16:10:01Z",
+        "pack_id": PACK,
+        "actor": {"actor_type": "system", "actor_id": "ontology-gate-test"},
+        "subject_refs": [RELATION],
+        "idempotency_key": key,
+        "payload": payload,
+        "provenance": {"method": "ontology-gate-test"},
+    }
+
+
+def _proposal(*, state: str = "proposed") -> dict:
+    return _event(
+        "relation.proposed",
+        {
+            "relation_id": RELATION,
+            "relation_type": "DEPENDS_ON",
+            "source_ref": SOURCE,
+            "target_ref": TARGET,
+            "state": state,
+        },
+        key=f"relation-proposal:{state}",
+    )
+
+
+def _acceptance(**overrides: str) -> dict:
+    payload = {
+        "relation_id": RELATION,
+        "from_state": "proposed",
+        "to_state": "active",
+        "ontology_ref": "dkg.core@1.0.0",
+        "relation_type": "DEPENDS_ON",
+        "source_ref": SOURCE,
+        "source_type": "Claim",
+        "target_ref": TARGET,
+        "target_type": "Claim",
+    }
+    payload.update(overrides)
+    return _event("relation.state_changed", payload, key="relation-acceptance")
+
+
+def test_new_relation_proposal_cannot_smuggle_active_state_into_durable_projection(tmp_path):
+    store = DurableEventStore(tmp_path / "events", SCHEMA)
+
+    with pytest.raises(EventContractError, match="relation.proposed.*proposed"):
+        store.commit(_proposal(state="active"))
+    assert list(store.iter_events()) == []
+
+
+def test_relation_proposal_remains_cheap_and_durable_as_proposed(tmp_path):
+    store = DurableEventStore(tmp_path / "events", SCHEMA)
+
+    committed = store.commit(_proposal())
+
+    assert committed["payload"]["state"] == "proposed"
+    assert KnowledgeState.replay([committed]).relations[RELATION].state == "proposed"
+
+
+def test_accepted_relation_transition_requires_self_contained_ontology_fields(tmp_path):
+    store = DurableEventStore(tmp_path / "events", SCHEMA)
+    candidate = _acceptance()
+    candidate["payload"].pop("source_type")
+
+    with pytest.raises(ValidationError):
+        store.commit(candidate)
+
+
+def test_accepted_relation_transition_rejects_wrong_ontology_revision(tmp_path):
+    store = DurableEventStore(tmp_path / "events", SCHEMA)
+
+    with pytest.raises(EventContractError, match="ontology_ref"):
+        store.commit(_acceptance(ontology_ref="dkg.core@0.9.0"))
+
+
+def test_accepted_relation_transition_rejects_illegal_endpoint_kind(tmp_path):
+    store = DurableEventStore(tmp_path / "events", SCHEMA)
+
+    with pytest.raises(EventContractError, match="source_type"):
+        store.commit(_acceptance(source_type="Evidence"))
+
+
+def test_valid_accepted_relation_transition_is_self_contained_and_replayable(tmp_path):
+    store = DurableEventStore(tmp_path / "events", SCHEMA)
+    proposed = store.commit(_proposal())
+    accepted = store.commit(_acceptance())
+
+    state = KnowledgeState.replay([proposed, accepted])
+    assert state.relations[RELATION].state == "active"
+    assert state.relation_history[RELATION] == ["proposed", "active"]
+
+
+def test_historical_active_relation_proposal_remains_replayable_without_revalidation(tmp_path):
+    store = DurableEventStore(tmp_path / "events", SCHEMA)
+    historical = _proposal(state="active")
+    historical.pop("idempotency_key")
+    historical["event_id"] = "evt_historical_active_relation_000001"
+    path = store._event_path(historical["event_id"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(store._canonical(historical))
+
+    loaded = store.get(historical["event_id"])
+    assert loaded == historical
+    assert KnowledgeState.replay([loaded]).relations[RELATION].state == "active"

--- a/tests/test_s3_storage_mutation_oracles.py
+++ b/tests/test_s3_storage_mutation_oracles.py
@@ -2,15 +2,46 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 import fossil_core.adapters.s3.storage as s3_storage
+from fossil_core.domain.event_contracts import EventContractError
 from fossil_core.s3_storage import S3ArtifactStore, S3DurableEventStore
 
 
 ROOT = Path(__file__).parents[1]
 SCHEMA = ROOT / "schemas/events/v1.schema.json"
+PACK = "pack_269099f7b2ba43b7a99b9427d64092de"
+SOURCE = "clm_s3_mutation_source_000001"
+TARGET = "clm_s3_mutation_target_000001"
 
 
-def test_s3_store_default_prefixes_remain_empty():
+def accepted_relation(*, source_type: str = "Claim") -> dict:
+    return {
+        "schema_version": "dkg.event.v1",
+        "event_type": "relation.state_changed",
+        "occurred_at": "2026-08-19T16:20:00Z",
+        "recorded_at": "2026-08-19T16:20:01Z",
+        "pack_id": PACK,
+        "actor": {"actor_type": "system", "actor_id": "s3-mutation-oracle"},
+        "subject_refs": ["rel_s3_mutation_000001"],
+        "idempotency_key": "s3-mutation:accepted-relation",
+        "payload": {
+            "relation_id": "rel_s3_mutation_000001",
+            "from_state": "proposed",
+            "to_state": "active",
+            "ontology_ref": "dkg.core@1.0.0",
+            "relation_type": "DEPENDS_ON",
+            "source_ref": SOURCE,
+            "source_type": source_type,
+            "target_ref": TARGET,
+            "target_type": "Claim",
+        },
+        "provenance": {"method": "s3-mutation-oracle"},
+    }
+
+
+def test_s3_store_default_prefixes_and_resolver_remain_empty():
     artifacts = S3ArtifactStore(bucket="fixture", client=object())
     events = S3DurableEventStore(
         bucket="fixture", schema_path=SCHEMA, client=object()
@@ -18,6 +49,48 @@ def test_s3_store_default_prefixes_remain_empty():
 
     assert artifacts.backend.prefix == ""
     assert events.backend.prefix == ""
+    assert events.endpoint_type_resolver is None
+
+
+def test_s3_event_store_preserves_exact_endpoint_resolver_identity():
+    resolver = {SOURCE: "Claim", TARGET: "Claim"}.get
+    events = S3DurableEventStore(
+        bucket="fixture",
+        schema_path=SCHEMA,
+        client=object(),
+        endpoint_type_resolver=resolver,
+    )
+
+    assert events.endpoint_type_resolver is resolver
+
+
+def test_s3_validate_forwards_endpoint_resolver_to_acceptance_gate():
+    resolver = {SOURCE: "Claim", TARGET: "Claim"}.get
+    events = S3DurableEventStore(
+        bucket="fixture",
+        schema_path=SCHEMA,
+        client=object(),
+        endpoint_type_resolver=resolver,
+    )
+
+    validated = events.validate(accepted_relation())
+    assert validated["payload"]["source_type"] == "Claim"
+
+    with pytest.raises(EventContractError, match="source_type.*does not match resolved"):
+        events.validate(accepted_relation(source_type="Concept"))
+
+
+def test_s3_commit_forwards_endpoint_resolver_before_any_provider_write():
+    resolver = {SOURCE: "Claim", TARGET: "Claim"}.get
+    events = S3DurableEventStore(
+        bucket="fixture",
+        schema_path=SCHEMA,
+        client=object(),
+        endpoint_type_resolver=resolver,
+    )
+
+    with pytest.raises(EventContractError, match="source_type.*does not match resolved"):
+        events.commit(accepted_relation(source_type="Concept"))
 
 
 def test_backend_slash_normalization_does_not_strip_valid_x_characters():


### PR DESCRIPTION
Continues #111 Step 1 after merged #223 by enforcing the frozen Law 3 at the real durable acceptance boundary.

What changed:
- adds a runtime `dkg.core@1.0.0` ontology relation-contract snapshot whose entity types, relation vocabulary, and source/target endpoint-kind sets are mechanically required to match `ontology/core/v1.yaml`;
- removes the independently duplicated lifecycle relation-type set and consumes the ontology-owned relation vocabulary instead;
- keeps `relation.proposed` proposal-only and rejects new `relation.proposed(state="active")` writes, closing the historical active-proposal shortcut for new durable acceptance;
- requires new accepted `relation.state_changed` / `relation.superseded` payloads to carry pinned `ontology_ref`, relation type, endpoint refs, and declared endpoint kinds;
- adds a provider-neutral `EndpointTypeResolver` seam to filesystem and S3 durable stores; accepted relation writes fail closed when no resolver exists, an endpoint ref cannot be resolved, a declared kind contradicts independent resolution, the ontology revision is wrong, or the resolved kind pair is illegal for the relation;
- proposal-only relation writes do not require the resolver, and historical relation events remain readable/replayable without revalidation or silent upgrade;
- converts the only characterized durable active-relation fixture into `relation.proposed` followed by an explicit accepted `relation.state_changed`, with a deterministic fixture resolver;
- adds adversarial functional and mutation-selected FS/S3 resolver oracles. No ID-prefix inference or permissive generic-relation fallback was added.

TDD / evidence:
- RED: test-only head `4cc2ef9770803ac82b0a5c53d3fdaabbd43bbfd4`; DKG run `32274186225` failed for the intended missing `fossil_core.domain.ontology` implementation;
- an earlier functional-green implementation (`6e6585ea0cb6b7c0e712f9ad99e5e61ceb2fb92b`) was not merged because adversarial review found that self-declared endpoint kinds alone did not prove endpoint identity;
- strengthened exact head `9ca6dacea44f4d5827033b9f8a0a80ed9aea717f` introduced independent endpoint resolution; its isolated adapter mutation jobs exposed that the resolver tests were outside those workflows' selected test surfaces;
- final exact head `dd1b1d66222200c6b7edaa824f4c97fa91bafe7f` adds resolver-specific oracles to the existing mutation-selected files, without changing thresholds or workflow scope:
  - DKG contract tests `32275940096` PASS;
  - Dependency integrity `32275940056` PASS;
  - Identity mutation assurance `32275940034` PASS;
  - general Mutation assurance `32275940037` PASS;
  - S3 storage mutation assurance `32275940046` PASS;
  - Filesystem event-store mutation assurance `32275940047` PASS.

Frozen-law status:
- Law 1 deterministic accepted-commit gating: strengthened for accepted relation writes;
- Law 2 explicit event-type contracts: preserved from #223;
- Law 3 ontology-owned endpoint validity: implemented for new accepted relation writes with independent endpoint resolution and fail-closed absence/unresolvability;
- Law 4 packset lock: untouched;
- Law 5 promotion source pin: untouched;
- Law 6 reviewed ingestion: untouched.

Historical compatibility:
- `dkg.event.v1` identity/envelope semantics are unchanged;
- `prepare()` remains envelope-only;
- historical active `relation.proposed` events are still replayable as historical data;
- no old event is silently rewritten, upgraded, or reinterpreted during read/replay.

Scope / explicit non-goals:
- no automatic mounted-pack/entity-catalog resolver composition in this PR; callers that want accepted relation writes must supply the provider-neutral resolver seam, otherwise acceptance fails closed;
- no claim that relation transition-history identity matching (same prior relation tuple) is complete; this PR is specifically ontology endpoint validity;
- no packset lock, promotion-v2/source revision pin, storage/provider/projection rewrite, private holdout, new mutation/TLA+/Lean lane, production promotion, or deployment.

Affected stable properties include `FOSSIL-PROP-ARCH-BOUNDARY-001`, `FOSSIL-PROP-HISTORY-001`, `FOSSIL-PROP-LIFECYCLE-DEPENDENCY-001`, `FOSSIL-PROP-IDEMPOTENCY-001`, and the accepted semantic-freeze Law 3 under #111/#176.

Closes no issue; #111 remains open for Step 2+ implementation.