### PR TITLE
Add exact portable packset lock

### DIFF
--- a/schemas/packset-lock/v1.schema.json
+++ b/schemas/packset-lock/v1.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pukujan.github.io/fossil-core/schemas/packset-lock/v1.schema.json",
+  "title": "DKG Packset Lock v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract_version", "packs"],
+  "properties": {
+    "contract_version": {
+      "const": "dkg.packset-lock.v1"
+    },
+    "packs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["pack_id", "revision", "manifest_digest", "dependencies"],
+        "properties": {
+          "pack_id": {
+            "type": "string",
+            "pattern": "^pack_[A-Za-z0-9_-]{16,}$"
+          },
+          "revision": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Opaque immutable revision for this mounted pack."
+          },
+          "manifest_digest": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["algorithm", "digest"],
+            "properties": {
+              "algorithm": {"const": "sha256"},
+              "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+            }
+          },
+          "dependencies": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["pack_id", "required"],
+              "properties": {
+                "pack_id": {
+                  "type": "string",
+                  "pattern": "^pack_[A-Za-z0-9_-]{16,}$"
+                },
+                "required": {"type": "boolean"}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/fossil_core/application/ingest/pack_validation.py
+++ b/src/fossil_core/application/ingest/pack_validation.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
 from jsonschema import Draft202012Validator, FormatChecker
 
-from ...domain.pack import PackAccess, PackBoundaryError
+from ...domain.pack import PackBoundaryError
+from ...domain.packset import (
+    build_packset_lock as build_validated_packset_lock,
+    validate_pack_dependency_graph,
+    validate_packset_lock as validate_existing_packset_lock,
+)
 
 
 class KnowledgePackValidator:
@@ -42,7 +46,28 @@ class KnowledgePackValidator:
                     raise PackBoundaryError(
                         f"required dependency {dependency['pack_id']} is unavailable"
                     )
+        validate_pack_dependency_graph(by_id)
         return by_id
+
+    def build_packset_lock(
+        self,
+        manifests: Iterable[dict[str, Any]],
+        revisions: Mapping[str, str],
+    ) -> dict[str, Any]:
+        """Validate a mounted manifest set, then freeze its exact revisions."""
+
+        by_id = self.validate_set(manifests)
+        return build_validated_packset_lock(by_id, revisions)
+
+    def validate_packset_lock(
+        self,
+        lock: Mapping[str, Any],
+        manifests: Iterable[dict[str, Any]],
+    ) -> None:
+        """Validate replay lock content against schema-valid available manifests."""
+
+        by_id = self.validate_set(manifests)
+        validate_existing_packset_lock(lock, by_id)
 
     def load_and_validate(self, path: Path) -> dict[str, Any]:
         manifest = json.loads(Path(path).read_text(encoding="utf-8"))

--- a/src/fossil_core/application/ingest/pack_validation.py
+++ b/src/fossil_core/application/ingest/pack_validation.py
@@ -32,7 +32,7 @@ class KnowledgePackValidator:
             if dependency["required"] and dependency["pack_id"] not in manifest["read_mounts"]:
                 raise PackBoundaryError("every required dependency must be in read_mounts")
 
-    def validate_set(self, manifests: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    def _validate_catalog(self, manifests: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:
         by_id: dict[str, dict[str, Any]] = {}
         for manifest in manifests:
             self.validate(manifest)
@@ -40,6 +40,10 @@ class KnowledgePackValidator:
             if pack_id in by_id:
                 raise PackBoundaryError(f"duplicate pack_id: {pack_id}")
             by_id[pack_id] = manifest
+        return by_id
+
+    def validate_set(self, manifests: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        by_id = self._validate_catalog(manifests)
         for manifest in by_id.values():
             for dependency in manifest.get("dependencies", []):
                 if dependency["required"] and dependency["pack_id"] not in by_id:
@@ -64,9 +68,14 @@ class KnowledgePackValidator:
         lock: Mapping[str, Any],
         manifests: Iterable[dict[str, Any]],
     ) -> None:
-        """Validate replay lock content against schema-valid available manifests."""
+        """Validate replay lock content against an available manifest catalog.
 
-        by_id = self.validate_set(manifests)
+        The catalog may contain packs that are not mounted by this lock. Those
+        unrelated packs are schema/boundary checked but do not participate in
+        this lock's dependency graph.
+        """
+
+        by_id = self._validate_catalog(manifests)
         validate_existing_packset_lock(lock, by_id)
 
     def load_and_validate(self, path: Path) -> dict[str, Any]:

--- a/src/fossil_core/domain/packset.py
+++ b/src/fossil_core/domain/packset.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from .pack import PackBoundaryError
+
+
+PACKSET_LOCK_CONTRACT_VERSION = "dkg.packset-lock.v1"
+_STANDARD_LAYER_RANK = {"common": 0, "domain": 1, "project": 2}
+
+
+class PackSetLockError(PackBoundaryError):
+    """A mounted pack revision set cannot satisfy the frozen lock contract."""
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def canonical_manifest_digest(manifest: Mapping[str, Any]) -> str:
+    """Hash manifest meaning independently of JSON object key order/formatting."""
+
+    return hashlib.sha256(_canonical_json_bytes(dict(manifest))).hexdigest()
+
+
+def _dependencies_by_target(manifest: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    by_target: dict[str, dict[str, Any]] = {}
+    for dependency in manifest.get("dependencies", []):
+        target = str(dependency["pack_id"])
+        if target in by_target:
+            raise PackBoundaryError(
+                f"duplicate dependency for pack {manifest['pack_id']}: {target}"
+            )
+        by_target[target] = dict(dependency)
+    return by_target
+
+
+def _resolved_dependencies(
+    manifest: Mapping[str, Any], mounted_pack_ids: set[str]
+) -> list[dict[str, Any]]:
+    dependencies = _dependencies_by_target(manifest)
+    return [
+        {
+            "pack_id": target,
+            "required": bool(dependencies[target]["required"]),
+        }
+        for target in sorted(dependencies)
+        if target in mounted_pack_ids
+    ]
+
+
+def validate_pack_dependency_graph(manifests: Mapping[str, Mapping[str, Any]]) -> None:
+    """Enforce mounted dependency resolution, standard layering, and acyclicity.
+
+    Optional dependencies that are not mounted are intentionally absent from the
+    resolved graph. If an optional target *is* mounted, it is a real edge and is
+    subject to the same layer and cycle laws as required dependencies.
+    """
+
+    mounted = set(manifests)
+    adjacency: dict[str, tuple[str, ...]] = {}
+
+    for pack_id in sorted(manifests):
+        manifest = manifests[pack_id]
+        dependencies = _dependencies_by_target(manifest)
+        source_kind = str(manifest.get("kind", ""))
+        resolved: list[str] = []
+        for target in sorted(dependencies):
+            dependency = dependencies[target]
+            if target not in mounted:
+                if bool(dependency["required"]):
+                    raise PackBoundaryError(
+                        f"required dependency {target} is unavailable"
+                    )
+                continue
+
+            target_kind = str(manifests[target].get("kind", ""))
+            if source_kind in _STANDARD_LAYER_RANK and target_kind in _STANDARD_LAYER_RANK:
+                if _STANDARD_LAYER_RANK[target_kind] >= _STANDARD_LAYER_RANK[source_kind]:
+                    raise PackBoundaryError(
+                        "dependency layer violation: "
+                        f"{pack_id} ({source_kind}) cannot depend on "
+                        f"{target} ({target_kind}); standard dependencies must point "
+                        "strictly upstream common <- domain <- project"
+                    )
+            resolved.append(target)
+        adjacency[pack_id] = tuple(resolved)
+
+    state: dict[str, int] = {}
+    stack: list[str] = []
+
+    def visit(pack_id: str) -> None:
+        status = state.get(pack_id, 0)
+        if status == 2:
+            return
+        if status == 1:
+            try:
+                index = stack.index(pack_id)
+            except ValueError:
+                index = 0
+            cycle = [*stack[index:], pack_id]
+            raise PackBoundaryError(
+                "dependency cycle: " + " -> ".join(cycle)
+            )
+        state[pack_id] = 1
+        stack.append(pack_id)
+        for target in adjacency[pack_id]:
+            visit(target)
+        stack.pop()
+        state[pack_id] = 2
+
+    for pack_id in sorted(adjacency):
+        visit(pack_id)
+
+
+def build_packset_lock(
+    validated_manifests: Mapping[str, Mapping[str, Any]],
+    revisions: Mapping[str, str],
+) -> dict[str, Any]:
+    """Build canonical portable lock content from validated manifests/revisions.
+
+    The SHA-256 lock digest is deliberately not embedded here; callers compute it
+    over this content with :func:`packset_lock_digest` to avoid self-reference.
+    """
+
+    manifests = {str(pack_id): dict(manifest) for pack_id, manifest in validated_manifests.items()}
+    if not manifests:
+        raise PackSetLockError("packset lock requires at least one mounted pack")
+    validate_pack_dependency_graph(manifests)
+
+    mounted = set(manifests)
+    revision_ids = {str(pack_id) for pack_id in revisions}
+    missing = sorted(mounted - revision_ids)
+    if missing:
+        raise PackSetLockError(
+            f"missing exact revision for mounted pack(s): {missing}"
+        )
+    extra = sorted(revision_ids - mounted)
+    if extra:
+        raise PackSetLockError(
+            f"unresolved revision pack(s) are not mounted: {extra}"
+        )
+
+    packs: list[dict[str, Any]] = []
+    for pack_id in sorted(manifests):
+        revision = revisions[pack_id]
+        if not isinstance(revision, str) or not revision.strip():
+            raise PackSetLockError(
+                f"pack {pack_id} requires a non-empty exact revision"
+            )
+        manifest = manifests[pack_id]
+        packs.append(
+            {
+                "pack_id": pack_id,
+                "revision": revision,
+                "manifest_digest": {
+                    "algorithm": "sha256",
+                    "digest": canonical_manifest_digest(manifest),
+                },
+                "dependencies": _resolved_dependencies(manifest, mounted),
+            }
+        )
+
+    return {
+        "contract_version": PACKSET_LOCK_CONTRACT_VERSION,
+        "packs": packs,
+    }
+
+
+def _lock_records(lock: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    if set(lock) != {"contract_version", "packs"}:
+        raise PackSetLockError(
+            "packset lock fields must be exactly contract_version and packs; "
+            "lock digest is external"
+        )
+    if lock.get("contract_version") != PACKSET_LOCK_CONTRACT_VERSION:
+        raise PackSetLockError(
+            f"unsupported packset lock contract: {lock.get('contract_version')!r}"
+        )
+    packs = lock.get("packs")
+    if not isinstance(packs, list) or not packs:
+        raise PackSetLockError("packset lock requires at least one pack record")
+    if not all(isinstance(item, Mapping) for item in packs):
+        raise PackSetLockError("packset lock pack records must be objects")
+    return list(packs)
+
+
+def pack_revisions_from_lock(lock: Mapping[str, Any]) -> dict[str, str]:
+    records = _lock_records(lock)
+    by_pack: dict[str, str] = {}
+    sequence: list[str] = []
+    for record in records:
+        pack_id = str(record.get("pack_id", ""))
+        revision = record.get("revision")
+        if not pack_id:
+            raise PackSetLockError("packset lock requires non-empty pack_id")
+        if pack_id in by_pack:
+            raise PackSetLockError(f"duplicate pack_id in packset lock: {pack_id}")
+        if not isinstance(revision, str) or not revision.strip():
+            raise PackSetLockError(
+                f"pack {pack_id} requires a non-empty exact revision"
+            )
+        by_pack[pack_id] = revision
+        sequence.append(pack_id)
+    if sequence != sorted(sequence):
+        raise PackSetLockError("packset lock pack records must be sorted by pack_id")
+    return by_pack
+
+
+def validate_packset_lock(
+    lock: Mapping[str, Any],
+    manifests: Mapping[str, Mapping[str, Any]],
+) -> None:
+    """Validate lock content against the manifests available for replay.
+
+    ``manifests`` may be a catalog superset. The mounted semantic input is exactly
+    the pack IDs in the lock; required dependencies must resolve inside that set.
+    """
+
+    revisions = pack_revisions_from_lock(lock)
+    records = _lock_records(lock)
+    mounted = set(revisions)
+
+    missing_manifests = sorted(pack_id for pack_id in mounted if pack_id not in manifests)
+    if missing_manifests:
+        raise PackSetLockError(
+            f"unresolved referenced pack manifest(s): {missing_manifests}"
+        )
+
+    mounted_manifests = {
+        pack_id: dict(manifests[pack_id])
+        for pack_id in mounted
+    }
+    validate_pack_dependency_graph(mounted_manifests)
+
+    for record in records:
+        pack_id = str(record["pack_id"])
+        manifest = mounted_manifests[pack_id]
+        dependencies = record.get("dependencies")
+        if not isinstance(dependencies, list):
+            raise PackSetLockError(
+                f"pack {pack_id} dependencies must be a list"
+            )
+
+        dependency_ids: list[str] = []
+        for dependency in dependencies:
+            if not isinstance(dependency, Mapping):
+                raise PackSetLockError(
+                    f"pack {pack_id} dependency records must be objects"
+                )
+            target = str(dependency.get("pack_id", ""))
+            if target not in mounted:
+                raise PackSetLockError(
+                    f"unresolved referenced pack in lock dependency: {pack_id} -> {target}"
+                )
+            if target in dependency_ids:
+                raise PackSetLockError(
+                    f"duplicate dependency in lock for pack {pack_id}: {target}"
+                )
+            dependency_ids.append(target)
+        if dependency_ids != sorted(dependency_ids):
+            raise PackSetLockError(
+                f"pack {pack_id} dependencies must be sorted by pack_id"
+            )
+
+        expected_dependencies = _resolved_dependencies(manifest, mounted)
+        normalized_dependencies = [
+            {
+                "pack_id": str(item.get("pack_id", "")),
+                "required": item.get("required"),
+            }
+            for item in dependencies
+        ]
+        if normalized_dependencies != expected_dependencies:
+            raise PackSetLockError(
+                f"pack {pack_id} dependency metadata differs from validated manifest"
+            )
+
+        manifest_digest = record.get("manifest_digest")
+        expected_digest = canonical_manifest_digest(manifest)
+        if not isinstance(manifest_digest, Mapping) or manifest_digest.get("algorithm") != "sha256":
+            raise PackSetLockError(
+                f"pack {pack_id} manifest digest must use sha256"
+            )
+        if manifest_digest.get("digest") != expected_digest:
+            raise PackSetLockError(
+                f"pack {pack_id} manifest digest differs from validated manifest"
+            )
+
+
+def packset_lock_digest(lock: Mapping[str, Any]) -> str:
+    """Return the external SHA-256 digest of canonical lock content."""
+
+    _lock_records(lock)
+    return hashlib.sha256(_canonical_json_bytes(dict(lock))).hexdigest()
+
+
+__all__ = [
+    "PACKSET_LOCK_CONTRACT_VERSION",
+    "PackSetLockError",
+    "build_packset_lock",
+    "canonical_manifest_digest",
+    "pack_revisions_from_lock",
+    "packset_lock_digest",
+    "validate_pack_dependency_graph",
+    "validate_packset_lock",
+]

--- a/src/fossil_core/domain/packset.py
+++ b/src/fossil_core/domain/packset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from collections.abc import Mapping
 from typing import Any
 
@@ -10,6 +11,11 @@ from .pack import PackBoundaryError
 
 PACKSET_LOCK_CONTRACT_VERSION = "dkg.packset-lock.v1"
 _STANDARD_LAYER_RANK = {"common": 0, "domain": 1, "project": 2}
+_PACK_ID_RE = re.compile(r"^pack_[A-Za-z0-9_-]{16,}$")
+_HEX64_RE = re.compile(r"^[0-9a-f]{64}$")
+_PACK_RECORD_FIELDS = {"pack_id", "revision", "manifest_digest", "dependencies"}
+_DIGEST_FIELDS = {"algorithm", "digest"}
+_DEPENDENCY_FIELDS = {"pack_id", "required"}
 
 
 class PackSetLockError(PackBoundaryError):
@@ -70,6 +76,10 @@ def validate_pack_dependency_graph(manifests: Mapping[str, Mapping[str, Any]]) -
 
     for pack_id in sorted(manifests):
         manifest = manifests[pack_id]
+        if manifest.get("pack_id") != pack_id:
+            raise PackBoundaryError(
+                f"manifest identity mismatch: catalog key {pack_id} != manifest pack_id {manifest.get('pack_id')}"
+            )
         dependencies = _dependencies_by_target(manifest)
         source_kind = str(manifest.get("kind", ""))
         resolved: list[str] = []
@@ -107,9 +117,7 @@ def validate_pack_dependency_graph(manifests: Mapping[str, Mapping[str, Any]]) -
             except ValueError:
                 index = 0
             cycle = [*stack[index:], pack_id]
-            raise PackBoundaryError(
-                "dependency cycle: " + " -> ".join(cycle)
-            )
+            raise PackBoundaryError("dependency cycle: " + " -> ".join(cycle))
         state[pack_id] = 1
         stack.append(pack_id)
         for target in adjacency[pack_id]:
@@ -131,7 +139,10 @@ def build_packset_lock(
     over this content with :func:`packset_lock_digest` to avoid self-reference.
     """
 
-    manifests = {str(pack_id): dict(manifest) for pack_id, manifest in validated_manifests.items()}
+    manifests = {
+        str(pack_id): dict(manifest)
+        for pack_id, manifest in validated_manifests.items()
+    }
     if not manifests:
         raise PackSetLockError("packset lock requires at least one mounted pack")
     validate_pack_dependency_graph(manifests)
@@ -140,14 +151,10 @@ def build_packset_lock(
     revision_ids = {str(pack_id) for pack_id in revisions}
     missing = sorted(mounted - revision_ids)
     if missing:
-        raise PackSetLockError(
-            f"missing exact revision for mounted pack(s): {missing}"
-        )
+        raise PackSetLockError(f"missing exact revision for mounted pack(s): {missing}")
     extra = sorted(revision_ids - mounted)
     if extra:
-        raise PackSetLockError(
-            f"unresolved revision pack(s) are not mounted: {extra}"
-        )
+        raise PackSetLockError(f"unresolved revision pack(s) are not mounted: {extra}")
 
     packs: list[dict[str, Any]] = []
     for pack_id in sorted(manifests):
@@ -193,21 +200,66 @@ def _lock_records(lock: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     return list(packs)
 
 
+def _validate_lock_record_shape(record: Mapping[str, Any]) -> None:
+    if set(record) != _PACK_RECORD_FIELDS:
+        raise PackSetLockError(
+            "pack record fields must be exactly pack_id, revision, manifest_digest, dependencies"
+        )
+
+    pack_id = record.get("pack_id")
+    if not isinstance(pack_id, str) or _PACK_ID_RE.fullmatch(pack_id) is None:
+        raise PackSetLockError(f"invalid pack_id in packset lock: {pack_id!r}")
+    revision = record.get("revision")
+    if not isinstance(revision, str) or not revision.strip():
+        raise PackSetLockError(f"pack {pack_id} requires a non-empty exact revision")
+
+    digest = record.get("manifest_digest")
+    if not isinstance(digest, Mapping) or set(digest) != _DIGEST_FIELDS:
+        raise PackSetLockError(
+            f"pack {pack_id} manifest digest fields must be exactly algorithm and digest"
+        )
+    if digest.get("algorithm") != "sha256" or not isinstance(digest.get("digest"), str):
+        raise PackSetLockError(f"pack {pack_id} manifest digest must use sha256")
+    if _HEX64_RE.fullmatch(str(digest["digest"])) is None:
+        raise PackSetLockError(f"pack {pack_id} manifest digest must be 64 lowercase hex chars")
+
+    dependencies = record.get("dependencies")
+    if not isinstance(dependencies, list):
+        raise PackSetLockError(f"pack {pack_id} dependencies must be a list")
+    dependency_ids: list[str] = []
+    for dependency in dependencies:
+        if not isinstance(dependency, Mapping):
+            raise PackSetLockError(f"pack {pack_id} dependency records must be objects")
+        if set(dependency) != _DEPENDENCY_FIELDS:
+            raise PackSetLockError(
+                f"pack {pack_id} dependency fields must be exactly pack_id and required"
+            )
+        target = dependency.get("pack_id")
+        if not isinstance(target, str) or _PACK_ID_RE.fullmatch(target) is None:
+            raise PackSetLockError(
+                f"pack {pack_id} has invalid dependency pack_id: {target!r}"
+            )
+        if not isinstance(dependency.get("required"), bool):
+            raise PackSetLockError(
+                f"pack {pack_id} dependency {target} required flag must be boolean"
+            )
+        if target in dependency_ids:
+            raise PackSetLockError(f"duplicate dependency in lock for pack {pack_id}: {target}")
+        dependency_ids.append(target)
+    if dependency_ids != sorted(dependency_ids):
+        raise PackSetLockError(f"pack {pack_id} dependencies must be sorted by pack_id")
+
+
 def pack_revisions_from_lock(lock: Mapping[str, Any]) -> dict[str, str]:
     records = _lock_records(lock)
     by_pack: dict[str, str] = {}
     sequence: list[str] = []
     for record in records:
-        pack_id = str(record.get("pack_id", ""))
-        revision = record.get("revision")
-        if not pack_id:
-            raise PackSetLockError("packset lock requires non-empty pack_id")
+        _validate_lock_record_shape(record)
+        pack_id = str(record["pack_id"])
+        revision = str(record["revision"])
         if pack_id in by_pack:
             raise PackSetLockError(f"duplicate pack_id in packset lock: {pack_id}")
-        if not isinstance(revision, str) or not revision.strip():
-            raise PackSetLockError(
-                f"pack {pack_id} requires a non-empty exact revision"
-            )
         by_pack[pack_id] = revision
         sequence.append(pack_id)
     if sequence != sorted(sequence):
@@ -235,47 +287,26 @@ def validate_packset_lock(
             f"unresolved referenced pack manifest(s): {missing_manifests}"
         )
 
-    mounted_manifests = {
-        pack_id: dict(manifests[pack_id])
-        for pack_id in mounted
-    }
+    mounted_manifests = {pack_id: dict(manifests[pack_id]) for pack_id in mounted}
     validate_pack_dependency_graph(mounted_manifests)
 
     for record in records:
         pack_id = str(record["pack_id"])
         manifest = mounted_manifests[pack_id]
-        dependencies = record.get("dependencies")
-        if not isinstance(dependencies, list):
-            raise PackSetLockError(
-                f"pack {pack_id} dependencies must be a list"
-            )
+        dependencies = record["dependencies"]
 
-        dependency_ids: list[str] = []
         for dependency in dependencies:
-            if not isinstance(dependency, Mapping):
-                raise PackSetLockError(
-                    f"pack {pack_id} dependency records must be objects"
-                )
-            target = str(dependency.get("pack_id", ""))
+            target = str(dependency["pack_id"])
             if target not in mounted:
                 raise PackSetLockError(
                     f"unresolved referenced pack in lock dependency: {pack_id} -> {target}"
                 )
-            if target in dependency_ids:
-                raise PackSetLockError(
-                    f"duplicate dependency in lock for pack {pack_id}: {target}"
-                )
-            dependency_ids.append(target)
-        if dependency_ids != sorted(dependency_ids):
-            raise PackSetLockError(
-                f"pack {pack_id} dependencies must be sorted by pack_id"
-            )
 
         expected_dependencies = _resolved_dependencies(manifest, mounted)
         normalized_dependencies = [
             {
-                "pack_id": str(item.get("pack_id", "")),
-                "required": item.get("required"),
+                "pack_id": str(item["pack_id"]),
+                "required": item["required"],
             }
             for item in dependencies
         ]
@@ -284,22 +315,18 @@ def validate_packset_lock(
                 f"pack {pack_id} dependency metadata differs from validated manifest"
             )
 
-        manifest_digest = record.get("manifest_digest")
+        manifest_digest = record["manifest_digest"]
         expected_digest = canonical_manifest_digest(manifest)
-        if not isinstance(manifest_digest, Mapping) or manifest_digest.get("algorithm") != "sha256":
-            raise PackSetLockError(
-                f"pack {pack_id} manifest digest must use sha256"
-            )
-        if manifest_digest.get("digest") != expected_digest:
+        if manifest_digest["digest"] != expected_digest:
             raise PackSetLockError(
                 f"pack {pack_id} manifest digest differs from validated manifest"
             )
 
 
 def packset_lock_digest(lock: Mapping[str, Any]) -> str:
-    """Return the external SHA-256 digest of canonical lock content."""
+    """Return the external SHA-256 digest of canonical valid lock content."""
 
-    _lock_records(lock)
+    pack_revisions_from_lock(lock)
     return hashlib.sha256(_canonical_json_bytes(dict(lock))).hexdigest()
 
 

--- a/tests/test_packset_lock.py
+++ b/tests/test_packset_lock.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from fossil_core.application.ingest.pack_validation import KnowledgePackValidator
+from fossil_core.application.query.receipt import normalize_pack_mounts
+from fossil_core.domain.pack import PackBoundaryError
+from fossil_core.domain.packset import (
+    PACKSET_LOCK_CONTRACT_VERSION,
+    PackSetLockError,
+    canonical_manifest_digest,
+    pack_revisions_from_lock,
+    packset_lock_digest,
+    validate_packset_lock,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACK_SCHEMA = ROOT / "schemas/knowledge-pack/v1.schema.json"
+LOCK_SCHEMA = ROOT / "schemas/packset-lock/v1.schema.json"
+
+COMMON = "pack_0000000000000001"
+DOMAIN = "pack_0000000000000002"
+PROJECT = "pack_0000000000000003"
+OPTIONAL = "pack_0000000000000004"
+PERSONAL_A = "pack_0000000000000005"
+PERSONAL_B = "pack_0000000000000006"
+
+
+def dependency(pack_id: str, *, required: bool = True) -> dict:
+    return {
+        "pack_id": pack_id,
+        "required": required,
+        "reason": "fixture dependency",
+    }
+
+
+def manifest(
+    pack_id: str,
+    *,
+    kind: str,
+    dependencies: list[dict] | None = None,
+    name: str | None = None,
+) -> dict:
+    deps = list(dependencies or [])
+    required_mounts = [item["pack_id"] for item in deps if item["required"]]
+    return {
+        "contract_version": "dkg.pack.v1",
+        "pack_id": pack_id,
+        "name": name or f"{kind} fixture",
+        "kind": kind,
+        "schema_version": "dkg.event.v1",
+        "dependencies": deps,
+        "read_mounts": sorted({pack_id, *required_mounts}),
+        "write_targets": [pack_id],
+        "event_roots": ["events/"],
+        "artifact_manifests": [],
+        "placement_hint": "unspecified",
+        "projection_namespace": f"projection-{pack_id}",
+    }
+
+
+def validator() -> KnowledgePackValidator:
+    return KnowledgePackValidator(PACK_SCHEMA)
+
+
+def standard_manifests() -> list[dict]:
+    common = manifest(COMMON, kind="common")
+    domain = manifest(DOMAIN, kind="domain", dependencies=[dependency(COMMON)])
+    project = manifest(
+        PROJECT,
+        kind="project",
+        dependencies=[dependency(COMMON), dependency(DOMAIN)],
+    )
+    return [project, common, domain]
+
+
+def standard_revisions() -> dict[str, str]:
+    return {
+        PROJECT: "git:project@cccccccc",
+        COMMON: "git:common@aaaaaaaa",
+        DOMAIN: "git:domain@bbbbbbbb",
+    }
+
+
+def test_build_lock_is_schema_valid_sorted_exact_and_digest_is_external():
+    lock = validator().build_packset_lock(standard_manifests(), standard_revisions())
+
+    schema = json.loads(LOCK_SCHEMA.read_text(encoding="utf-8"))
+    Draft202012Validator(schema).validate(lock)
+    assert lock["contract_version"] == PACKSET_LOCK_CONTRACT_VERSION
+    assert [item["pack_id"] for item in lock["packs"]] == [COMMON, DOMAIN, PROJECT]
+    assert "lock_digest" not in lock
+
+    by_pack = {item["pack_id"]: item for item in lock["packs"]}
+    assert by_pack[COMMON]["revision"] == "git:common@aaaaaaaa"
+    assert by_pack[DOMAIN]["dependencies"] == [
+        {"pack_id": COMMON, "required": True}
+    ]
+    assert by_pack[PROJECT]["dependencies"] == [
+        {"pack_id": COMMON, "required": True},
+        {"pack_id": DOMAIN, "required": True},
+    ]
+    for source in standard_manifests():
+        record = by_pack[source["pack_id"]]
+        assert record["manifest_digest"] == {
+            "algorithm": "sha256",
+            "digest": canonical_manifest_digest(source),
+        }
+
+    digest = packset_lock_digest(lock)
+    assert len(digest) == 64
+    assert all(ch in "0123456789abcdef" for ch in digest)
+
+
+def test_lock_is_portable_across_input_order_paths_and_json_formatting(tmp_path):
+    manifests = standard_manifests()
+    compact_root = tmp_path / "compact"
+    pretty_root = tmp_path / "moved" / "pretty"
+    compact_root.mkdir(parents=True)
+    pretty_root.mkdir(parents=True)
+
+    compact_paths: list[Path] = []
+    pretty_paths: list[Path] = []
+    for index, item in enumerate(manifests):
+        compact = compact_root / f"{index}.json"
+        pretty = pretty_root / f"{index}.json"
+        compact.write_text(json.dumps(item, sort_keys=True, separators=(",", ":")), encoding="utf-8")
+        pretty.write_text(json.dumps(dict(reversed(list(item.items()))), indent=4), encoding="utf-8")
+        compact_paths.append(compact)
+        pretty_paths.append(pretty)
+
+    compact_manifests = [json.loads(path.read_text(encoding="utf-8")) for path in compact_paths]
+    pretty_manifests = [json.loads(path.read_text(encoding="utf-8")) for path in reversed(pretty_paths)]
+    left = validator().build_packset_lock(compact_manifests, standard_revisions())
+    right = validator().build_packset_lock(pretty_manifests, standard_revisions())
+
+    assert left == right
+    assert packset_lock_digest(left) == packset_lock_digest(right)
+
+
+def test_query_receipt_mounts_preserve_exact_lock_revisions():
+    lock = validator().build_packset_lock(standard_manifests(), standard_revisions())
+
+    assert normalize_pack_mounts(pack_revisions_from_lock(lock)) == [
+        {"pack_id": COMMON, "revision": "git:common@aaaaaaaa"},
+        {"pack_id": DOMAIN, "revision": "git:domain@bbbbbbbb"},
+        {"pack_id": PROJECT, "revision": "git:project@cccccccc"},
+    ]
+
+
+def test_revision_set_must_match_mounted_pack_set_exactly():
+    manifests = standard_manifests()
+    revisions = standard_revisions()
+
+    missing = dict(revisions)
+    missing.pop(DOMAIN)
+    with pytest.raises(PackSetLockError, match="missing exact revision"):
+        validator().build_packset_lock(manifests, missing)
+
+    extra = dict(revisions)
+    extra[OPTIONAL] = "git:optional@dddddddd"
+    with pytest.raises(PackSetLockError, match="unresolved revision pack"):
+        validator().build_packset_lock(manifests, extra)
+
+    blank = dict(revisions)
+    blank[DOMAIN] = ""
+    with pytest.raises(PackSetLockError, match="non-empty exact revision"):
+        validator().build_packset_lock(manifests, blank)
+
+
+def test_required_dependency_must_be_mounted_but_absent_optional_dependency_is_not_a_resolved_edge():
+    required = manifest(DOMAIN, kind="domain", dependencies=[dependency(COMMON, required=True)])
+    with pytest.raises(PackBoundaryError, match="required dependency.*unavailable"):
+        validator().build_packset_lock([required], {DOMAIN: "rev-domain"})
+
+    optional = manifest(DOMAIN, kind="domain", dependencies=[dependency(OPTIONAL, required=False)])
+    lock = validator().build_packset_lock([optional], {DOMAIN: "rev-domain"})
+    assert lock["packs"][0]["dependencies"] == []
+
+
+def test_lock_validation_rejects_unresolved_dependency_edge_and_manifest_dependency_drift():
+    manifests = standard_manifests()
+    lock = validator().build_packset_lock(manifests, standard_revisions())
+
+    unresolved = deepcopy(lock)
+    unresolved["packs"][0]["dependencies"] = [
+        {"pack_id": OPTIONAL, "required": False}
+    ]
+    with pytest.raises(PackSetLockError, match="unresolved referenced pack"):
+        validate_packset_lock(unresolved, {item["pack_id"]: item for item in manifests})
+
+    metadata_drift = deepcopy(lock)
+    project = next(item for item in metadata_drift["packs"] if item["pack_id"] == PROJECT)
+    project["dependencies"][0]["required"] = False
+    with pytest.raises(PackSetLockError, match="dependency metadata differs"):
+        validate_packset_lock(metadata_drift, {item["pack_id"]: item for item in manifests})
+
+
+def test_lock_validation_rejects_manifest_drift_even_when_pack_id_and_revision_match():
+    manifests = standard_manifests()
+    lock = validator().build_packset_lock(manifests, standard_revisions())
+    changed = deepcopy(manifests)
+    changed[0]["name"] = "renamed project"
+
+    with pytest.raises(PackSetLockError, match="manifest digest differs"):
+        validate_packset_lock(lock, {item["pack_id"]: item for item in changed})
+
+
+def test_lock_validation_rejects_duplicate_pack_identity_even_with_different_revisions():
+    manifests = standard_manifests()
+    lock = validator().build_packset_lock(manifests, standard_revisions())
+    duplicate = deepcopy(lock)
+    duplicate["packs"].append(deepcopy(duplicate["packs"][0]))
+    duplicate["packs"][-1]["revision"] = "another-revision"
+
+    with pytest.raises(PackSetLockError, match="duplicate pack_id"):
+        validate_packset_lock(duplicate, {item["pack_id"]: item for item in manifests})
+
+
+def test_standard_dependency_layers_are_strictly_upstream():
+    common_to_domain = [
+        manifest(COMMON, kind="common", dependencies=[dependency(DOMAIN)]),
+        manifest(DOMAIN, kind="domain"),
+    ]
+    with pytest.raises(PackBoundaryError, match="dependency layer violation"):
+        validator().validate_set(common_to_domain)
+
+    domain_to_project = [
+        manifest(DOMAIN, kind="domain", dependencies=[dependency(PROJECT)]),
+        manifest(PROJECT, kind="project"),
+    ]
+    with pytest.raises(PackBoundaryError, match="dependency layer violation"):
+        validator().validate_set(domain_to_project)
+
+    project_to_project = [
+        manifest(PROJECT, kind="project", dependencies=[dependency(OPTIONAL)]),
+        manifest(OPTIONAL, kind="project"),
+    ]
+    with pytest.raises(PackBoundaryError, match="dependency layer violation"):
+        validator().validate_set(project_to_project)
+
+    validator().validate_set(standard_manifests())
+
+
+def test_cycle_detection_applies_to_personal_and_experimental_packs_too():
+    first = manifest(PERSONAL_A, kind="personal", dependencies=[dependency(PERSONAL_B)])
+    second = manifest(PERSONAL_B, kind="experimental", dependencies=[dependency(PERSONAL_A)])
+
+    with pytest.raises(PackBoundaryError, match="dependency cycle"):
+        validator().validate_set([first, second])
+
+
+def test_duplicate_dependency_metadata_for_one_target_is_rejected():
+    candidate = manifest(
+        PROJECT,
+        kind="project",
+        dependencies=[
+            dependency(COMMON, required=True),
+            dependency(COMMON, required=False),
+        ],
+    )
+    common = manifest(COMMON, kind="common")
+
+    with pytest.raises(PackBoundaryError, match="duplicate dependency"):
+        validator().validate_set([candidate, common])

--- a/tests/test_packset_lock_adversarial.py
+++ b/tests/test_packset_lock_adversarial.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from fossil_core.application.ingest.pack_validation import KnowledgePackValidator
+from fossil_core.domain.packset import PackSetLockError, packset_lock_digest, validate_packset_lock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACK_SCHEMA = ROOT / "schemas/knowledge-pack/v1.schema.json"
+
+COMMON = "pack_0000000000000101"
+PROJECT = "pack_0000000000000102"
+EXTRA_A = "pack_0000000000000103"
+EXTRA_B = "pack_0000000000000104"
+
+
+def dep(pack_id: str, *, required: bool) -> dict:
+    return {"pack_id": pack_id, "required": required, "reason": "adversarial fixture"}
+
+
+def manifest(pack_id: str, kind: str, dependencies: list[dict] | None = None) -> dict:
+    deps = list(dependencies or [])
+    return {
+        "contract_version": "dkg.pack.v1",
+        "pack_id": pack_id,
+        "name": f"{kind}-{pack_id}",
+        "kind": kind,
+        "schema_version": "dkg.event.v1",
+        "dependencies": deps,
+        "read_mounts": sorted({pack_id, *(item["pack_id"] for item in deps if item["required"])}),
+        "write_targets": [pack_id],
+        "event_roots": ["events/"],
+        "artifact_manifests": [],
+    }
+
+
+def validator() -> KnowledgePackValidator:
+    return KnowledgePackValidator(PACK_SCHEMA)
+
+
+def test_mounted_optional_dependency_is_a_resolved_required_false_edge():
+    common = manifest(COMMON, "common")
+    project = manifest(PROJECT, "project", [dep(COMMON, required=False)])
+
+    lock = validator().build_packset_lock(
+        [project, common],
+        {PROJECT: "project-rev", COMMON: "common-rev"},
+    )
+
+    project_record = next(item for item in lock["packs"] if item["pack_id"] == PROJECT)
+    assert project_record["dependencies"] == [
+        {"pack_id": COMMON, "required": False}
+    ]
+
+
+def test_lock_validator_rejects_noncanonical_extra_fields_without_relying_on_schema_callers():
+    common = manifest(COMMON, "common")
+    lock = validator().build_packset_lock([common], {COMMON: "common-rev"})
+    lock["packs"][0]["provider_native_location"] = "s3://must-not-be-semantic-identity"
+
+    with pytest.raises(PackSetLockError, match="pack record fields"):
+        validate_packset_lock(lock, {COMMON: common})
+
+
+def test_lock_validator_rejects_noncanonical_dependency_shape():
+    common = manifest(COMMON, "common")
+    project = manifest(PROJECT, "project", [dep(COMMON, required=False)])
+    lock = validator().build_packset_lock(
+        [project, common],
+        {PROJECT: "project-rev", COMMON: "common-rev"},
+    )
+    project_record = next(item for item in lock["packs"] if item["pack_id"] == PROJECT)
+    project_record["dependencies"][0]["reason"] = "not part of lock edge contract"
+
+    with pytest.raises(PackSetLockError, match="dependency fields"):
+        validate_packset_lock(lock, {COMMON: common, PROJECT: project})
+
+
+def test_replay_validation_ignores_unmounted_catalog_cycles():
+    common = manifest(COMMON, "common")
+    lock = validator().build_packset_lock([common], {COMMON: "common-rev"})
+    extra_a = manifest(EXTRA_A, "personal", [dep(EXTRA_B, required=True)])
+    extra_b = manifest(EXTRA_B, "experimental", [dep(EXTRA_A, required=True)])
+
+    validator().validate_packset_lock(lock, [common, extra_a, extra_b])
+
+
+def test_lock_digest_changes_when_exact_revision_changes_but_digest_never_enters_content():
+    common = manifest(COMMON, "common")
+    first = validator().build_packset_lock([common], {COMMON: "rev-a"})
+    second = validator().build_packset_lock([deepcopy(common)], {COMMON: "rev-b"})
+
+    assert "lock_digest" not in first
+    assert "lock_digest" not in second
+    assert packset_lock_digest(first) != packset_lock_digest(second)

--- a/tests/test_packset_lock_properties.py
+++ b/tests/test_packset_lock_properties.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from itertools import permutations
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings, strategies as st
+
+from fossil_core.application.ingest.pack_validation import KnowledgePackValidator
+from fossil_core.domain.pack import PackBoundaryError
+from fossil_core.domain.packset import packset_lock_digest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACK_SCHEMA = ROOT / "schemas/knowledge-pack/v1.schema.json"
+
+COMMON = "pack_0000000000000011"
+DOMAIN = "pack_0000000000000012"
+PROJECT = "pack_0000000000000013"
+
+
+def manifest(pack_id: str, *, kind: str, dependencies: list[dict] | None = None) -> dict:
+    deps = list(dependencies or [])
+    return {
+        "contract_version": "dkg.pack.v1",
+        "pack_id": pack_id,
+        "name": f"{kind} generated fixture",
+        "kind": kind,
+        "schema_version": "dkg.event.v1",
+        "dependencies": deps,
+        "read_mounts": sorted({pack_id, *(dep["pack_id"] for dep in deps if dep["required"])}),
+        "write_targets": [pack_id],
+        "event_roots": ["events/"],
+        "artifact_manifests": [],
+    }
+
+
+def validator() -> KnowledgePackValidator:
+    return KnowledgePackValidator(PACK_SCHEMA)
+
+
+@settings(max_examples=80, derandomize=True)
+@given(
+    common_revision=st.text(min_size=1, max_size=40).filter(lambda value: bool(value.strip())),
+    domain_revision=st.text(min_size=1, max_size=40).filter(lambda value: bool(value.strip())),
+    project_revision=st.text(min_size=1, max_size=40).filter(lambda value: bool(value.strip())),
+)
+def test_pack_input_order_never_changes_canonical_lock_or_digest(
+    common_revision: str,
+    domain_revision: str,
+    project_revision: str,
+) -> None:
+    manifests = [
+        manifest(COMMON, kind="common"),
+        manifest(DOMAIN, kind="domain", dependencies=[{"pack_id": COMMON, "required": True}]),
+        manifest(
+            PROJECT,
+            kind="project",
+            dependencies=[
+                {"pack_id": DOMAIN, "required": True},
+                {"pack_id": COMMON, "required": False},
+            ],
+        ),
+    ]
+    revisions = {
+        COMMON: common_revision,
+        DOMAIN: domain_revision,
+        PROJECT: project_revision,
+    }
+
+    locks = [validator().build_packset_lock(order, revisions) for order in permutations(manifests)]
+
+    assert all(lock == locks[0] for lock in locks)
+    assert all(packset_lock_digest(lock) == packset_lock_digest(locks[0]) for lock in locks)
+
+
+@settings(max_examples=120, derandomize=True)
+@given(
+    source_kind=st.sampled_from(["common", "domain", "project"]),
+    target_kind=st.sampled_from(["common", "domain", "project"]),
+)
+def test_standard_layer_dependency_is_allowed_exactly_when_target_is_upstream(
+    source_kind: str,
+    target_kind: str,
+) -> None:
+    source = "pack_0000000000000021"
+    target = "pack_0000000000000022"
+    manifests = [
+        manifest(source, kind=source_kind, dependencies=[{"pack_id": target, "required": True}]),
+        manifest(target, kind=target_kind),
+    ]
+    rank = {"common": 0, "domain": 1, "project": 2}
+
+    if rank[target_kind] < rank[source_kind]:
+        validator().validate_set(manifests)
+    else:
+        with pytest.raises(PackBoundaryError, match="dependency layer violation"):
+            validator().validate_set(manifests)
+
+
+@settings(max_examples=80, derandomize=True)
+@given(revision=st.text(min_size=1, max_size=64).filter(lambda value: bool(value.strip())))
+def test_exact_revision_is_preserved_opaquely_in_lock(revision: str) -> None:
+    lock = validator().build_packset_lock(
+        [manifest(COMMON, kind="common")],
+        {COMMON: revision},
+    )
+
+    assert lock["packs"] == [
+        {
+            "pack_id": COMMON,
+            "revision": revision,
+            "manifest_digest": lock["packs"][0]["manifest_digest"],
+            "dependencies": [],
+        }
+    ]


### PR DESCRIPTION
Implements the frozen #111 Step 2 mounted-pack-set law as `dkg.packset-lock.v1`.

What changed:
- adds a canonical JSON lock schema with one record per mounted `pack_id`, sorted by `pack_id`;
- freezes one opaque non-empty exact `revision` per mounted pack while preserving `pack_id` as the stable logical identity;
- records a canonical SHA-256 manifest digest for drift detection and resolved dependency edges with explicit `required: true|false` status;
- computes the lock SHA-256 externally from canonical lock content; no self-referential digest field exists in the lock;
- rejects duplicate pack identities/revisions-for-one-pack representation, missing exact revisions, revision entries for unmounted packs, missing required dependencies, unresolved lock references, manifest drift, dependency metadata drift, noncanonical extra fields, duplicate dependency metadata, and malformed lock records;
- enforces the frozen default standard layering strictly upstream (`common <- domain <- project`): domain may depend on common; project may depend on common/domain; common cannot depend downstream and same-layer standard dependencies are rejected;
- detects dependency cycles globally, including personal/experimental packs; those kinds do not weaken exact-revision or cycle laws;
- treats an optional dependency as unresolved/absent when its target is not in the mounted pack set, and as a real `required:false` edge when the target is mounted;
- extends `KnowledgePackValidator` with validated lock build/replay entrypoints while allowing replay validation against a manifest catalog superset without letting unrelated unmounted cycles contaminate the locked graph;
- preserves the existing query-receipt contract: exact revisions extracted from a lock normalize to the same sorted `{pack_id, revision}` receipt surface; receipts remain evidence of what ran, not the lock authority;
- adds deterministic, adversarial, portability, and Hypothesis/generative oracles, including relocation/JSON-format invariance.

TDD / exact-head evidence:
- RED test-only head `e6d72f2181b3f71e414026e43af3a2f9e4720737`; DKG run `32276820805` failed for the intended missing `fossil_core.domain.packset` module;
- initial GREEN head `cb4a1febe7fd438087571cf718fa78a9e27ee9c1`: DKG `32277000208` PASS; dependency integrity `32277000008` PASS;
- self-review then hardened schema-independent record validation and replay-against-catalog-superset behavior;
- final exact head `d41e7c64b5c4a3f8ebda509d7d1fbed2cb438410`: DKG contract tests `32277293128` PASS; dependency integrity `32277293122` PASS.

Affected stable properties: `FOSSIL-PROP-PACK-MANIFEST-001`, `FOSSIL-PROP-STABLE-ID-001`, `FOSSIL-PROP-REBUILD-001`, `FOSSIL-PROP-QUERY-RECEIPT-001`, and `FOSSIL-PROP-ARCH-BOUNDARY-001`. This strengthens frozen Law 4 without changing event identity or query-receipt authority.

Scope / non-goals:
- no promotion-v2/source revision+event pin (Step 3);
- no storage/provider/projection rewrite;
- no hidden holdout work;
- no new mutation/TLA+/Lean lane;
- no production promotion or deployment.

Closes no issue; #111 remains open for Step 3+ implementation.