### PR TITLE
Implement reviewed evidence ingestion

### DIFF
--- a/schemas/reviewed-evidence-ingest/receipt-v1.schema.json
+++ b/schemas/reviewed-evidence-ingest/receipt-v1.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pukujan.github.io/fossil-core/schemas/reviewed-evidence-ingest/receipt-v1.schema.json",
+  "title": "FOSSIL Reviewed Evidence Ingest Receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "receipt_id",
+    "authority",
+    "status",
+    "pack_id",
+    "review_ref",
+    "correlation_id",
+    "source",
+    "validation",
+    "proposal_event_ids",
+    "proposal_count",
+    "accepted_count",
+    "requires_explicit_promotion",
+    "rejection_reason"
+  ],
+  "properties": {
+    "schema_version": {"const": "fossil.reviewed-evidence-ingest-receipt.v1"},
+    "receipt_id": {"type": "string", "pattern": "^ingest_receipt_[A-Za-z0-9_-]{16,}$"},
+    "authority": {"const": "non_authoritative_receipt"},
+    "status": {"enum": ["proposed", "rejected"]},
+    "pack_id": {"type": "string", "minLength": 1},
+    "review_ref": {"type": "string", "minLength": 1},
+    "correlation_id": {"type": "string", "minLength": 1},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_kind", "preserved", "artifact_id", "snapshot_id"],
+      "properties": {
+        "source_kind": {"type": "string", "minLength": 1},
+        "preserved": {"type": "boolean"},
+        "artifact_id": {"type": ["string", "null"]},
+        "snapshot_id": {"type": ["string", "null"]}
+      }
+    },
+    "validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pack", "source", "events", "provenance", "evidence", "ontology"],
+      "properties": {
+        "pack": {"enum": ["passed", "not_run"]},
+        "source": {"enum": ["passed", "not_run", "rejected_by_ingest_policy"]},
+        "events": {"enum": ["passed", "not_run"]},
+        "provenance": {"enum": ["passed", "not_run"]},
+        "evidence": {"enum": ["passed", "not_run"]},
+        "ontology": {"enum": ["passed", "not_applicable", "not_run"]}
+      }
+    },
+    "proposal_event_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "proposal_count": {"type": "integer", "minimum": 0},
+    "accepted_count": {"const": 0},
+    "requires_explicit_promotion": {"const": true},
+    "rejection_reason": {"type": ["string", "null"]}
+  }
+}

--- a/schemas/reviewed-evidence-ingest/receipt-v1.schema.json
+++ b/schemas/reviewed-evidence-ingest/receipt-v1.schema.json
@@ -59,7 +59,7 @@
     },
     "proposal_count": {"type": "integer", "minimum": 0},
     "accepted_count": {"const": 0},
-    "requires_explicit_promotion": {"const": true},
+    "requires_explicit_promotion": {"type": "boolean"},
     "rejection_reason": {"type": ["string", "null"]}
   }
 }

--- a/src/fossil_core/application/ingest/reviewed_evidence.py
+++ b/src/fossil_core/application/ingest/reviewed_evidence.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import hashlib
-import json
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 
@@ -202,9 +201,8 @@ class ReviewedEvidenceIngestService:
                 },
                 "provenance": {
                     "method": "reviewed_evidence_ingest",
-                    "review_ref": review_ref,
-                    "source_snapshot_ref": snapshot_id,
                     "prompt_or_policy_ref": "skills/research-ingestion/manifest.json",
+                    "benchmark_ref": review_ref,
                 },
             }
             prepared_events.append(self.event_store.validate(event))

--- a/src/fossil_core/application/ingest/reviewed_evidence.py
+++ b/src/fossil_core/application/ingest/reviewed_evidence.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from .pack_validation import KnowledgePackValidator
+from ...source import SourceSnapshotStore
+
+
+REVIEWED_EVIDENCE_RECEIPT_VERSION = "fossil.reviewed-evidence-ingest-receipt.v1"
+_RAW_LOG_SOURCE_KINDS = frozenset({"raw_ci_log", "raw_build_log", "raw_runtime_log"})
+
+
+class ReviewedEvidenceIngestError(ValueError):
+    """Reviewed evidence cannot satisfy the frozen ingestion policy."""
+
+
+@dataclass(frozen=True)
+class ReviewedSource:
+    data: bytes
+    source_kind: str
+    source_role: str
+    locator: Mapping[str, Any]
+    retrieved_at: str
+    quality: Mapping[str, Any]
+    published_at: str | None = None
+    version_metadata: Mapping[str, Any] | None = None
+    derivation: Mapping[str, Any] | None = None
+    media_type: str = "application/octet-stream"
+
+
+@dataclass(frozen=True)
+class ReviewedClaimDraft:
+    subject_ref: str
+    claim_text: str
+    reason: str = ""
+
+
+def _receipt_id(correlation_id: str, review_ref: str, pack_id: str) -> str:
+    digest = hashlib.sha256(
+        f"{correlation_id}\x1f{review_ref}\x1f{pack_id}".encode("utf-8")
+    ).hexdigest()
+    return f"ingest_receipt_{digest[:24]}"
+
+
+class ReviewedEvidenceIngestService:
+    """Provenance-first reviewed evidence ingestion over existing durable contracts.
+
+    This service intentionally cannot emit accepted knowledge. It preserves an
+    allowed reviewed source as an immutable source snapshot, constructs only
+    ``claim.proposed`` events that reference that source, validates the complete
+    proposal batch through the real durable event gate, and only then commits the
+    proposals. Shared/common acceptance remains a separate review/promotion act.
+    """
+
+    def __init__(
+        self,
+        *,
+        source_store: SourceSnapshotStore,
+        event_store: Any,
+        pack_validator: KnowledgePackValidator,
+    ) -> None:
+        self.source_store = source_store
+        self.event_store = event_store
+        self.pack_validator = pack_validator
+
+    @staticmethod
+    def _base_receipt(
+        *,
+        pack_id: str,
+        source_kind: str,
+        review_ref: str,
+        correlation_id: str,
+    ) -> dict[str, Any]:
+        return {
+            "schema_version": REVIEWED_EVIDENCE_RECEIPT_VERSION,
+            "receipt_id": _receipt_id(correlation_id, review_ref, pack_id),
+            "authority": "non_authoritative_receipt",
+            "pack_id": pack_id,
+            "review_ref": review_ref,
+            "correlation_id": correlation_id,
+            "source": {
+                "source_kind": source_kind,
+                "preserved": False,
+                "artifact_id": None,
+                "snapshot_id": None,
+            },
+            "validation": {
+                "pack": "passed",
+                "source": "not_run",
+                "events": "not_run",
+                "provenance": "not_run",
+                "evidence": "not_run",
+                "ontology": "not_applicable",
+            },
+            "proposal_event_ids": [],
+            "proposal_count": 0,
+            "accepted_count": 0,
+            "requires_explicit_promotion": True,
+            "rejection_reason": None,
+        }
+
+    def ingest(
+        self,
+        *,
+        pack_manifest: Mapping[str, Any],
+        source: ReviewedSource,
+        claims: Sequence[ReviewedClaimDraft],
+        review_ref: str,
+        actor: Mapping[str, Any],
+        occurred_at: str,
+        recorded_at: str,
+        correlation_id: str,
+        requested_outcome: str = "proposed",
+    ) -> dict[str, Any]:
+        manifest = copy.deepcopy(dict(pack_manifest))
+        self.pack_validator.validate(manifest)
+        pack_id = str(manifest["pack_id"])
+        if pack_id not in manifest["write_targets"]:
+            raise ReviewedEvidenceIngestError(
+                "reviewed evidence ingest requires the target pack as an explicit write target"
+            )
+        if not review_ref or not correlation_id:
+            raise ReviewedEvidenceIngestError(
+                "reviewed evidence ingest requires review_ref and correlation_id"
+            )
+        if requested_outcome != "proposed":
+            raise ReviewedEvidenceIngestError(
+                "accepted shared knowledge requires explicit review/promotion; "
+                "reviewed evidence ingest emits proposals only"
+            )
+
+        receipt = self._base_receipt(
+            pack_id=pack_id,
+            source_kind=source.source_kind,
+            review_ref=review_ref,
+            correlation_id=correlation_id,
+        )
+
+        if source.source_kind in _RAW_LOG_SOURCE_KINDS:
+            receipt["status"] = "rejected"
+            receipt["rejection_reason"] = "raw_ci_or_log_noise_not_wholesale_ingestable"
+            receipt["validation"]["source"] = "rejected_by_ingest_policy"
+            return receipt
+
+        snapshot = self.source_store.put_snapshot(
+            source.data,
+            locator=source.locator,
+            retrieved_at=source.retrieved_at,
+            published_at=source.published_at,
+            source_role=source.source_role,
+            quality=source.quality,
+            version_metadata=source.version_metadata,
+            derivation=source.derivation,
+            media_type=source.media_type,
+        )
+        artifact_id = str(snapshot["artifact_id"])
+        snapshot_id = str(snapshot["snapshot_id"])
+        receipt["source"] = {
+            "source_kind": source.source_kind,
+            "preserved": True,
+            "artifact_id": artifact_id,
+            "snapshot_id": snapshot_id,
+        }
+        receipt["validation"]["source"] = "passed"
+
+        if not claims:
+            raise ReviewedEvidenceIngestError(
+                "reviewed evidence ingest requires at least one synthesis proposal"
+            )
+
+        prepared_events: list[dict[str, Any]] = []
+        for index, draft in enumerate(claims):
+            if not draft.subject_ref.strip():
+                raise ReviewedEvidenceIngestError(
+                    "reviewed synthesis requires a stable subject_ref"
+                )
+            if not draft.claim_text.strip():
+                raise ReviewedEvidenceIngestError(
+                    "reviewed synthesis requires non-empty claim_text"
+                )
+            event = {
+                "schema_version": "dkg.event.v1",
+                "event_type": "claim.proposed",
+                "occurred_at": occurred_at,
+                "recorded_at": recorded_at,
+                "pack_id": pack_id,
+                "actor": copy.deepcopy(dict(actor)),
+                "subject_refs": [draft.subject_ref],
+                "correlation_id": correlation_id,
+                "idempotency_key": (
+                    f"reviewed-evidence-ingest:{correlation_id}:{index}:{draft.subject_ref}"
+                ),
+                "evidence_refs": [artifact_id],
+                "source_snapshot_refs": [snapshot_id],
+                "payload": {
+                    "claim_text": draft.claim_text,
+                    "reason": draft.reason,
+                },
+                "provenance": {
+                    "method": "reviewed_evidence_ingest",
+                    "review_ref": review_ref,
+                    "source_snapshot_ref": snapshot_id,
+                    "prompt_or_policy_ref": "skills/research-ingestion/manifest.json",
+                },
+            }
+            prepared_events.append(self.event_store.validate(event))
+
+        receipt["validation"].update(
+            {
+                "events": "passed",
+                "provenance": "passed",
+                "evidence": "passed",
+            }
+        )
+
+        committed = [self.event_store.commit(event) for event in prepared_events]
+        receipt["status"] = "proposed"
+        receipt["proposal_event_ids"] = [str(event["event_id"]) for event in committed]
+        receipt["proposal_count"] = len(committed)
+        return receipt
+
+
+__all__ = [
+    "REVIEWED_EVIDENCE_RECEIPT_VERSION",
+    "ReviewedClaimDraft",
+    "ReviewedEvidenceIngestError",
+    "ReviewedEvidenceIngestService",
+    "ReviewedSource",
+]

--- a/src/fossil_core/application/ingest/reviewed_evidence.py
+++ b/src/fossil_core/application/ingest/reviewed_evidence.py
@@ -11,6 +11,7 @@ from ...source import SourceSnapshotStore
 
 REVIEWED_EVIDENCE_RECEIPT_VERSION = "fossil.reviewed-evidence-ingest-receipt.v1"
 _RAW_LOG_SOURCE_KINDS = frozenset({"raw_ci_log", "raw_build_log", "raw_runtime_log"})
+_SHARED_PACK_KINDS = frozenset({"common", "domain"})
 
 
 class ReviewedEvidenceIngestError(ValueError):
@@ -45,6 +46,15 @@ def _receipt_id(correlation_id: str, review_ref: str, pack_id: str) -> str:
     return f"ingest_receipt_{digest[:24]}"
 
 
+def _normalize_source_kind(source_kind: str) -> str:
+    normalized = source_kind.strip().lower()
+    if not normalized:
+        raise ReviewedEvidenceIngestError(
+            "reviewed evidence ingest requires a non-empty source_kind"
+        )
+    return normalized
+
+
 class ReviewedEvidenceIngestService:
     """Provenance-first reviewed evidence ingestion over existing durable contracts.
 
@@ -73,6 +83,7 @@ class ReviewedEvidenceIngestService:
         source_kind: str,
         review_ref: str,
         correlation_id: str,
+        requires_explicit_promotion: bool,
     ) -> dict[str, Any]:
         return {
             "schema_version": REVIEWED_EVIDENCE_RECEIPT_VERSION,
@@ -98,7 +109,7 @@ class ReviewedEvidenceIngestService:
             "proposal_event_ids": [],
             "proposal_count": 0,
             "accepted_count": 0,
-            "requires_explicit_promotion": True,
+            "requires_explicit_promotion": requires_explicit_promotion,
             "rejection_reason": None,
         }
 
@@ -132,14 +143,16 @@ class ReviewedEvidenceIngestService:
                 "reviewed evidence ingest emits proposals only"
             )
 
+        source_kind = _normalize_source_kind(source.source_kind)
         receipt = self._base_receipt(
             pack_id=pack_id,
-            source_kind=source.source_kind,
+            source_kind=source_kind,
             review_ref=review_ref,
             correlation_id=correlation_id,
+            requires_explicit_promotion=str(manifest.get("kind", "")) in _SHARED_PACK_KINDS,
         )
 
-        if source.source_kind in _RAW_LOG_SOURCE_KINDS:
+        if source_kind in _RAW_LOG_SOURCE_KINDS:
             receipt["status"] = "rejected"
             receipt["rejection_reason"] = "raw_ci_or_log_noise_not_wholesale_ingestable"
             receipt["validation"]["source"] = "rejected_by_ingest_policy"
@@ -159,7 +172,7 @@ class ReviewedEvidenceIngestService:
         artifact_id = str(snapshot["artifact_id"])
         snapshot_id = str(snapshot["snapshot_id"])
         receipt["source"] = {
-            "source_kind": source.source_kind,
+            "source_kind": source_kind,
             "preserved": True,
             "artifact_id": artifact_id,
             "snapshot_id": snapshot_id,

--- a/tests/test_reviewed_evidence_ingest.py
+++ b/tests/test_reviewed_evidence_ingest.py
@@ -144,8 +144,10 @@ def test_reviewed_ingest_preserves_source_first_and_emits_proposals_with_compact
         assert event["evidence_refs"] == [snapshot["artifact_id"]]
         assert event["source_snapshot_refs"] == [snapshot["snapshot_id"]]
         assert event["provenance"]["method"] == "reviewed_evidence_ingest"
-        assert event["provenance"]["review_ref"] == receipt["review_ref"]
-        assert event["provenance"]["source_snapshot_ref"] == snapshot["snapshot_id"]
+        assert event["provenance"]["benchmark_ref"] == receipt["review_ref"]
+        assert event["provenance"]["prompt_or_policy_ref"] == (
+            "skills/research-ingestion/manifest.json"
+        )
         assert "Primary research says" not in json.dumps(event["payload"])
 
     schema = json.loads(

--- a/tests/test_reviewed_evidence_ingest.py
+++ b/tests/test_reviewed_evidence_ingest.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from fossil_core.application.ingest.pack_validation import KnowledgePackValidator
+from fossil_core.application.ingest.reviewed_evidence import (
+    ReviewedClaimDraft,
+    ReviewedEvidenceIngestError,
+    ReviewedEvidenceIngestService,
+    ReviewedSource,
+)
+from fossil_core.artifact_store import ArtifactStore
+from fossil_core.event_store import DurableEventStore
+from fossil_core.source import SourceSnapshotStore
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACK = "pack_269099f7b2ba43b7a99b9427d64092de"
+
+
+def _manifest(*, kind: str = "common") -> dict:
+    return {
+        "contract_version": "dkg.pack.v1",
+        "pack_id": PACK,
+        "name": "reviewed ingest fixture",
+        "kind": kind,
+        "schema_version": "dkg.event.v1",
+        "dependencies": [],
+        "read_mounts": [PACK],
+        "write_targets": [PACK],
+        "event_roots": ["events/"],
+        "artifact_manifests": [],
+        "placement_hint": "unspecified",
+        "projection_namespace": "reviewed-ingest-fixture",
+    }
+
+
+def _service(tmp_path: Path) -> ReviewedEvidenceIngestService:
+    artifact_store = ArtifactStore(tmp_path / "artifacts")
+    source_store = SourceSnapshotStore(
+        tmp_path / "sources",
+        artifact_store,
+        ROOT / "schemas" / "source-snapshot" / "v1.schema.json",
+        ROOT / "schemas" / "citation" / "v1.schema.json",
+    )
+    event_store = DurableEventStore(
+        tmp_path / "events", ROOT / "schemas" / "events" / "v1.schema.json"
+    )
+    pack_validator = KnowledgePackValidator(
+        ROOT / "schemas" / "knowledge-pack" / "v1.schema.json"
+    )
+    return ReviewedEvidenceIngestService(
+        source_store=source_store,
+        event_store=event_store,
+        pack_validator=pack_validator,
+    )
+
+
+def _source(*, source_kind: str = "research") -> ReviewedSource:
+    return ReviewedSource(
+        data=b"Primary research says durable event replay remains authoritative.\n",
+        source_kind=source_kind,
+        source_role="primary",
+        locator={"identifier": "research-note-2026-08-19"},
+        retrieved_at="2026-08-19T19:40:00Z",
+        published_at="2026-08-19T19:35:00Z",
+        media_type="text/plain",
+        quality={
+            "authority": 0.8,
+            "directness": 1.0,
+            "independence": 0.7,
+            "reproducibility": 0.9,
+            "timeliness": 1.0,
+            "notes": "reviewed primary research fixture",
+        },
+    )
+
+
+def _draft(index: int = 1) -> ReviewedClaimDraft:
+    return ReviewedClaimDraft(
+        subject_ref=f"clm_reviewed_ingest_{index:06d}",
+        claim_text="Durable event replay remains the authority substrate.",
+        reason="Reviewed research synthesis; proposal only pending promotion/review.",
+    )
+
+
+def test_reviewed_ingest_preserves_source_first_and_emits_proposals_with_compact_receipt(
+    tmp_path: Path,
+):
+    service = _service(tmp_path)
+
+    receipt = service.ingest(
+        pack_manifest=_manifest(kind="common"),
+        source=_source(),
+        claims=[_draft(1), _draft(2)],
+        review_ref="review:architecture:2026-08-19",
+        actor={
+            "actor_type": "importer",
+            "actor_id": "reviewed-evidence-ingest",
+            "harness_version": "fixture-v1",
+            "skill_id": "skill_research-ingestion",
+            "skill_version": "1.1.0",
+        },
+        occurred_at="2026-08-19T19:41:00Z",
+        recorded_at="2026-08-19T19:41:01Z",
+        correlation_id="reviewed-ingest-fixture-1",
+    )
+
+    assert receipt["schema_version"] == "fossil.reviewed-evidence-ingest-receipt.v1"
+    assert receipt["status"] == "proposed"
+    assert receipt["authority"] == "non_authoritative_receipt"
+    assert receipt["pack_id"] == PACK
+    assert receipt["source"]["preserved"] is True
+    assert receipt["source"]["source_kind"] == "research"
+    assert receipt["source"]["artifact_id"].startswith("art_")
+    assert receipt["source"]["snapshot_id"].startswith("snap_")
+    assert receipt["validation"] == {
+        "pack": "passed",
+        "source": "passed",
+        "events": "passed",
+        "provenance": "passed",
+        "evidence": "passed",
+        "ontology": "not_applicable",
+    }
+    assert receipt["proposal_count"] == 2
+    assert receipt["accepted_count"] == 0
+    assert receipt["requires_explicit_promotion"] is True
+    assert receipt["review_ref"] == "review:architecture:2026-08-19"
+
+    snapshots = list(service.source_store.iter_snapshots())
+    assert len(snapshots) == 1
+    snapshot = snapshots[0]
+    assert service.source_store.artifact_store.read_bytes(snapshot["artifact_id"]) == _source().data
+
+    events = list(service.event_store.iter_events())
+    assert len(events) == 2
+    assert {event["event_type"] for event in events} == {"claim.proposed"}
+    assert {event["event_id"] for event in events} == set(receipt["proposal_event_ids"])
+    for event in events:
+        assert event["evidence_refs"] == [snapshot["artifact_id"]]
+        assert event["source_snapshot_refs"] == [snapshot["snapshot_id"]]
+        assert event["provenance"]["method"] == "reviewed_evidence_ingest"
+        assert event["provenance"]["review_ref"] == receipt["review_ref"]
+        assert event["provenance"]["source_snapshot_ref"] == snapshot["snapshot_id"]
+        assert "Primary research says" not in json.dumps(event["payload"])
+
+    schema = json.loads(
+        (ROOT / "schemas" / "reviewed-evidence-ingest" / "receipt-v1.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    Draft202012Validator(schema).validate(receipt)
+
+
+def test_raw_ci_and_build_log_noise_is_rejected_before_canonical_preservation(tmp_path: Path):
+    service = _service(tmp_path)
+
+    for source_kind in ("raw_ci_log", "raw_build_log", "raw_runtime_log"):
+        receipt = service.ingest(
+            pack_manifest=_manifest(),
+            source=_source(source_kind=source_kind),
+            claims=[_draft()],
+            review_ref="review:noise-filter",
+            actor={"actor_type": "importer", "actor_id": "noise-filter"},
+            occurred_at="2026-08-19T19:42:00Z",
+            recorded_at="2026-08-19T19:42:01Z",
+            correlation_id=f"noise:{source_kind}",
+        )
+        assert receipt["status"] == "rejected"
+        assert receipt["rejection_reason"] == "raw_ci_or_log_noise_not_wholesale_ingestable"
+        assert receipt["source"]["preserved"] is False
+        assert receipt["proposal_count"] == 0
+        assert receipt["accepted_count"] == 0
+
+    assert list(service.source_store.iter_snapshots()) == []
+    assert list(service.event_store.iter_events()) == []
+    assert list((tmp_path / "artifacts").rglob("*.json")) == []
+
+
+def test_reviewed_ingest_cannot_directly_accept_shared_or_architecture_knowledge(tmp_path: Path):
+    service = _service(tmp_path)
+
+    with pytest.raises(
+        ReviewedEvidenceIngestError,
+        match="accepted shared knowledge requires explicit review/promotion",
+    ):
+        service.ingest(
+            pack_manifest=_manifest(kind="common"),
+            source=_source(),
+            claims=[_draft()],
+            review_ref="review:architecture:accepted",
+            actor={"actor_type": "human", "actor_id": "reviewer"},
+            occurred_at="2026-08-19T19:43:00Z",
+            recorded_at="2026-08-19T19:43:01Z",
+            correlation_id="accepted-bypass",
+            requested_outcome="accepted",
+        )
+
+    assert list(service.source_store.iter_snapshots()) == []
+    assert list(service.event_store.iter_events()) == []
+
+
+def test_pack_validation_happens_before_source_or_event_mutation(tmp_path: Path):
+    service = _service(tmp_path)
+    invalid_manifest = _manifest()
+    invalid_manifest["read_mounts"] = []
+
+    with pytest.raises(Exception, match="read itself"):
+        service.ingest(
+            pack_manifest=invalid_manifest,
+            source=_source(),
+            claims=[_draft()],
+            review_ref="review:invalid-pack",
+            actor={"actor_type": "importer", "actor_id": "reviewed-evidence-ingest"},
+            occurred_at="2026-08-19T19:44:00Z",
+            recorded_at="2026-08-19T19:44:01Z",
+            correlation_id="invalid-pack",
+        )
+
+    assert list(service.source_store.iter_snapshots()) == []
+    assert list(service.event_store.iter_events()) == []
+
+
+def test_event_validation_occurs_before_any_proposal_commit_but_after_source_preservation(tmp_path: Path):
+    service = _service(tmp_path)
+    bad = ReviewedClaimDraft(
+        subject_ref="",
+        claim_text="This draft has no stable subject identity.",
+        reason="adversarial fixture",
+    )
+
+    with pytest.raises(ReviewedEvidenceIngestError, match="stable subject_ref"):
+        service.ingest(
+            pack_manifest=_manifest(),
+            source=_source(),
+            claims=[_draft(1), bad],
+            review_ref="review:bad-draft",
+            actor={"actor_type": "importer", "actor_id": "reviewed-evidence-ingest"},
+            occurred_at="2026-08-19T19:45:00Z",
+            recorded_at="2026-08-19T19:45:01Z",
+            correlation_id="bad-draft",
+        )
+
+    # Source-first durability is preserved, but the all-events validation pass
+    # prevents a partial proposal batch from being committed.
+    assert len(list(service.source_store.iter_snapshots())) == 1
+    assert list(service.event_store.iter_events()) == []

--- a/tests/test_reviewed_evidence_ingest_properties.py
+++ b/tests/test_reviewed_evidence_ingest_properties.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from hypothesis import HealthCheck, given, settings, strategies as st
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "reviewed_ingest_fixture_module",
+    ROOT / "tests" / "test_reviewed_evidence_ingest.py",
+)
+assert SPEC is not None and SPEC.loader is not None
+FIXTURE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(FIXTURE)
+
+
+@settings(
+    max_examples=8,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    source_kind=st.sampled_from(
+        [
+            "RAW_CI_LOG",
+            " raw_ci_log ",
+            "Raw_Build_Log",
+            " raw_runtime_log ",
+        ]
+    )
+)
+def test_raw_log_policy_cannot_be_bypassed_by_case_or_whitespace(
+    tmp_path: Path,
+    source_kind: str,
+):
+    service = FIXTURE._service(tmp_path)
+    receipt = service.ingest(
+        pack_manifest=FIXTURE._manifest(),
+        source=FIXTURE._source(source_kind=source_kind),
+        claims=[FIXTURE._draft()],
+        review_ref="review:noise-normalization",
+        actor={"actor_type": "importer", "actor_id": "noise-filter"},
+        occurred_at="2026-08-19T19:46:00Z",
+        recorded_at="2026-08-19T19:46:01Z",
+        correlation_id=f"noise:{source_kind.strip().lower()}",
+    )
+
+    assert receipt["status"] == "rejected"
+    assert receipt["source"]["preserved"] is False
+    assert list(service.source_store.iter_snapshots()) == []
+    assert list(service.event_store.iter_events()) == []
+
+
+def test_reviewed_ingest_retry_is_idempotent_for_source_proposals_and_receipt(tmp_path: Path):
+    service = FIXTURE._service(tmp_path)
+    kwargs = {
+        "pack_manifest": FIXTURE._manifest(),
+        "source": FIXTURE._source(),
+        "claims": [FIXTURE._draft()],
+        "review_ref": "review:idempotent-retry",
+        "actor": {"actor_type": "importer", "actor_id": "reviewed-evidence-ingest"},
+        "occurred_at": "2026-08-19T19:47:00Z",
+        "recorded_at": "2026-08-19T19:47:01Z",
+        "correlation_id": "reviewed-ingest-idempotent",
+    }
+
+    first = service.ingest(**kwargs)
+    second = service.ingest(**kwargs)
+
+    assert first == second
+    assert len(list(service.source_store.iter_snapshots())) == 1
+    assert len(list(service.event_store.iter_events())) == 1


### PR DESCRIPTION
Implements frozen #111 Step 5 as a provenance-first reviewed evidence ingestion application service.

What changed:
- adds `ReviewedEvidenceIngestService` under the existing application ingest boundary; no external GitHub Actions orchestration is introduced;
- validates the target pack before any source/event mutation and requires the pack to retain explicit write authority;
- normalizes source-kind policy labels and rejects raw CI/build/runtime-log noise before canonical preservation, including casing/whitespace bypass attempts;
- preserves allowed reviewed source bytes first through the existing immutable artifact + `SourceSnapshotStore` path;
- keeps preserved source evidence separate from derived synthesis: proposal payloads contain claim text/reason only, while `evidence_refs` and `source_snapshot_refs` pin the preserved source;
- constructs only `claim.proposed` events, validates the complete proposal batch through the real durable semantic gate before any event commit, then commits the validated batch;
- refuses `requested_outcome=accepted`; shared `common`/`domain` receipts explicitly signal that later cross-pack acceptance requires the separate reviewed promotion path;
- uses only existing closed `dkg.event.v1` provenance fields (`method`, `prompt_or_policy_ref`, `benchmark_ref`) rather than widening the event schema;
- emits `fossil.reviewed-evidence-ingest-receipt.v1`, an in-memory/non-authoritative compact receipt reporting source preservation, validation stages, proposal IDs/count, zero accepted writes, and rejection reason when applicable;
- retrying the same reviewed ingest is idempotent across source snapshot, proposal events, and receipt identity.

TDD / exact-head evidence:
- RED head `9aeee6e3c75e378b6954ebf421d3b50832e5053c` opened with missing reviewed-ingest application API;
- first GREEN attempt exposed the existing closed event-provenance schema; the implementation was corrected to reuse `benchmark_ref` + existing source/evidence reference fields rather than broadening `dkg.event.v1`;
- final exact head `3b0e6915ccf584404e720a834dd50ff15701e27c`: DKG contract tests `32295171918` PASS; dependency integrity `32295171945` PASS;
- deterministic/adversarial coverage proves source-first persistence, all-event validation before proposal commit, no direct accepted path, pack preflight before mutation, raw-log exclusion before canonical persistence, compact receipt schema, and source/synthesis separation;
- Hypothesis coverage proves raw-log policy cannot be bypassed by simple case/whitespace variation; retry coverage proves idempotency.

Frozen Step 5 laws are strengthened without changing durable identity, provider/storage/projection authority, event schemas, or promotion semantics.

Scope / non-goals:
- no GitHub Actions workflow implementation from #89;
- no provider/projection/database rewrite;
- no private holdout work;
- no production promotion or deployment.

Closes no issue automatically; #111 should be reconciled against the original backlog after this merge.