### PR TITLE
Add promotion mutation and Lean assurance

### DIFF
--- a/.github/workflows/lean-promotion.yml
+++ b/.github/workflows/lean-promotion.yml
@@ -1,0 +1,80 @@
+name: Promotion Lean assurance
+
+on:
+  pull_request:
+    paths:
+      - "lean-toolchain"
+      - "formal/lean/Fossil/Promotion.lean"
+      - "formal/lean/README.md"
+      - "contracts/properties/fossil-properties-v1.json"
+      - ".github/workflows/lean-promotion.yml"
+  push:
+    branches: [main]
+    paths:
+      - "lean-toolchain"
+      - "formal/lean/Fossil/Promotion.lean"
+      - "formal/lean/README.md"
+      - "contracts/properties/fossil-properties-v1.json"
+      - ".github/workflows/lean-promotion.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  promotion:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      FOSSIL_SOFTWARE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact target checkout
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "${FOSSIL_SOFTWARE_COMMIT}"
+      - name: Restore pinned Lean toolchain cache
+        id: lean-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.elan
+          key: lean-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}
+      - name: Install pinned elan and Lean toolchain on cache miss
+        if: steps.lean-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          curl --fail --silent --show-error --location \
+            https://raw.githubusercontent.com/leanprover/elan/464c9d28395000a2a0128e07081e4956d50eced2/elan-init.sh \
+            --output /tmp/elan-init.sh
+          sh /tmp/elan-init.sh -y --default-toolchain "$(cat lean-toolchain)"
+      - name: Add elan to PATH
+        shell: bash
+        run: echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: Verify Lean toolchain identity
+        shell: bash
+        run: |
+          lean --version | tee /tmp/lean-version.txt
+          grep -F "version 4.30.0" /tmp/lean-version.txt
+      - name: Reject incomplete theorem placeholders
+        shell: bash
+        run: |
+          if grep -En '\b(sorry|admit)\b' formal/lean/Fossil/Promotion.lean; then
+            echo "incomplete Lean proof placeholder detected" >&2
+            exit 1
+          fi
+      - name: Check Promotion semantic kernel
+        run: lean formal/lean/Fossil/Promotion.lean
+      - name: Emit compact Lean assurance receipt
+        shell: bash
+        run: |
+          {
+            echo "## Promotion Lean assurance receipt"
+            echo "- issue: #176"
+            echo "- property: FOSSIL-PROP-PROMOTION-001"
+            echo "- theorem_file: formal/lean/Fossil/Promotion.lean"
+            echo "- commit_sha: ${FOSSIL_SOFTWARE_COMMIT}"
+            echo "- toolchain: $(cat lean-toolchain)"
+            echo "- checks: version PASS; no sorry/admit; theorem compile PASS"
+            echo "- evidence_scope: exact source-pin, target authority, subject containment, source non-mutation semantic kernel; not proof of Python implementation"
+            echo "- security: secretless; contents:read"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mutation-promotion.yml
+++ b/.github/workflows/mutation-promotion.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Show surviving mutant diffs
         shell: bash
         run: |
-          awk -F': ' '/: (survived|no_tests)$/ {print $1}' \
+          awk -F': ' '/: (survived|no_tests)$/ {name=$1; gsub(/^[[:space:]]+|[[:space:]]+$/, "", name); print name}' \
             build/assurance/mutation-promotion-survivors.txt \
           | while IFS= read -r mutant; do
               echo "::group::${mutant}"

--- a/.github/workflows/mutation-promotion.yml
+++ b/.github/workflows/mutation-promotion.yml
@@ -66,6 +66,7 @@ jobs:
           pytest_add_cli_args_test_selection = [
             "tests/test_promotion.py",
             "tests/test_promotion_source_pin.py",
+            "tests/test_promotion_mutation_oracles.py",
           ]
           '''
           path.write_text(prefix + scoped, encoding="utf-8")
@@ -113,7 +114,7 @@ jobs:
             echo "- coordination: #94"
             echo "- property: FOSSIL-PROP-PROMOTION-001"
             echo "- mutable source: src/fossil_core/domain/promotion.py only"
-            echo "- tests: test_promotion.py + test_promotion_source_pin.py"
+            echo "- tests: test_promotion.py + test_promotion_source_pin.py + test_promotion_mutation_oracles.py"
             echo "- characterization only: floor intentionally non-enforcing until survivors are reviewed"
             echo "- security: secretless; contents:read"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mutation-promotion.yml
+++ b/.github/workflows/mutation-promotion.yml
@@ -1,0 +1,119 @@
+name: Promotion mutation assurance
+
+on:
+  pull_request:
+    paths:
+      - "src/fossil_core/domain/promotion.py"
+      - "tests/test_promotion.py"
+      - "tests/test_promotion_source_pin.py"
+      - "tests/test_promotion_mutation_oracles.py"
+      - "scripts/check_mutation_assurance.py"
+      - ".github/workflows/mutation-promotion.yml"
+      - "pyproject.toml"
+  push:
+    branches: [main]
+    paths:
+      - "src/fossil_core/domain/promotion.py"
+      - "tests/test_promotion.py"
+      - "tests/test_promotion_source_pin.py"
+      - "tests/test_promotion_mutation_oracles.py"
+      - "scripts/check_mutation_assurance.py"
+      - ".github/workflows/mutation-promotion.yml"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  promotion:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      FOSSIL_SOFTWARE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact target checkout
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "${FOSSIL_SOFTWARE_COMMIT}"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install mutation toolchain
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[test,mutation,s3]'
+          python -m pip check
+          mutmut --version
+      - name: Configure isolated promotion mutation scope
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          marker = "[tool.mutmut]\n"
+          if marker not in text:
+              raise SystemExit("missing [tool.mutmut] block")
+          prefix, _old = text.split(marker, 1)
+          scoped = '''[tool.mutmut]
+          source_paths = ["src/fossil_core"]
+          only_mutate = ["src/fossil_core/domain/promotion.py"]
+          also_copy = ["schemas", "examples", "skills"]
+          pytest_add_cli_args_test_selection = [
+            "tests/test_promotion.py",
+            "tests/test_promotion_source_pin.py",
+          ]
+          '''
+          path.write_text(prefix + scoped, encoding="utf-8")
+          PY
+      - name: Run promotion mutants
+        shell: bash
+        run: |
+          rm -rf mutants
+          mutmut run
+          mkdir -p build/assurance
+          mutmut results | tee build/assurance/mutation-promotion-survivors.txt
+          mutmut export-cicd-stats
+      - name: Show surviving mutant diffs
+        shell: bash
+        run: |
+          awk -F': ' '/: (survived|no_tests)$/ {print $1}' \
+            build/assurance/mutation-promotion-survivors.txt \
+          | while IFS= read -r mutant; do
+              echo "::group::${mutant}"
+              mutmut show "${mutant}"
+              echo "::endgroup::"
+            done
+      - name: Characterize promotion mutation strength
+        run: |
+          python scripts/check_mutation_assurance.py \
+            mutants/mutmut-cicd-stats.json \
+            --scope promotion \
+            --minimum-score 0 \
+            --maximum-survivors 999 \
+            --maximum-no-tests 999 \
+            --receipt build/assurance/mutation-promotion.json
+      - name: Emit characterization receipt
+        shell: bash
+        run: |
+          {
+            echo "## Promotion mutation characterization"
+            echo '```json'
+            cat build/assurance/mutation-promotion.json
+            echo '```'
+            echo "### Surviving mutants"
+            echo '```text'
+            cat build/assurance/mutation-promotion-survivors.txt
+            echo '```'
+            echo "- issue: #176"
+            echo "- coordination: #94"
+            echo "- property: FOSSIL-PROP-PROMOTION-001"
+            echo "- mutable source: src/fossil_core/domain/promotion.py only"
+            echo "- tests: test_promotion.py + test_promotion_source_pin.py"
+            echo "- characterization only: floor intentionally non-enforcing until survivors are reviewed"
+            echo "- security: secretless; contents:read"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mutation-promotion.yml
+++ b/.github/workflows/mutation-promotion.yml
@@ -89,20 +89,20 @@ jobs:
               mutmut show "${mutant}"
               echo "::endgroup::"
             done
-      - name: Characterize promotion mutation strength
+      - name: Enforce promotion mutation strength
         run: |
           python scripts/check_mutation_assurance.py \
             mutants/mutmut-cicd-stats.json \
             --scope promotion \
-            --minimum-score 0 \
-            --maximum-survivors 999 \
-            --maximum-no-tests 999 \
+            --minimum-score 79 \
+            --maximum-survivors 40 \
+            --maximum-no-tests 0 \
             --receipt build/assurance/mutation-promotion.json
-      - name: Emit characterization receipt
+      - name: Emit compact promotion mutation receipt
         shell: bash
         run: |
           {
-            echo "## Promotion mutation characterization"
+            echo "## Promotion mutation assurance"
             echo '```json'
             cat build/assurance/mutation-promotion.json
             echo '```'
@@ -115,6 +115,7 @@ jobs:
             echo "- property: FOSSIL-PROP-PROMOTION-001"
             echo "- mutable source: src/fossil_core/domain/promotion.py only"
             echo "- tests: test_promotion.py + test_promotion_source_pin.py + test_promotion_mutation_oracles.py"
-            echo "- characterization only: floor intentionally non-enforcing until survivors are reviewed"
+            echo "- enforced floor: score >=79%; survivors <=40; no_tests = 0"
+            echo "- reviewed residuals: exception-message/default-value equivalents behind the validated promotion envelope"
             echo "- security: secretless; contents:read"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/contracts/properties/fossil-properties-v1.json
+++ b/contracts/properties/fossil-properties-v1.json
@@ -131,19 +131,19 @@
     },
     {
       "property_id": "FOSSIL-PROP-PROMOTION-001",
-      "statement": "Cross-pack promotion is explicit, requires different source and target packs, and records a new target-pack event rather than silently mutating the source pack.",
+      "statement": "Cross-pack promotion is explicit, requires different source and target packs, pins the exact source pack revision and source event in a new target-pack event, preserves promoted subjects from that source event, and never mutates the source event.",
       "criticality": "high",
       "semantic_owner": "domain promotion",
       "modules": ["src/fossil_core/domain/promotion.py"],
-      "deterministic_oracles": ["tests/test_promotion.py", "tests/test_agent_boundary.py"],
+      "deterministic_oracles": ["tests/test_promotion.py", "tests/test_promotion_source_pin.py", "tests/test_promotion_mutation_oracles.py", "tests/test_agent_boundary.py"],
       "property_oracles": [],
       "mutation_scope": ["src/fossil_core/domain/promotion.py"],
       "tla_refs": [],
-      "lean_refs": ["formal/lean/Fossil/Promotion.lean"],
+      "lean_refs": ["formal/lean/Fossil/Promotion.lean::promote_does_not_mutate_source", "formal/lean/Fossil/Promotion.lean::promote_pins_source_exactly", "formal/lean/Fossil/Promotion.lean::promote_targets_requested_pack", "formal/lean/Fossil/Promotion.lean::validPromotion_requires_different_packs", "formal/lean/Fossil/Promotion.lean::validPromotion_pins_source_exactly", "formal/lean/Fossil/Promotion.lean::validPromotion_subjects_come_from_source"],
       "hidden_acceptance_required": false,
       "status": "active",
       "source_refs": ["ARCHITECTURE.md"],
-      "notes": "Final source-revision/event pinning law is intentionally deferred to #111 before Lean proof work."
+      "notes": "Lean 4.30.0 checks the named source-pin, target-authority, subject-containment, and source-nonmutation theorems with no sorry/admit placeholders. The isolated promotion mutation lane enforces the measured 79% / <=40 survivor / zero-no-test boundary; reviewed residual survivors are exception-message or default-value equivalents behind the validated event envelope. Lean evidence does not prove the Python implementation."
     },
     {
       "property_id": "FOSSIL-PROP-PROVENANCE-001",

--- a/formal/lean/Fossil/Promotion.lean
+++ b/formal/lean/Fossil/Promotion.lean
@@ -1,0 +1,94 @@
+namespace Fossil.Promotion
+
+structure SourcePin where
+  packId : String
+  revision : String
+  eventId : String
+deriving DecidableEq, Repr
+
+structure SourceEvent where
+  pin : SourcePin
+  subjects : String → Prop
+
+structure PromotionEvent where
+  targetPackId : String
+  sourcePin : SourcePin
+  subjects : String → Prop
+
+structure PromotionResult where
+  source : SourceEvent
+  target : PromotionEvent
+
+
+def SubjectsSubset (left right : String → Prop) : Prop :=
+  ∀ subject, left subject → right subject
+
+
+def promote
+    (source : SourceEvent)
+    (targetPackId : String)
+    (subjects : String → Prop) : PromotionResult :=
+  {
+    source := source
+    target := {
+      targetPackId := targetPackId
+      sourcePin := source.pin
+      subjects := subjects
+    }
+  }
+
+
+def ValidPromotion (source : SourceEvent) (target : PromotionEvent) : Prop :=
+  source.pin.packId ≠ target.targetPackId ∧
+    target.sourcePin = source.pin ∧
+    SubjectsSubset target.subjects source.subjects
+
+
+theorem promote_does_not_mutate_source
+    (source : SourceEvent)
+    (targetPackId : String)
+    (subjects : String → Prop) :
+    (promote source targetPackId subjects).source = source := by
+  rfl
+
+
+theorem promote_pins_source_exactly
+    (source : SourceEvent)
+    (targetPackId : String)
+    (subjects : String → Prop) :
+    (promote source targetPackId subjects).target.sourcePin = source.pin := by
+  rfl
+
+
+theorem promote_targets_requested_pack
+    (source : SourceEvent)
+    (targetPackId : String)
+    (subjects : String → Prop) :
+    (promote source targetPackId subjects).target.targetPackId = targetPackId := by
+  rfl
+
+
+theorem validPromotion_requires_different_packs
+    (source : SourceEvent)
+    (target : PromotionEvent)
+    (h : ValidPromotion source target) :
+    source.pin.packId ≠ target.targetPackId := by
+  exact h.1
+
+
+theorem validPromotion_pins_source_exactly
+    (source : SourceEvent)
+    (target : PromotionEvent)
+    (h : ValidPromotion source target) :
+    target.sourcePin = source.pin := by
+  exact h.2.1
+
+
+theorem validPromotion_subjects_come_from_source
+    (source : SourceEvent)
+    (target : PromotionEvent)
+    (h : ValidPromotion source target) :
+    SubjectsSubset target.subjects source.subjects := by
+  exact h.2.2
+
+end Fossil.Promotion

--- a/formal/lean/README.md
+++ b/formal/lean/README.md
@@ -43,6 +43,25 @@ Current theorem surface:
 
 The theorem file intentionally does not define manifests, dependency resolution, pack locks, retrieval ranking, provider APIs, promotion semantics, or Python enforcement mechanics. Python conformance remains established by pack, authorization, and property tests.
 
+## Promotion
+
+`Fossil/Promotion.lean` formalizes the source-pinned cross-pack promotion kernel frozen and implemented by #111 and exercised by `src/fossil_core/domain/promotion.py`.
+
+Property traceability:
+
+- `FOSSIL-PROP-PROMOTION-001`
+
+Current theorem surface:
+
+- constructing a target promotion leaves the modeled source event unchanged;
+- the target promotion copies the exact source pack/revision/event pin;
+- the durable target identity remains the explicitly requested target pack;
+- a valid promotion requires distinct source and target packs;
+- a valid promotion pins exactly the modeled source event;
+- promoted subjects remain a subset of the pinned source event's subjects.
+
+The theorem file is a provider-free semantic kernel. Python/schema tests remain responsible for string/non-empty validation, resolver behavior, durable event-envelope conformance, and storage/authorization integration.
+
 ## Checking
 
 From the repository root with the pinned Lean toolchain active:
@@ -50,6 +69,7 @@ From the repository root with the pinned Lean toolchain active:
 ```sh
 lean formal/lean/Fossil/Lifecycle.lean
 lean formal/lean/Fossil/PackAccess.lean
+lean formal/lean/Fossil/Promotion.lean
 ```
 
 The spec-triggered CI lanes perform the corresponding checks on the exact pull-request head and reject `sorry`/`admit` placeholders in the bounded theorem files.

--- a/src/fossil_core/domain/promotion.py
+++ b/src/fossil_core/domain/promotion.py
@@ -12,6 +12,15 @@ class PromotionSourceError(ValueError):
     """The exact source meaning for a promotion cannot be resolved safely."""
 
 
+def _required_source_pin(payload: Mapping[str, Any], field: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise PromotionSourceError(
+            f"promotion requires a non-empty string {field} source pin"
+        )
+    return value
+
+
 def build_promotion_event(
     *,
     source_pack_id: str,
@@ -81,9 +90,9 @@ def validate_promotion_source(
     if not isinstance(payload, Mapping):
         raise PromotionSourceError("promotion payload must be an object")
 
-    source_pack_id = str(payload.get("source_pack_id", ""))
-    source_revision = str(payload.get("source_pack_revision", ""))
-    source_event_id = str(payload.get("source_event_id", ""))
+    source_pack_id = _required_source_pin(payload, "source_pack_id")
+    source_revision = _required_source_pin(payload, "source_pack_revision")
+    source_event_id = _required_source_pin(payload, "source_event_id")
     target_pack_id = str(payload.get("target_pack_id", ""))
     durable_pack_id = str(event.get("pack_id", ""))
 

--- a/tests/test_promotion_mutation_oracles.py
+++ b/tests/test_promotion_mutation_oracles.py
@@ -15,6 +15,7 @@ TARGET_PACK = "pack_target_0123456789abcdef"
 SOURCE_REVISION = "rev_source_0123456789abcdef"
 SOURCE_EVENT = "evt_source_0123456789abcdef"
 SUBJECT = "clm_subject_0123456789abcdef"
+ACTOR = {"actor_type": "human", "actor_id": "reviewer"}
 
 
 def _promotion_event() -> dict:
@@ -24,7 +25,7 @@ def _promotion_event() -> dict:
         source_event_id=SOURCE_EVENT,
         target_pack_id=TARGET_PACK,
         subject_refs=[SUBJECT],
-        actor_id="reviewer",
+        actor=ACTOR,
         occurred_at="2026-08-19T20:00:00Z",
         recorded_at="2026-08-19T20:00:01Z",
         idempotency_key="promotion-mutation-oracle",
@@ -64,7 +65,7 @@ def test_builder_rejects_whitespace_only_exact_source_pins(field: str, value: st
         "source_event_id": SOURCE_EVENT,
         "target_pack_id": TARGET_PACK,
         "subject_refs": [SUBJECT],
-        "actor_id": "reviewer",
+        "actor": ACTOR,
         "occurred_at": "2026-08-19T20:00:00Z",
         "recorded_at": "2026-08-19T20:00:01Z",
         "idempotency_key": "promotion-whitespace-pin",

--- a/tests/test_promotion_mutation_oracles.py
+++ b/tests/test_promotion_mutation_oracles.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from fossil_core.domain.promotion import (
+    PromotionSourceError,
+    build_promotion_event,
+    validate_promotion_source,
+)
+
+SOURCE_PACK = "pack_source_0123456789abcdef"
+TARGET_PACK = "pack_target_0123456789abcdef"
+SOURCE_REVISION = "rev_source_0123456789abcdef"
+SOURCE_EVENT = "evt_source_0123456789abcdef"
+SUBJECT = "clm_subject_0123456789abcdef"
+
+
+def _promotion_event() -> dict:
+    return build_promotion_event(
+        source_pack_id=SOURCE_PACK,
+        source_pack_revision=SOURCE_REVISION,
+        source_event_id=SOURCE_EVENT,
+        target_pack_id=TARGET_PACK,
+        subject_refs=[SUBJECT],
+        actor_id="reviewer",
+        occurred_at="2026-08-19T20:00:00Z",
+        recorded_at="2026-08-19T20:00:01Z",
+        idempotency_key="promotion-mutation-oracle",
+    )
+
+
+def _permissive_resolver(pack_id: str, revision: str, event_id: str) -> dict:
+    return {
+        "pack_id": pack_id,
+        "event_id": event_id,
+        "subject_refs": [SUBJECT],
+        "revision": revision,
+    }
+
+
+def test_builder_default_reason_and_exact_source_pins_are_observable() -> None:
+    event = _promotion_event()
+
+    assert event["payload"]["reason"] == ""
+    assert event["payload"]["source_pack_id"] == SOURCE_PACK
+    assert event["payload"]["source_pack_revision"] == SOURCE_REVISION
+    assert event["payload"]["source_event_id"] == SOURCE_EVENT
+    assert event["payload"]["target_pack_id"] == TARGET_PACK
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("source_pack_revision", "   "),
+        ("source_event_id", "\t\n"),
+    ],
+)
+def test_builder_rejects_whitespace_only_exact_source_pins(field: str, value: str) -> None:
+    kwargs = {
+        "source_pack_id": SOURCE_PACK,
+        "source_pack_revision": SOURCE_REVISION,
+        "source_event_id": SOURCE_EVENT,
+        "target_pack_id": TARGET_PACK,
+        "subject_refs": [SUBJECT],
+        "actor_id": "reviewer",
+        "occurred_at": "2026-08-19T20:00:00Z",
+        "recorded_at": "2026-08-19T20:00:01Z",
+        "idempotency_key": "promotion-whitespace-pin",
+    }
+    kwargs[field] = value
+
+    with pytest.raises(ValueError):
+        build_promotion_event(**kwargs)
+
+
+@pytest.mark.parametrize("field", ["source_pack_id", "source_pack_revision", "source_event_id"])
+@pytest.mark.parametrize("mode", ["missing", "empty", "whitespace"])
+def test_validator_rejects_absent_or_blank_source_pins_before_permissive_resolution(
+    field: str,
+    mode: str,
+) -> None:
+    event = _promotion_event()
+    if mode == "missing":
+        event["payload"].pop(field)
+    elif mode == "empty":
+        event["payload"][field] = ""
+    else:
+        event["payload"][field] = "   "
+
+    with pytest.raises(PromotionSourceError):
+        validate_promotion_source(event, resolver=_permissive_resolver)
+
+
+@pytest.mark.parametrize(
+    "bad_subject_refs",
+    [SUBJECT, (SUBJECT,), {SUBJECT: True}],
+)
+def test_validator_rejects_non_list_promoted_subject_refs(bad_subject_refs: object) -> None:
+    event = _promotion_event()
+    event["subject_refs"] = bad_subject_refs
+
+    with pytest.raises(PromotionSourceError):
+        validate_promotion_source(event, resolver=_permissive_resolver)
+
+
+def test_validator_does_not_mutate_promotion_or_resolved_source() -> None:
+    event = _promotion_event()
+    source = _permissive_resolver(SOURCE_PACK, SOURCE_REVISION, SOURCE_EVENT)
+    event_before = copy.deepcopy(event)
+    source_before = copy.deepcopy(source)
+
+    resolved = validate_promotion_source(event, resolver=lambda *_args: source)
+
+    assert resolved is source
+    assert event == event_before
+    assert source == source_before


### PR DESCRIPTION
Continues #176 now that #111 has completed and frozen the final source-pinned promotion law. This slice adds executable mutation assurance plus a bounded Lean conformance kernel around that already-landed law; it does not redesign promotion.

What changed:
- adds an isolated `Promotion mutation assurance` lane over `src/fossil_core/domain/promotion.py` using the existing promotion/source-pin tests plus focused mutation oracles;
- mutation characterization started at 195 mutants / 143 killed / 52 survived = 73.33%; survivor review identified a real fail-closed gap in direct source validation rather than raising a threshold blindly;
- adds RED oracles proving a permissive resolver must not make missing/empty/whitespace `source_pack_id`, `source_pack_revision`, or `source_event_id` acceptable;
- minimally hardens `validate_promotion_source()` so all three exact source pins must be non-empty strings before resolver invocation; builder/runtime/public surface otherwise remains unchanged;
- post-hardening mutation result is 195 tested / 155 killed / 40 survived = 79.49%, zero no-test/skipped/suspicious/timeout/segfault; all 40 residual diffs were reviewed as exception-message or default-value equivalents behind the validated promotion envelope;
- enforces the measured promotion gate at score >=79%, survivors <=40, no_tests = 0 instead of retaining the temporary characterization floor;
- adds `formal/lean/Fossil/Promotion.lean` with named theorems for source non-mutation, exact source pin copying, requested target identity, distinct source/target packs, and promoted-subject containment;
- adds an exact-head, secretless Lean 4.30.0 workflow that rejects `sorry`/`admit` placeholders;
- replaces the stale deferred `FOSSIL-PROP-PROMOTION-001` catalog entry with concrete deterministic-oracle and named Lean theorem anchors. The existing property-catalog test therefore fails closed on missing theorem symbols/paths.

TDD / assurance evidence:
- characterization head `cfba2fac519a404ce8025d40cceb0516141f5961`: promotion mutation 73.33% with 52 survivors;
- RED head `8ef309a9830f05b799e816bccf91d3039feb9b61`: DKG run #737 failed with 9 promotion-source-pin cases, all showing absent/blank source pins could reach a permissive resolver;
- first GREEN/post-hardening head `498a52025c94ceba9120f41cfbbd7e0cde1c25f8`: DKG #739 PASS, dependency integrity #190 PASS, mutation characterization 79.49% / 40 / 0;
- final exact head `1bf543e01e28df16d3bd4f9811543e96589656bc`: DKG `32298618752` PASS; dependency integrity `32298618738` PASS; Promotion mutation `32298618744` PASS at enforced 79.49% / 40 / 0; Promotion Lean `32298618743` PASS; PackAccess Lean `32298618794` PASS; Lifecycle Lean `32298618714` PASS; DurableStore TLA+ `32298618790` PASS; ProjectionLifecycle TLA+ `32298618755` PASS; Engineering assurance `32298618716` PASS.

Semantic/review fences:
- base `main` remains exactly `b5fd57725c910b149910371964adb35d9280016e`, the branch base; no base drift;
- property-catalog diff changes only `FOSSIL-PROP-PROMOTION-001`;
- runtime semantic change is limited to fail-closing malformed source pins before resolution;
- no PR reviews, review threads, or comments are outstanding.

Explicitly excluded: sealed/private holdout placement or cases, production promotion/deployment, provider/storage/projection rewrites, or weakening any existing assurance threshold. Lean remains semantic-kernel evidence and is not represented as proof of the Python implementation.

Closes no issue automatically; after merge #176 should retain only separately authorized private/sealed holdout execution or other explicitly outstanding assurance work.