### PR TITLE
[ARCH-P4] Extract ThinMCPAdapter behind MCP adapter package

### DIFF
--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -34,6 +34,7 @@ CANONICAL_MODULES = {
     "fossil_core.domain.provenance",
     "fossil_core.ports",
     "fossil_core.ports.artifact_store",
+    "fossil_core.ports.capability",
     "fossil_core.ports.cognitive_service",
     "fossil_core.ports.context_provider",
     "fossil_core.ports.embedding_provider",
@@ -51,6 +52,7 @@ CANONICAL_MODULES = {
     "fossil_core.adapters.litellm",
     "fossil_core.adapters.litellm.embedding",
     "fossil_core.adapters.litellm.reranker",
+    "fossil_core.adapters.mcp",
     "fossil_core.adapters.s3",
     "fossil_core.adapters.s3.storage",
     "fossil_core.adapters.vector",
@@ -107,6 +109,7 @@ ADAPTER_SELF_SHIMS = {
         "fossil_core.artifact_store",
         "fossil_core.event_store",
     },
+    "fossil_core.adapters.mcp": {"fossil_core.agent"},
     "fossil_core.adapters.s3": {"fossil_core.s3_storage"},
 }
 

--- a/src/fossil_core/adapters/mcp/__init__.py
+++ b/src/fossil_core/adapters/mcp/__init__.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from fossil_core.ports.capability import CapabilityError
+
+
+__all__ = ["ThinMCPAdapter"]
+
+
+class ThinMCPAdapter:
+    """MCP-shaped dictionary adapter over :class:`CorpusService`.
+
+    No MCP SDK types appear in the domain service. Replacing this adapter does not
+    change durable schemas or corpus semantics.
+    """
+
+    TOOL_NAMES = (
+        "fossil.search",
+        "fossil.read",
+        "fossil.lineage",
+        "fossil.propose",
+        "fossil.validate",
+        "fossil.commit",
+        "fossil.manage",
+    )
+
+    def __init__(
+        self,
+        *,
+        service: CorpusService,
+        access: PackAccess,
+        context: AgentContext,
+    ):
+        self.service = service
+        self.access = access
+        self.context = context
+
+    def list_tools(self) -> list[str]:
+        return list(self.TOOL_NAMES)
+
+    def invoke(self, tool_name: str, arguments: Mapping[str, Any]) -> Any:
+        args = dict(arguments)
+        if tool_name == "fossil.search":
+            return self.service.search(
+                str(args["query"]),
+                access=self.access,
+                context=self.context,
+                limit=int(args.get("limit", 20)),
+            )
+        if tool_name == "fossil.read":
+            return self.service.read(
+                str(args["event_id"]), access=self.access, context=self.context
+            )
+        if tool_name == "fossil.lineage":
+            return self.service.lineage(
+                str(args["conversation_id"]),
+                access=self.access,
+                context=self.context,
+                node_id=args.get("node_id"),
+            )
+        if tool_name == "fossil.propose":
+            return self.service.propose(
+                event_type=str(args["event_type"]),
+                pack_id=str(args["pack_id"]),
+                subject_refs=list(args["subject_refs"]),
+                payload=dict(args["payload"]),
+                occurred_at=str(args["occurred_at"]),
+                recorded_at=str(args["recorded_at"]),
+                idempotency_key=str(args["idempotency_key"]),
+                evidence_refs=list(args.get("evidence_refs", [])),
+                source_snapshot_refs=list(args.get("source_snapshot_refs", [])),
+                caused_by_event_ids=list(args.get("caused_by_event_ids", [])),
+                correlation_id=args.get("correlation_id"),
+                provenance=dict(args.get("provenance", {})),
+                access=self.access,
+                context=self.context,
+            )
+        if tool_name == "fossil.validate":
+            return self.service.validate(
+                dict(args["event"]), access=self.access, context=self.context
+            )
+        if tool_name == "fossil.commit":
+            return self.service.commit(
+                dict(args["event"]), access=self.access, context=self.context
+            )
+        if tool_name == "fossil.manage":
+            return self.service.manage(str(args["action"]), context=self.context)
+        raise CapabilityError(
+            f"tool {tool_name!r} is not in the FOSSIL agent capability surface"
+        )

--- a/src/fossil_core/agent.py
+++ b/src/fossil_core/agent.py
@@ -8,13 +8,11 @@ from typing import Any, Mapping
 
 from jsonschema import Draft202012Validator, FormatChecker
 
+from fossil_core.adapters.mcp import ThinMCPAdapter
 from fossil_core.event_store import DurableEventStore
 from fossil_core.pack import PackAccess, PackBoundaryError
+from fossil_core.ports.capability import CapabilityError
 from fossil_core.promotion import build_promotion_event
-
-
-class CapabilityError(PermissionError):
-    pass
 
 
 class AgentProvenanceError(ValueError):
@@ -425,86 +423,3 @@ class CorpusService:
                 "event_store_root": str(self.event_store.root),
             }
         raise CapabilityError(f"unsupported management action: {action}")
-
-
-class ThinMCPAdapter:
-    """MCP-shaped dictionary adapter over :class:`CorpusService`.
-
-    No MCP SDK types appear in the domain service. Replacing this adapter does not
-    change durable schemas or corpus semantics.
-    """
-
-    TOOL_NAMES = (
-        "fossil.search",
-        "fossil.read",
-        "fossil.lineage",
-        "fossil.propose",
-        "fossil.validate",
-        "fossil.commit",
-        "fossil.manage",
-    )
-
-    def __init__(
-        self,
-        *,
-        service: CorpusService,
-        access: PackAccess,
-        context: AgentContext,
-    ):
-        self.service = service
-        self.access = access
-        self.context = context
-
-    def list_tools(self) -> list[str]:
-        return list(self.TOOL_NAMES)
-
-    def invoke(self, tool_name: str, arguments: Mapping[str, Any]) -> Any:
-        args = dict(arguments)
-        if tool_name == "fossil.search":
-            return self.service.search(
-                str(args["query"]),
-                access=self.access,
-                context=self.context,
-                limit=int(args.get("limit", 20)),
-            )
-        if tool_name == "fossil.read":
-            return self.service.read(
-                str(args["event_id"]), access=self.access, context=self.context
-            )
-        if tool_name == "fossil.lineage":
-            return self.service.lineage(
-                str(args["conversation_id"]),
-                access=self.access,
-                context=self.context,
-                node_id=args.get("node_id"),
-            )
-        if tool_name == "fossil.propose":
-            return self.service.propose(
-                event_type=str(args["event_type"]),
-                pack_id=str(args["pack_id"]),
-                subject_refs=list(args["subject_refs"]),
-                payload=dict(args["payload"]),
-                occurred_at=str(args["occurred_at"]),
-                recorded_at=str(args["recorded_at"]),
-                idempotency_key=str(args["idempotency_key"]),
-                evidence_refs=list(args.get("evidence_refs", [])),
-                source_snapshot_refs=list(args.get("source_snapshot_refs", [])),
-                caused_by_event_ids=list(args.get("caused_by_event_ids", [])),
-                correlation_id=args.get("correlation_id"),
-                provenance=dict(args.get("provenance", {})),
-                access=self.access,
-                context=self.context,
-            )
-        if tool_name == "fossil.validate":
-            return self.service.validate(
-                dict(args["event"]), access=self.access, context=self.context
-            )
-        if tool_name == "fossil.commit":
-            return self.service.commit(
-                dict(args["event"]), access=self.access, context=self.context
-            )
-        if tool_name == "fossil.manage":
-            return self.service.manage(str(args["action"]), context=self.context)
-        raise CapabilityError(
-            f"tool {tool_name!r} is not in the FOSSIL agent capability surface"
-        )

--- a/src/fossil_core/ports/capability.py
+++ b/src/fossil_core/ports/capability.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+class CapabilityError(PermissionError):
+    pass

--- a/tests/test_mcp_adapter_boundary.py
+++ b/tests/test_mcp_adapter_boundary.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+import fossil_core.adapters.mcp as canonical_mcp
+import fossil_core.agent as legacy_agent
+from fossil_core.ports.capability import CapabilityError
+
+
+EXPECTED_TOOLS = (
+    "fossil.search",
+    "fossil.read",
+    "fossil.lineage",
+    "fossil.propose",
+    "fossil.validate",
+    "fossil.commit",
+    "fossil.manage",
+)
+
+
+def test_thin_mcp_adapter_legacy_identity_and_allowlist_are_frozen():
+    assert canonical_mcp.__all__ == ["ThinMCPAdapter"]
+    assert legacy_agent.ThinMCPAdapter is canonical_mcp.ThinMCPAdapter
+    assert legacy_agent.CapabilityError is CapabilityError
+    assert canonical_mcp.ThinMCPAdapter.__module__ == "fossil_core.adapters.mcp"
+    assert canonical_mcp.ThinMCPAdapter.TOOL_NAMES == EXPECTED_TOOLS
+
+    adapter = canonical_mcp.ThinMCPAdapter(
+        service=object(), access=object(), context=object()
+    )
+    assert adapter.list_tools() == list(EXPECTED_TOOLS)
+
+
+def test_thin_mcp_adapter_call_shapes_are_unchanged():
+    init_parameters = list(
+        inspect.signature(canonical_mcp.ThinMCPAdapter.__init__).parameters.values()
+    )
+    assert [parameter.name for parameter in init_parameters] == [
+        "self",
+        "service",
+        "access",
+        "context",
+    ]
+    assert init_parameters[0].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert all(
+        parameter.kind is inspect.Parameter.KEYWORD_ONLY
+        for parameter in init_parameters[1:]
+    )
+    assert all(
+        parameter.default is inspect.Parameter.empty for parameter in init_parameters
+    )
+
+    invoke_parameters = list(
+        inspect.signature(canonical_mcp.ThinMCPAdapter.invoke).parameters.values()
+    )
+    assert [parameter.name for parameter in invoke_parameters] == [
+        "self",
+        "tool_name",
+        "arguments",
+    ]
+    assert all(
+        parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+        for parameter in invoke_parameters
+    )
+    assert all(
+        parameter.default is inspect.Parameter.empty for parameter in invoke_parameters
+    )
+
+
+def test_thin_mcp_adapter_rejects_graph_escape_with_same_error_type():
+    adapter = canonical_mcp.ThinMCPAdapter(
+        service=object(), access=object(), context=object()
+    )
+
+    with pytest.raises(
+        CapabilityError, match="not in the FOSSIL agent capability surface"
+    ):
+        adapter.invoke("neo4j.cypher", {"query": "MATCH (n) DETACH DELETE n"})
+
+    with pytest.raises(
+        CapabilityError, match="not in the FOSSIL agent capability surface"
+    ):
+        adapter.invoke("graphiti.add_episode", {"content": "bypass durable event"})


### PR DESCRIPTION
## Scope

Bounded Phase-4 modularization slice for #82, coordinated through #94.

- Extract only `ThinMCPAdapter` from the mixed `fossil_core.agent` module into `fossil_core.adapters.mcp`.
- Preserve `from fossil_core.agent import ThinMCPAdapter` with object identity intact.
- Freeze the constructor/invoke call shapes, exact `TOOL_NAMES` allowlist, dispatch behavior, and graph-escape rejection.
- Move only the shared `CapabilityError` to a provider-neutral capability module so the adapter does not import `fossil_core.agent` and create a first-party import cycle; `fossil_core.agent.CapabilityError` remains an identity-preserving import.
- Register the MCP adapter and capability type in the mechanical architecture inventory and explicitly reject a future MCP-adapter -> legacy-agent dependency.

## Gate precondition

The prior #82 post-merge verification blocker on `8808b4d25b9b06d8302bd41935c471c3f8d6a484` is now satisfied with authoritative `push`-event exact-main receipts supplied from local `gh`:

- DKG contract tests `32078574335` — SUCCESS
- Dependency integrity `32078574419` — SUCCESS
- Engineering assurance `32078574179` — SUCCESS
- Security risk gate `32078574503` — SUCCESS
- Cross-repo contracts `32078574210` — SUCCESS

## Non-goals / invariants

No `CorpusService`, `AgentContext`, or `SkillRegistry` movement. No retrieval/ranking/context/model behavior, routing, storage/projection/event/schema/stable-ID/hash semantics, executor behavior, LiteLLM/Cortex runtime authority, production action, or acceptance weakening.

## Verification

Focused compatibility tests freeze canonical/legacy object identity, call shapes, exact tool allowlist, and graph-escape rejection. Existing agent-boundary tests continue to exercise the legacy import path against real service behavior. Exact-head DKG and Dependency Integrity are required before merge consideration.