### PR TITLE
FOSSIL-NODE-01: add persistent projector runtime

### DIFF
--- a/src/fossil_core/runtime/__init__.py
+++ b/src/fossil_core/runtime/__init__.py
@@ -1,0 +1,18 @@
+"""Persistent FOSSIL node composition and projector runtime."""
+
+from .node import (
+    FilesystemFossilNode,
+    FilesystemNodeConfig,
+    FilesystemNodePaths,
+    compose_filesystem_node,
+)
+from .projector import ProjectorCycle, ProjectorWorker
+
+__all__ = [
+    "FilesystemFossilNode",
+    "FilesystemNodeConfig",
+    "FilesystemNodePaths",
+    "ProjectorCycle",
+    "ProjectorWorker",
+    "compose_filesystem_node",
+]

--- a/src/fossil_core/runtime/node.py
+++ b/src/fossil_core/runtime/node.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -109,6 +110,16 @@ def _schema(repository_root: Path, *parts: str) -> Path:
     return repository_root / "schemas" / Path(*parts)
 
 
+def _graphiti_from_environment() -> tuple[Any, Any]:
+    from graphiti_core import Graphiti
+    from graphiti_core.nodes import EpisodeType
+
+    uri = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+    user = os.environ.get("NEO4J_USER", "neo4j")
+    password = os.environ["NEO4J_PASSWORD"]
+    return Graphiti(uri, user, password), EpisodeType.json
+
+
 def compose_filesystem_node(
     config: FilesystemNodeConfig,
     *,
@@ -118,7 +129,7 @@ def compose_filesystem_node(
 ) -> FilesystemFossilNode:
     """Compose one filesystem-backed FOSSIL node around existing contracts.
 
-    With no injected Graphiti client, the projection adapter is constructed from
+    With no injected Graphiti client, the projection client is constructed from
     the existing Neo4j environment contract. Tests may inject a client without
     importing the optional Graphiti dependency.
     """
@@ -162,30 +173,24 @@ def compose_filesystem_node(
             raise ValueError(
                 "episode_type_json is only valid when graphiti_client is injected"
             )
-        projection = GraphitiProjectionAdapter.from_environment(
-            ledger_root=paths.projection_ledger_root,
-            build_manifest=dict(config.projection_build_manifest),
-            visibility_policy=visibility_policy,
-            build_id=config.projection_build_id,
-        )
-    else:
-        if episode_type_json is None:
-            raise ValueError(
-                "episode_type_json is required when graphiti_client is injected"
-            )
-        ledger = ProjectionLedger(
-            paths.projection_ledger_root,
-            GraphitiProjectionAdapter.name,
-            build_id=config.projection_build_id,
-        )
-        projection = GraphitiProjectionAdapter(
-            client=graphiti_client,
-            ledger=ledger,
-            build_manifest=dict(config.projection_build_manifest),
-            episode_type_json=episode_type_json,
-            visibility_policy=visibility_policy,
+        graphiti_client, episode_type_json = _graphiti_from_environment()
+    elif episode_type_json is None:
+        raise ValueError(
+            "episode_type_json is required when graphiti_client is injected"
         )
 
+    ledger = ProjectionLedger(
+        paths.projection_ledger_root,
+        GraphitiProjectionAdapter.name,
+        build_id=config.projection_build_id,
+    )
+    projection = GraphitiProjectionAdapter(
+        client=graphiti_client,
+        ledger=ledger,
+        build_manifest=dict(config.projection_build_manifest),
+        episode_type_json=episode_type_json,
+        visibility_policy=visibility_policy,
+    )
     projector = ProjectorWorker(
         event_store=event_store,
         projection=projection,

--- a/src/fossil_core/runtime/node.py
+++ b/src/fossil_core/runtime/node.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from fossil_core.adapters.filesystem.artifact_store import ArtifactStore
+from fossil_core.adapters.filesystem.event_store import DurableEventStore
+from fossil_core.agent import CorpusService, SkillRegistry
+from fossil_core.application.ingest.pack_validation import KnowledgePackValidator
+from fossil_core.application.ingest.reviewed_evidence import ReviewedEvidenceIngestService
+from fossil_core.domain.pack import PackAccess
+from fossil_core.projection.graphiti import GraphitiProjectionAdapter
+from fossil_core.projection.ledger import ProjectionLedger
+from fossil_core.source import SourceSnapshotStore
+
+from .projector import ProjectorWorker
+
+
+_BUILD_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+@dataclass(frozen=True)
+class FilesystemNodePaths:
+    """Separate canonical truth from rebuildable operational state."""
+
+    data_root: Path
+
+    @property
+    def canonical_root(self) -> Path:
+        return self.data_root / "canonical"
+
+    @property
+    def artifacts_root(self) -> Path:
+        return self.canonical_root / "artifacts"
+
+    @property
+    def sources_root(self) -> Path:
+        return self.canonical_root / "sources"
+
+    @property
+    def events_root(self) -> Path:
+        return self.canonical_root / "events"
+
+    @property
+    def operational_root(self) -> Path:
+        return self.data_root / "operational"
+
+    @property
+    def projection_ledger_root(self) -> Path:
+        return self.operational_root / "projection-ledger"
+
+
+@dataclass(frozen=True)
+class FilesystemNodeConfig:
+    repository_root: Path
+    data_root: Path
+    pack_manifest_path: Path
+    projection_build_id: str
+    projection_build_manifest: Mapping[str, Any]
+    poll_interval_seconds: float = 1.0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "repository_root", Path(self.repository_root))
+        object.__setattr__(self, "data_root", Path(self.data_root))
+        object.__setattr__(self, "pack_manifest_path", Path(self.pack_manifest_path))
+        object.__setattr__(
+            self, "projection_build_manifest", dict(self.projection_build_manifest)
+        )
+        if not _BUILD_ID.fullmatch(self.projection_build_id):
+            raise ValueError(
+                "projection_build_id must be a non-empty path-safe identifier"
+            )
+        if self.poll_interval_seconds <= 0:
+            raise ValueError("poll_interval_seconds must be positive")
+
+    @property
+    def paths(self) -> FilesystemNodePaths:
+        return FilesystemNodePaths(self.data_root)
+
+
+@dataclass(frozen=True)
+class FilesystemFossilNode:
+    """Concrete NODE-01 composition without introducing a second authority."""
+
+    config: FilesystemNodeConfig
+    paths: FilesystemNodePaths
+    pack_manifest: dict[str, Any]
+    pack_access: PackAccess
+    artifact_store: ArtifactStore
+    source_store: SourceSnapshotStore
+    event_store: DurableEventStore
+    corpus_service: CorpusService
+    reviewed_ingest: ReviewedEvidenceIngestService
+    projection: GraphitiProjectionAdapter
+    projector: ProjectorWorker
+
+    async def run_projector_async(self, stop_event: asyncio.Event) -> None:
+        await self.projection.initialize_async()
+        try:
+            await self.projector.run_forever(stop_event)
+        finally:
+            await self.projection.close_async()
+
+
+def _schema(repository_root: Path, *parts: str) -> Path:
+    return repository_root / "schemas" / Path(*parts)
+
+
+def compose_filesystem_node(
+    config: FilesystemNodeConfig,
+    *,
+    graphiti_client: Any | None = None,
+    episode_type_json: Any | None = None,
+    visibility_policy: Any | None = None,
+) -> FilesystemFossilNode:
+    """Compose one filesystem-backed FOSSIL node around existing contracts.
+
+    With no injected Graphiti client, the projection adapter is constructed from
+    the existing Neo4j environment contract. Tests may inject a client without
+    importing the optional Graphiti dependency.
+    """
+
+    repository_root = config.repository_root
+    paths = config.paths
+
+    pack_validator = KnowledgePackValidator(
+        _schema(repository_root, "knowledge-pack", "v1.schema.json")
+    )
+    pack_manifest_path = config.pack_manifest_path
+    if not pack_manifest_path.is_absolute():
+        pack_manifest_path = repository_root / pack_manifest_path
+    pack_manifest = pack_validator.load_and_validate(pack_manifest_path)
+    pack_access = PackAccess.from_manifest(pack_manifest)
+
+    artifact_store = ArtifactStore(paths.artifacts_root)
+    source_store = SourceSnapshotStore(
+        paths.sources_root,
+        artifact_store,
+        _schema(repository_root, "source-snapshot", "v1.schema.json"),
+        _schema(repository_root, "citation", "v1.schema.json"),
+    )
+    event_store = DurableEventStore(
+        paths.events_root,
+        _schema(repository_root, "events", "v1.schema.json"),
+    )
+    skills = SkillRegistry(
+        repository_root / "skills",
+        _schema(repository_root, "agent-skill", "v1.schema.json"),
+    )
+    corpus_service = CorpusService(event_store=event_store, skills=skills)
+    reviewed_ingest = ReviewedEvidenceIngestService(
+        source_store=source_store,
+        event_store=event_store,
+        pack_validator=pack_validator,
+    )
+
+    if graphiti_client is None:
+        if episode_type_json is not None:
+            raise ValueError(
+                "episode_type_json is only valid when graphiti_client is injected"
+            )
+        projection = GraphitiProjectionAdapter.from_environment(
+            ledger_root=paths.projection_ledger_root,
+            build_manifest=dict(config.projection_build_manifest),
+            visibility_policy=visibility_policy,
+            build_id=config.projection_build_id,
+        )
+    else:
+        if episode_type_json is None:
+            raise ValueError(
+                "episode_type_json is required when graphiti_client is injected"
+            )
+        ledger = ProjectionLedger(
+            paths.projection_ledger_root,
+            GraphitiProjectionAdapter.name,
+            build_id=config.projection_build_id,
+        )
+        projection = GraphitiProjectionAdapter(
+            client=graphiti_client,
+            ledger=ledger,
+            build_manifest=dict(config.projection_build_manifest),
+            episode_type_json=episode_type_json,
+            visibility_policy=visibility_policy,
+        )
+
+    projector = ProjectorWorker(
+        event_store=event_store,
+        projection=projection,
+        ledger=projection.ledger,
+        poll_interval_seconds=config.poll_interval_seconds,
+    )
+
+    return FilesystemFossilNode(
+        config=config,
+        paths=paths,
+        pack_manifest=pack_manifest,
+        pack_access=pack_access,
+        artifact_store=artifact_store,
+        source_store=source_store,
+        event_store=event_store,
+        corpus_service=corpus_service,
+        reviewed_ingest=reviewed_ingest,
+        projection=projection,
+        projector=projector,
+    )
+
+
+__all__ = [
+    "FilesystemFossilNode",
+    "FilesystemNodeConfig",
+    "FilesystemNodePaths",
+    "compose_filesystem_node",
+]

--- a/src/fossil_core/runtime/projector.py
+++ b/src/fossil_core/runtime/projector.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+from fossil_core.ports.projection import ProjectionReceipt
+from fossil_core.projection.migration import ordered_events
+
+
+@dataclass(frozen=True)
+class ProjectorCycle:
+    """Machine-testable summary of one deterministic projector scan."""
+
+    scanned: int
+    receipts: tuple[ProjectionReceipt, ...]
+
+    @property
+    def applied(self) -> int:
+        return sum(receipt.status == "applied" for receipt in self.receipts)
+
+    @property
+    def skipped(self) -> int:
+        return sum(receipt.status == "skipped" for receipt in self.receipts)
+
+    @property
+    def redacted(self) -> int:
+        return sum(receipt.status == "redacted" for receipt in self.receipts)
+
+    @property
+    def failed(self) -> int:
+        return sum(receipt.status == "failed" for receipt in self.receipts)
+
+
+class ProjectorWorker:
+    """Continuously materialize accepted durable events into one projection build.
+
+    Durable event acceptance is upstream of this worker. A projection failure is
+    therefore recorded and retried; it never rolls back or rewrites canonical
+    truth. Events are scanned in corpus commit order. If one pending event fails,
+    the current cycle stops before later events so lifecycle materialization cannot
+    silently advance past an earlier failed event.
+    """
+
+    def __init__(
+        self,
+        *,
+        event_store: Any,
+        projection: Any,
+        ledger: Any,
+        poll_interval_seconds: float = 1.0,
+    ) -> None:
+        if poll_interval_seconds <= 0:
+            raise ValueError("projector poll_interval_seconds must be positive")
+        self.event_store = event_store
+        self.projection = projection
+        self.ledger = ledger
+        self.poll_interval_seconds = float(poll_interval_seconds)
+
+    def _skip_receipt(self, event_id: str, detail: str) -> ProjectionReceipt:
+        return ProjectionReceipt(
+            self.projection.name,
+            self.projection.version,
+            event_id,
+            "skipped",
+            detail,
+        )
+
+    async def run_once_async(self) -> ProjectorCycle:
+        receipts: list[ProjectionReceipt] = []
+
+        purge_event_redactions = getattr(
+            self.projection, "purge_event_redactions_async", None
+        )
+        if callable(purge_event_redactions):
+            purge_receipts = await purge_event_redactions(event_store=self.event_store)
+            receipts.extend(purge_receipts)
+            if any(receipt.status == "failed" for receipt in purge_receipts):
+                return ProjectorCycle(scanned=0, receipts=tuple(receipts))
+
+        events = ordered_events(self.event_store.iter_events())
+        scanned = 0
+        for event in events:
+            scanned += 1
+            event_id = str(event["event_id"])
+
+            if self.ledger.is_redacted(event_id):
+                receipts.append(self._skip_receipt(event_id, "projection redacted"))
+                continue
+            if self.ledger.is_applied(event_id):
+                receipts.append(self._skip_receipt(event_id, "already applied"))
+                continue
+
+            receipt = await self.projection.apply_event_async(event)
+            receipts.append(receipt)
+            if receipt.status == "failed":
+                break
+
+        return ProjectorCycle(scanned=scanned, receipts=tuple(receipts))
+
+    async def run_forever(self, stop_event: asyncio.Event) -> None:
+        """Run restartably until requested to stop.
+
+        Waiting is interruptible by ``stop_event`` so shutdown does not need to
+        wait for the polling interval to expire. Any event not durably marked as
+        applied remains eligible for the next cycle or process restart.
+        """
+
+        while not stop_event.is_set():
+            await self.run_once_async()
+            if stop_event.is_set():
+                break
+            try:
+                await asyncio.wait_for(
+                    stop_event.wait(), timeout=self.poll_interval_seconds
+                )
+            except TimeoutError:
+                continue
+
+
+__all__ = ["ProjectorCycle", "ProjectorWorker"]

--- a/tests/test_fossil_node_runtime.py
+++ b/tests/test_fossil_node_runtime.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from fossil_core.agent import AgentContext
+from fossil_core.runtime import FilesystemNodeConfig, compose_filesystem_node
+
+
+COMMON = "pack_269099f7b2ba43b7a99b9427d64092de"
+
+
+def root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+class FakeGraphiti:
+    def __init__(self) -> None:
+        self.attempts: list[str] = []
+        self.calls: list[str] = []
+        self.fail_on: set[str] = set()
+        self.initialized = 0
+        self.closed = 0
+
+    async def build_indices_and_constraints(self) -> None:
+        self.initialized += 1
+
+    async def add_episode(self, **kwargs):
+        event_id = str(json.loads(kwargs["episode_body"])["event_id"])
+        self.attempts.append(event_id)
+        if event_id in self.fail_on:
+            raise RuntimeError("temporary graph failure")
+        self.calls.append(event_id)
+        return SimpleNamespace(
+            episode=SimpleNamespace(uuid=f"episode-{event_id}")
+        )
+
+    async def remove_episode(self, episode_uuid: str) -> None:
+        return None
+
+    async def close(self) -> None:
+        self.closed += 1
+
+
+def config(tmp_path: Path, *, build_id: str = "build-a", poll: float = 0.01):
+    return FilesystemNodeConfig(
+        repository_root=root(),
+        data_root=tmp_path / "node-data",
+        pack_manifest_path=root() / "examples" / "packs" / "common" / "manifest.json",
+        projection_build_id=build_id,
+        projection_build_manifest={
+            "graphiti_version": "0.29.3",
+            "neo4j_version": "test",
+            "model_id": "test-model",
+            "ontology_version": "1.0.0",
+            "software_commit": "test",
+        },
+        poll_interval_seconds=poll,
+    )
+
+
+def compose(tmp_path: Path, client: FakeGraphiti, *, build_id: str = "build-a", poll: float = 0.01):
+    return compose_filesystem_node(
+        config(tmp_path, build_id=build_id, poll=poll),
+        graphiti_client=client,
+        episode_type_json="json",
+    )
+
+
+def agent_context() -> AgentContext:
+    return AgentContext(
+        actor_id="runtime-fixture",
+        model_id="fixture-model-v1",
+        harness_version="fixture-harness-v1",
+        skill_id="skill_research-ingestion",
+        skill_version="1.1.0",
+    )
+
+
+def commit_claim(
+    node,
+    *,
+    key: str,
+    subject: str,
+    occurred_at: str,
+    recorded_at: str,
+):
+    ctx = agent_context()
+    proposal = node.corpus_service.propose(
+        event_type="claim.proposed",
+        pack_id=COMMON,
+        subject_refs=[subject],
+        payload={"claim_text": f"runtime claim {key}"},
+        occurred_at=occurred_at,
+        recorded_at=recorded_at,
+        idempotency_key=key,
+        access=node.pack_access,
+        context=ctx,
+    )
+    return node.corpus_service.commit(
+        proposal,
+        access=node.pack_access,
+        context=ctx,
+    )
+
+
+def test_node_composition_uses_one_canonical_writer_and_separates_operational_state(tmp_path):
+    node = compose(tmp_path, FakeGraphiti())
+
+    assert node.pack_access.pack_id == COMMON
+    assert node.corpus_service.event_store is node.event_store
+    assert node.reviewed_ingest.event_store is node.event_store
+    assert node.reviewed_ingest.source_store is node.source_store
+    assert node.projector.event_store is node.event_store
+    assert node.projector.ledger is node.projection.ledger
+
+    assert node.paths.artifacts_root == tmp_path / "node-data" / "canonical" / "artifacts"
+    assert node.paths.sources_root == tmp_path / "node-data" / "canonical" / "sources"
+    assert node.paths.events_root == tmp_path / "node-data" / "canonical" / "events"
+    assert node.paths.projection_ledger_root == (
+        tmp_path / "node-data" / "operational" / "projection-ledger"
+    )
+
+
+def test_projection_failure_does_not_rollback_durable_commit_and_restart_catches_up(tmp_path):
+    client = FakeGraphiti()
+    first = compose(tmp_path, client)
+    event = commit_claim(
+        first,
+        key="runtime-restart-v1",
+        subject="clm_runtime_restart_fixture",
+        occurred_at="2026-08-20T03:30:00Z",
+        recorded_at="2026-08-20T03:30:00Z",
+    )
+
+    client.fail_on.add(event["event_id"])
+    failed_cycle = asyncio.run(first.projector.run_once_async())
+    assert failed_cycle.failed == 1
+    assert first.event_store.get(event["event_id"]) == event
+    assert not first.projection.ledger.is_applied(event["event_id"])
+
+    client.fail_on.clear()
+    restarted = compose(tmp_path, client)
+    catchup_cycle = asyncio.run(restarted.projector.run_once_async())
+    assert catchup_cycle.applied == 1
+    assert restarted.projection.ledger.is_applied(event["event_id"])
+    assert client.calls == [event["event_id"]]
+
+    restarted_again = compose(tmp_path, client)
+    idempotent_cycle = asyncio.run(restarted_again.projector.run_once_async())
+    assert idempotent_cycle.skipped == 1
+    assert client.calls == [event["event_id"]]
+
+
+def test_projector_preserves_commit_order_and_stops_cycle_at_first_failure(tmp_path):
+    client = FakeGraphiti()
+    node = compose(tmp_path, client)
+
+    later = commit_claim(
+        node,
+        key="runtime-order-later-v1",
+        subject="clm_runtime_order_later",
+        occurred_at="2026-08-20T03:32:00Z",
+        recorded_at="2026-08-20T03:32:00Z",
+    )
+    earlier = commit_claim(
+        node,
+        key="runtime-order-earlier-v1",
+        subject="clm_runtime_order_earlier",
+        occurred_at="2026-08-20T03:31:00Z",
+        recorded_at="2026-08-20T03:31:00Z",
+    )
+
+    client.fail_on.add(earlier["event_id"])
+    first_cycle = asyncio.run(node.projector.run_once_async())
+    assert first_cycle.failed == 1
+    assert client.attempts == [earlier["event_id"]]
+    assert not node.projection.ledger.is_applied(later["event_id"])
+
+    client.fail_on.clear()
+    second_cycle = asyncio.run(node.projector.run_once_async())
+    assert second_cycle.applied == 2
+    assert client.attempts == [
+        earlier["event_id"],
+        earlier["event_id"],
+        later["event_id"],
+    ]
+
+
+def test_fresh_projection_build_id_replays_without_stale_applied_markers(tmp_path):
+    first_client = FakeGraphiti()
+    first = compose(tmp_path, first_client, build_id="build-a")
+    event = commit_claim(
+        first,
+        key="runtime-rebuild-v1",
+        subject="clm_runtime_rebuild_fixture",
+        occurred_at="2026-08-20T03:33:00Z",
+        recorded_at="2026-08-20T03:33:00Z",
+    )
+    assert asyncio.run(first.projector.run_once_async()).applied == 1
+    assert first_client.calls == [event["event_id"]]
+
+    rebuilt_client = FakeGraphiti()
+    rebuilt = compose(tmp_path, rebuilt_client, build_id="build-b")
+    rebuild_cycle = asyncio.run(rebuilt.projector.run_once_async())
+
+    assert rebuild_cycle.applied == 1
+    assert rebuilt_client.calls == [event["event_id"]]
+    assert first.projection.ledger.root != rebuilt.projection.ledger.root
+    assert rebuilt.projection.ledger.is_applied(event["event_id"])
+
+
+def test_projector_shutdown_is_bounded_by_stop_event_not_poll_interval(tmp_path):
+    node = compose(tmp_path, FakeGraphiti(), poll=60.0)
+
+    async def scenario() -> None:
+        stop = asyncio.Event()
+        task = asyncio.create_task(node.projector.run_forever(stop))
+        await asyncio.sleep(0)
+        stop.set()
+        await asyncio.wait_for(task, timeout=0.2)
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Implements Phase-1 NODE-01 of #231.

Scope:
- filesystem-backed FOSSIL node composition;
- one canonical event-store writer boundary shared by CorpusService and reviewed ingestion;
- deterministic long-running projector in canonical commit order;
- ledger-driven idempotent skip/retry behavior;
- fail-stop cycle ordering when a pending projection fails;
- durable commit remains authoritative through projection outage;
- fresh projection build IDs for destructive rebuild;
- bounded stop-event shutdown.

Out of scope:
- MCP/HTTP transport;
- Podman/Quadlet packaging;
- Tailscale deployment;
- live LOCAL_INFRA PC proof.

TDD / hosted evidence:
- RED: `9ac5453795857dc78448f3a138eb6ff6f8b55f57`, DKG run `32328083349` — expected `ModuleNotFoundError: fossil_core.runtime` before implementation;
- GREEN head: `2e9bea969f810d3facae1e9448bfc80648f9ad88`;
- DKG run `32328182071` — SUCCESS, 698 passed / 1 skipped;
- Dependency Integrity run `32328182082` — SUCCESS, including architecture-boundary verification;
- reviews: 0;
- review threads: 0.

Task: FOSSIL-NODE-01
Issue: #231
Ledger: #94
Starting main: `1882aadcda7d9ea544e7d8c7a597ace6d9772f00`