### PR TITLE
FOSSIL-NODE-01: prove projector against live Graphiti

### DIFF
--- a/.github/workflows/graphiti-live.yml
+++ b/.github/workflows/graphiti-live.yml
@@ -10,6 +10,7 @@ on:
       - "scripts/live_redaction_smoke.py"
       - "src/fossil_core/event_store.py"
       - "src/fossil_core/projection/**"
+      - "src/fossil_core/runtime/**"
       - "schemas/events/**"
       - "pyproject.toml"
   pull_request:
@@ -19,6 +20,7 @@ on:
       - "scripts/live_redaction_smoke.py"
       - "src/fossil_core/event_store.py"
       - "src/fossil_core/projection/**"
+      - "src/fossil_core/runtime/**"
       - "schemas/events/**"
       - "pyproject.toml"
 

--- a/scripts/live_graphiti_smoke.py
+++ b/scripts/live_graphiti_smoke.py
@@ -20,6 +20,7 @@ from neo4j import AsyncGraphDatabase
 from fossil_core.event_store import DurableEventStore
 from fossil_core.projection.graphiti import GraphitiProjectionAdapter
 from fossil_core.projection.ledger import ProjectionLedger
+from fossil_core.runtime import ProjectorWorker
 
 
 PACK_ID = "pack_269099f7b2ba43b7a99b9427d64092de"
@@ -278,15 +279,35 @@ async def main() -> None:
             ledger=ProjectionLedger(
                 root / "projection-ledger",
                 GraphitiProjectionAdapter.name,
+                build_id="node-01-live-smoke-v1",
             ),
             build_manifest=build_manifest,
             episode_type_json=EpisodeType.json,
+        )
+        projector = ProjectorWorker(
+            event_store=event_store,
+            projection=projection,
+            ledger=projection.ledger,
+            poll_interval_seconds=1.0,
         )
 
         await projection.initialize_async()
         proof["status"] = "graphiti_initialized"
 
-        first = await projection.apply_event_async(accepted_event)
+        first_cycle = await projector.run_once_async()
+        proof["first_projector_cycle"] = {
+            "scanned": first_cycle.scanned,
+            "applied": first_cycle.applied,
+            "skipped": first_cycle.skipped,
+            "failed": first_cycle.failed,
+        }
+        if first_cycle.applied != 1 or first_cycle.failed != 0:
+            raise AssertionError(
+                f"first projector cycle did not apply exactly one event: {first_cycle}"
+            )
+        first = next(
+            receipt for receipt in first_cycle.receipts if receipt.event_id == event_id
+        )
         proof["first_receipt"] = {
             "status": first.status,
             "detail": first.detail,
@@ -316,14 +337,23 @@ async def main() -> None:
                 "Graphiti materialized the episode but extracted no mentioned entities"
             )
 
-        second = await projection.apply_event_async(accepted_event)
+        second_cycle = await projector.run_once_async()
+        proof["second_projector_cycle"] = {
+            "scanned": second_cycle.scanned,
+            "applied": second_cycle.applied,
+            "skipped": second_cycle.skipped,
+            "failed": second_cycle.failed,
+        }
+        second = next(
+            receipt for receipt in second_cycle.receipts if receipt.event_id == event_id
+        )
         proof["second_receipt"] = {
             "status": second.status,
             "detail": second.detail,
         }
-        if second.status != "skipped":
+        if second.status != "skipped" or second_cycle.skipped != 1:
             raise AssertionError(
-                f"replay should be skipped by projection ledger: {second}"
+                f"replay should be skipped by projection ledger: {second_cycle}"
             )
 
         after_retry = await observe_projection(


### PR DESCRIPTION
Final hosted acceptance for Phase-1 NODE-01 of #231.

This PR adds no new runtime/domain semantics. It makes the existing real Neo4j/Graphiti smoke exercise the merged `ProjectorWorker` and ensures future `src/fossil_core/runtime/**` changes trigger the live workflow.

Exact head: `4c9498ed679b8a5d1dbb966155a8ee11e7444e87`

Hosted acceptance:
- DKG run `32328635886` — SUCCESS.
- Graphiti live run `32328635897` — SUCCESS.
- exact-target checkout guard — PASS.
- durable event existed and was readable before projection — PASS.
- first projector cycle: scanned=1, applied=1, skipped=0, failed=0.
- real Neo4j after first projection: episode_count=1, mentioned_entity_count=5, fact_edge_count=4.
- projection ledger: projection=`graphiti-neo4j`, build_id=`node-01-live-smoke-v1`, pack/group namespace preserved.
- second projector cycle: scanned=1, applied=0, skipped=1, failed=0 (`already applied`).
- after idempotent retry: episode_count remained exactly 1 with the same episode UUID.
- live redaction/non-resurrection regression — PASS; active purge leaves 0 episodes/entities/facts, fresh rebuild remains empty, same event identity republication blocked.
- proof artifact ID `9392379286`, archive SHA256 `2d4289374b264121d84dc5f8b3ade582d77f6406d6c334d6478b21251c2f001b`.
- reviews: 0; review threads: 0.

This closes the remaining real/test Neo4j acceptance gap for FOSSIL-NODE-01 after #232.

Task: FOSSIL-NODE-01
Issue: #231
Ledger: #94
Base main: `191331db3def54e4c4a7a8f1ce3b15ac832728dd`