### PR TITLE
FOSSIL-NODE-02: add MCP and HTTP network boundary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,17 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest>=8,<9", "hypothesis>=6,<7"]
+test = [
+  "pytest>=8,<9",
+  "hypothesis>=6,<7",
+  "mcp==2.0.0",
+  "httpx>=0.28,<1",
+]
 mutation = ["mutmut @ git+https://github.com/boxed/mutmut.git@dc58270d5234752e22247f814431750eafcf6e5f"]
 graphiti = ["graphiti-core==0.29.3", "httpx>=0.27,<1"]
 semantic = ["sentence-transformers==5.2.2"]
 s3 = ["boto3>=1.40,<2"]
+node = ["mcp==2.0.0"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/fossil_core/adapters/mcp/server.py
+++ b/src/fossil_core/adapters/mcp/server.py
@@ -103,24 +103,26 @@ def build_mcp_server(adapter: ThinMCPAdapter) -> MCPServer:
     ) -> dict[str, Any]:
         """Prepare a pack-authorized durable knowledge proposal."""
 
-        return _invoke(
-            adapter,
-            "fossil.propose",
-            {
-                "event_type": event_type,
-                "pack_id": pack_id,
-                "subject_refs": subject_refs,
-                "payload": payload,
-                "occurred_at": occurred_at,
-                "recorded_at": recorded_at,
-                "idempotency_key": idempotency_key,
-                "evidence_refs": evidence_refs,
-                "source_snapshot_refs": source_snapshot_refs,
-                "caused_by_event_ids": caused_by_event_ids,
-                "correlation_id": correlation_id,
-                "provenance": provenance,
-            },
+        arguments: dict[str, Any] = {
+            "event_type": event_type,
+            "pack_id": pack_id,
+            "subject_refs": subject_refs,
+            "payload": payload,
+            "occurred_at": occurred_at,
+            "recorded_at": recorded_at,
+            "idempotency_key": idempotency_key,
+        }
+        optional_arguments = {
+            "evidence_refs": evidence_refs,
+            "source_snapshot_refs": source_snapshot_refs,
+            "caused_by_event_ids": caused_by_event_ids,
+            "correlation_id": correlation_id,
+            "provenance": provenance,
+        }
+        arguments.update(
+            {key: value for key, value in optional_arguments.items() if value is not None}
         )
+        return _invoke(adapter, "fossil.propose", arguments)
 
     @server.tool(name="fossil.validate")
     def fossil_validate(event: dict[str, Any]) -> dict[str, Any]:

--- a/src/fossil_core/adapters/mcp/server.py
+++ b/src/fossil_core/adapters/mcp/server.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server import MCPServer
+
+from fossil_core.domain.pack import PackBoundaryError
+from fossil_core.ports.capability import CapabilityError
+
+from . import ThinMCPAdapter
+
+
+class FossilMCPToolError(RuntimeError):
+    """Stable agent-visible MCP failure without exposing internal exceptions."""
+
+    def __init__(self, code: str, detail: str):
+        self.code = code
+        self.detail = detail
+        super().__init__(f"{code}: {detail}")
+
+
+def _mapped_error(exc: Exception) -> FossilMCPToolError:
+    if isinstance(exc, PackBoundaryError):
+        return FossilMCPToolError("unauthorized_pack", str(exc))
+    if isinstance(exc, CapabilityError):
+        return FossilMCPToolError("capability_denied", str(exc))
+    if isinstance(exc, FileNotFoundError):
+        return FossilMCPToolError("not_found", str(exc))
+    if isinstance(exc, KeyError):
+        detail = str(exc.args[0]) if exc.args else "resource not found"
+        return FossilMCPToolError("not_found", detail)
+    if isinstance(exc, (TypeError, ValueError)):
+        return FossilMCPToolError("invalid_request", str(exc))
+    if isinstance(exc, OSError):
+        return FossilMCPToolError("canonical_store_unavailable", str(exc))
+    return FossilMCPToolError("internal_error", "FOSSIL tool execution failed")
+
+
+def _invoke(adapter: ThinMCPAdapter, tool_name: str, arguments: dict[str, Any]) -> Any:
+    try:
+        return adapter.invoke(tool_name, arguments)
+    except FossilMCPToolError:
+        raise
+    except Exception as exc:
+        raise _mapped_error(exc) from exc
+
+
+def build_mcp_server(adapter: ThinMCPAdapter) -> MCPServer:
+    """Expose the frozen ThinMCPAdapter capability surface as a real MCP server.
+
+    The transport layer deliberately does not know Graphiti or Neo4j mutation APIs.
+    Every tool delegates to ``ThinMCPAdapter.invoke`` so pack authorization,
+    provenance checks, durable validation, and the canonical seven-tool allowlist
+    remain the single source of truth.
+    """
+
+    server = MCPServer(
+        name="fossil-core",
+        version="0.1.0",
+        instructions=(
+            "FOSSIL durable corpus tools. Durable events are canonical; graph "
+            "projections are rebuildable and cannot be mutated through this surface."
+        ),
+    )
+
+    @server.tool(name="fossil.search")
+    def fossil_search(query: str, limit: int = 20) -> list[dict[str, Any]]:
+        """Search readable FOSSIL packs through the canonical corpus service."""
+
+        return _invoke(adapter, "fossil.search", {"query": query, "limit": limit})
+
+    @server.tool(name="fossil.read")
+    def fossil_read(event_id: str) -> dict[str, Any]:
+        """Read one durable event when its pack is mounted for the caller."""
+
+        return _invoke(adapter, "fossil.read", {"event_id": event_id})
+
+    @server.tool(name="fossil.lineage")
+    def fossil_lineage(
+        conversation_id: str, node_id: str | None = None
+    ) -> dict[str, Any]:
+        """Read conversation lineage through the pack-authorized corpus boundary."""
+
+        arguments: dict[str, Any] = {"conversation_id": conversation_id}
+        if node_id is not None:
+            arguments["node_id"] = node_id
+        return _invoke(adapter, "fossil.lineage", arguments)
+
+    @server.tool(name="fossil.propose")
+    def fossil_propose(
+        event_type: str,
+        pack_id: str,
+        subject_refs: list[str],
+        payload: dict[str, Any],
+        occurred_at: str,
+        recorded_at: str,
+        idempotency_key: str,
+        evidence_refs: list[str] | None = None,
+        source_snapshot_refs: list[str] | None = None,
+        caused_by_event_ids: list[str] | None = None,
+        correlation_id: str | None = None,
+        provenance: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Prepare a pack-authorized durable knowledge proposal."""
+
+        return _invoke(
+            adapter,
+            "fossil.propose",
+            {
+                "event_type": event_type,
+                "pack_id": pack_id,
+                "subject_refs": subject_refs,
+                "payload": payload,
+                "occurred_at": occurred_at,
+                "recorded_at": recorded_at,
+                "idempotency_key": idempotency_key,
+                "evidence_refs": evidence_refs,
+                "source_snapshot_refs": source_snapshot_refs,
+                "caused_by_event_ids": caused_by_event_ids,
+                "correlation_id": correlation_id,
+                "provenance": provenance,
+            },
+        )
+
+    @server.tool(name="fossil.validate")
+    def fossil_validate(event: dict[str, Any]) -> dict[str, Any]:
+        """Validate a prepared event without committing it."""
+
+        return _invoke(adapter, "fossil.validate", {"event": event})
+
+    @server.tool(name="fossil.commit")
+    def fossil_commit(event: dict[str, Any]) -> dict[str, Any]:
+        """Commit a validated durable event through the canonical writer."""
+
+        return _invoke(adapter, "fossil.commit", {"event": event})
+
+    @server.tool(name="fossil.manage")
+    def fossil_manage(action: str) -> dict[str, Any]:
+        """Read the bounded management surface such as capabilities or health."""
+
+        return _invoke(adapter, "fossil.manage", {"action": action})
+
+    registered = tuple(tool.name for tool in server._tool_manager.list_tools())
+    if registered != ThinMCPAdapter.TOOL_NAMES:
+        raise RuntimeError(
+            "network MCP tool surface drifted from ThinMCPAdapter allowlist: "
+            f"{registered!r}"
+        )
+    return server
+
+
+__all__ = ["FossilMCPToolError", "build_mcp_server"]

--- a/src/fossil_core/runtime/network.py
+++ b/src/fossil_core/runtime/network.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import inspect
+import json
+import os
+from collections.abc import Awaitable, Callable, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+from jsonschema import ValidationError
+from mcp.server.transport_security import TransportSecuritySettings
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Mount, Route
+
+from fossil_core.adapters.mcp import ThinMCPAdapter
+from fossil_core.adapters.mcp.server import build_mcp_server
+from fossil_core.agent import AgentContext
+from fossil_core.application.ingest.reviewed_evidence import (
+    ReviewedClaimDraft,
+    ReviewedEvidenceIngestError,
+    ReviewedSource,
+)
+from fossil_core.domain.pack import PackBoundaryError
+
+from .node import FilesystemFossilNode
+
+
+Probe = Callable[[], Any | Awaitable[Any]]
+
+
+async def _await_if_needed(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _json_error(code: str, detail: str, status_code: int) -> JSONResponse:
+    return JSONResponse(
+        {"error": {"code": code, "detail": detail}}, status_code=status_code
+    )
+
+
+@dataclass
+class NodeReadinessProbe:
+    """Machine-readable readiness for canonical truth and its projection.
+
+    Liveness is intentionally separate. A graph outage can make the node not
+    ready for semantic retrieval while the canonical evidence/event substrate is
+    still healthy and authoritative.
+    """
+
+    node: FilesystemFossilNode
+    projection_check: Probe | None = None
+    max_projection_lag_events: int = 0
+
+    def __post_init__(self) -> None:
+        if self.max_projection_lag_events < 0:
+            raise ValueError("max_projection_lag_events must be non-negative")
+
+    def _canonical_status(self) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        roots = {
+            "artifacts": self.node.paths.artifacts_root,
+            "sources": self.node.paths.sources_root,
+            "events": self.node.paths.events_root,
+        }
+        try:
+            for name, root in roots.items():
+                if not root.is_dir():
+                    raise OSError(f"canonical {name} root is unavailable: {root}")
+                if not os.access(root, os.R_OK | os.W_OK):
+                    raise OSError(f"canonical {name} root is not readable/writable: {root}")
+            events = list(self.node.event_store.iter_events())
+        except Exception as exc:
+            return (
+                {
+                    "status": "unavailable",
+                    "reason": "canonical_store_unavailable",
+                    "detail": str(exc),
+                },
+                [],
+            )
+        return (
+            {
+                "status": "available",
+                "event_count": len(events),
+            },
+            events,
+        )
+
+    async def _probe_projection(self) -> Any:
+        if self.projection_check is not None:
+            return await _await_if_needed(self.projection_check())
+
+        driver = getattr(self.node.projection.client, "driver", None)
+        execute_query = getattr(driver, "execute_query", None)
+        if callable(execute_query):
+            return await _await_if_needed(
+                execute_query("RETURN 1 AS fossil_ready", routing_="r")
+            )
+
+        # Test/dummy projection clients may not expose a database driver. The
+        # adapter health contract still establishes that the projection is wired;
+        # production Graphiti exposes ``driver.execute_query`` and is probed above.
+        return self.node.projection.health()
+
+    async def check(self) -> dict[str, Any]:
+        canonical, events = self._canonical_status()
+        durable_truth = (
+            "available" if canonical["status"] == "available" else "unavailable"
+        )
+
+        try:
+            projection_probe = await self._probe_projection()
+            if projection_probe is False:
+                raise RuntimeError("projection readiness probe returned false")
+        except Exception as exc:
+            projection = {
+                "status": "unavailable",
+                "reason": "projection_unavailable",
+                "detail": str(exc),
+            }
+            return {
+                "status": "not_ready",
+                "durable_truth": durable_truth,
+                "canonical": canonical,
+                "projection": projection,
+            }
+
+        pending_event_ids = [
+            str(event["event_id"])
+            for event in events
+            if not self.node.projection.ledger.is_applied(str(event["event_id"]))
+            and not self.node.projection.ledger.is_redacted(str(event["event_id"]))
+        ]
+        if len(pending_event_ids) > self.max_projection_lag_events:
+            projection = {
+                "status": "lagging",
+                "reason": "projection_lag",
+                "pending_events": len(pending_event_ids),
+                "max_pending_events": self.max_projection_lag_events,
+            }
+        else:
+            projection = {
+                "status": "available",
+                "pending_events": len(pending_event_ids),
+                "max_pending_events": self.max_projection_lag_events,
+            }
+
+        ready = canonical["status"] == "available" and projection["status"] == "available"
+        return {
+            "status": "ready" if ready else "not_ready",
+            "durable_truth": durable_truth,
+            "canonical": canonical,
+            "projection": projection,
+        }
+
+
+def _required_mapping(value: Any, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{field} must be an object")
+    return value
+
+
+def _required_text(mapping: Mapping[str, Any], field: str) -> str:
+    value = mapping[field]
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _decode_source(source: Mapping[str, Any]) -> ReviewedSource:
+    encoded = _required_text(source, "data_b64")
+    try:
+        data = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("source.data_b64 must be valid base64") from exc
+
+    return ReviewedSource(
+        data=data,
+        source_kind=_required_text(source, "source_kind"),
+        source_role=_required_text(source, "source_role"),
+        locator=dict(_required_mapping(source["locator"], "source.locator")),
+        retrieved_at=_required_text(source, "retrieved_at"),
+        quality=dict(_required_mapping(source["quality"], "source.quality")),
+        published_at=source.get("published_at"),
+        version_metadata=(
+            dict(_required_mapping(source["version_metadata"], "source.version_metadata"))
+            if source.get("version_metadata") is not None
+            else None
+        ),
+        derivation=(
+            dict(_required_mapping(source["derivation"], "source.derivation"))
+            if source.get("derivation") is not None
+            else None
+        ),
+        media_type=str(source.get("media_type") or "application/octet-stream"),
+    )
+
+
+def _decode_claims(value: Any) -> list[ReviewedClaimDraft]:
+    if not isinstance(value, list):
+        raise TypeError("claims must be an array")
+    claims: list[ReviewedClaimDraft] = []
+    for index, raw_claim in enumerate(value):
+        claim = _required_mapping(raw_claim, f"claims[{index}]")
+        claims.append(
+            ReviewedClaimDraft(
+                subject_ref=_required_text(claim, "subject_ref"),
+                claim_text=_required_text(claim, "claim_text"),
+                reason=_required_text(claim, "reason"),
+            )
+        )
+    return claims
+
+
+async def _read_json(request: Request, *, max_bytes: int) -> Mapping[str, Any] | JSONResponse:
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            if int(content_length) > max_bytes:
+                return _json_error(
+                    "request_too_large",
+                    f"request exceeds {max_bytes} byte ingest limit",
+                    413,
+                )
+        except ValueError:
+            return _json_error("invalid_request", "invalid Content-Length header", 400)
+
+    raw = await request.body()
+    if len(raw) > max_bytes:
+        return _json_error(
+            "request_too_large",
+            f"request exceeds {max_bytes} byte ingest limit",
+            413,
+        )
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return _json_error("invalid_json", "request body must be valid UTF-8 JSON", 400)
+    if not isinstance(payload, Mapping):
+        return _json_error("invalid_request", "request body must be a JSON object", 400)
+    return payload
+
+
+def create_node_network_app(
+    node: FilesystemFossilNode,
+    *,
+    context: AgentContext,
+    readiness_probe: NodeReadinessProbe | None = None,
+    transport_security: TransportSecuritySettings | None = None,
+    host: str = "127.0.0.1",
+    max_ingest_bytes: int = 16 * 1024 * 1024,
+    max_mcp_request_body_size: int = 1024 * 1024,
+) -> Starlette:
+    """Compose MCP Streamable HTTP and operational HTTP routes for one node.
+
+    The configured ``AgentContext`` is node-owned authority. HTTP request bodies
+    cannot supply a durable actor or a pack manifest, preventing remote callers
+    from manufacturing provenance or widening the pack boundary.
+    """
+
+    if max_ingest_bytes < 1 or max_mcp_request_body_size < 1:
+        raise ValueError("request body limits must be positive")
+
+    mcp_adapter = ThinMCPAdapter(
+        service=node.corpus_service,
+        access=node.pack_access,
+        context=context,
+    )
+    mcp = build_mcp_server(mcp_adapter)
+    mcp_app = mcp.streamable_http_app(
+        streamable_http_path="/mcp",
+        json_response=True,
+        stateless_http=True,
+        max_request_body_size=max_mcp_request_body_size,
+        transport_security=transport_security,
+        host=host,
+    )
+    readiness = readiness_probe or NodeReadinessProbe(node)
+
+    async def healthz(request: Request) -> JSONResponse:
+        return JSONResponse(
+            {
+                "status": "ok",
+                "service": "fossil-core",
+                "service_version": node.corpus_service.service_version,
+            }
+        )
+
+    async def readyz(request: Request) -> JSONResponse:
+        snapshot = await readiness.check()
+        return JSONResponse(
+            snapshot,
+            status_code=200 if snapshot["status"] == "ready" else 503,
+        )
+
+    async def ingest(request: Request) -> JSONResponse:
+        parsed = await _read_json(request, max_bytes=max_ingest_bytes)
+        if isinstance(parsed, JSONResponse):
+            return parsed
+
+        try:
+            expected_pack_id = str(node.pack_manifest["pack_id"])
+            requested_pack_id = str(parsed.get("pack_id") or expected_pack_id)
+            if requested_pack_id != expected_pack_id:
+                raise PackBoundaryError(
+                    f"ingest pack {requested_pack_id} does not match mounted pack {expected_pack_id}"
+                )
+            node.pack_access.require_write(expected_pack_id)
+
+            source = _decode_source(_required_mapping(parsed["source"], "source"))
+            claims = _decode_claims(parsed["claims"])
+            receipt = node.reviewed_ingest.ingest(
+                pack_manifest=node.pack_manifest,
+                source=source,
+                claims=claims,
+                review_ref=_required_text(parsed, "review_ref"),
+                actor=context.durable_actor(),
+                occurred_at=_required_text(parsed, "occurred_at"),
+                recorded_at=_required_text(parsed, "recorded_at"),
+                correlation_id=_required_text(parsed, "correlation_id"),
+                requested_outcome="proposed",
+            )
+        except PackBoundaryError as exc:
+            return _json_error("unauthorized_pack", str(exc), 403)
+        except OSError as exc:
+            return _json_error("canonical_store_unavailable", str(exc), 503)
+        except (
+            KeyError,
+            TypeError,
+            ValueError,
+            ValidationError,
+            ReviewedEvidenceIngestError,
+        ) as exc:
+            return _json_error("invalid_ingest", str(exc), 422)
+        except Exception:
+            return _json_error("internal_error", "reviewed ingest failed", 500)
+
+        if receipt.get("status") == "rejected":
+            return JSONResponse(receipt, status_code=422)
+        return JSONResponse(receipt, status_code=201)
+
+    @asynccontextmanager
+    async def lifespan(app: Starlette):
+        async with mcp.session_manager.run():
+            yield
+
+    app = Starlette(
+        routes=[
+            Route("/healthz", healthz, methods=["GET"]),
+            Route("/readyz", readyz, methods=["GET"]),
+            Route("/ingest", ingest, methods=["POST"]),
+            Mount("/", app=mcp_app),
+        ],
+        lifespan=lifespan,
+    )
+    app.state.fossil_node = node
+    app.state.mcp_server = mcp
+    app.state.readiness_probe = readiness
+    return app
+
+
+__all__ = ["NodeReadinessProbe", "create_node_network_app"]

--- a/tests/test_fossil_node_network.py
+++ b/tests/test_fossil_node_network.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from mcp import Client
+from mcp.server.transport_security import TransportSecuritySettings
+from starlette.testclient import TestClient
+
+from fossil_core.adapters.mcp import ThinMCPAdapter
+from fossil_core.adapters.mcp.server import build_mcp_server
+from fossil_core.agent import AgentContext
+from fossil_core.runtime import FilesystemNodeConfig, compose_filesystem_node
+from fossil_core.runtime.network import NodeReadinessProbe, create_node_network_app
+
+
+COMMON = "pack_269099f7b2ba43b7a99b9427d64092de"
+EXPECTED_TOOLS = (
+    "fossil.search",
+    "fossil.read",
+    "fossil.lineage",
+    "fossil.propose",
+    "fossil.validate",
+    "fossil.commit",
+    "fossil.manage",
+)
+
+
+def root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+class FakeGraphiti:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def build_indices_and_constraints(self) -> None:
+        return None
+
+    async def add_episode(self, **kwargs):
+        event_id = str(json.loads(kwargs["episode_body"])["event_id"])
+        self.calls.append(event_id)
+        return SimpleNamespace(episode=SimpleNamespace(uuid=f"episode-{event_id}"))
+
+    async def remove_episode(self, episode_uuid: str) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+class FakeLineage:
+    def current_conclusions(self):
+        return [{"node_id": "lin_current", "kind": "conclusion"}]
+
+    def historical_nodes(self):
+        return [{"node_id": "lin_history", "kind": "claim"}]
+
+    def node(self, node_id: str):
+        return {"node_id": node_id, "kind": "conclusion"}
+
+    def citations(self, node_id: str):
+        return [{"span_id": "span_fixture", "text": "fixture evidence"}]
+
+    def opposing_positions(self, node_id: str):
+        return []
+
+
+def config(tmp_path: Path):
+    return FilesystemNodeConfig(
+        repository_root=root(),
+        data_root=tmp_path / "node-data",
+        pack_manifest_path=root() / "examples" / "packs" / "common" / "manifest.json",
+        projection_build_id="node-02-test",
+        projection_build_manifest={
+            "graphiti_version": "0.29.3",
+            "neo4j_version": "test",
+            "model_id": "test-model",
+            "ontology_version": "1.0.0",
+            "software_commit": "test",
+        },
+        poll_interval_seconds=0.01,
+    )
+
+
+def compose(tmp_path: Path):
+    return compose_filesystem_node(
+        config(tmp_path),
+        graphiti_client=FakeGraphiti(),
+        episode_type_json="json",
+    )
+
+
+def agent_context() -> AgentContext:
+    return AgentContext(
+        actor_id="node-02-fixture",
+        model_id="fixture-model-v2",
+        harness_version="fixture-harness-v2",
+        skill_id="skill_research-ingestion",
+        skill_version="1.1.0",
+    )
+
+
+def adapter(node) -> ThinMCPAdapter:
+    return ThinMCPAdapter(
+        service=node.corpus_service,
+        access=node.pack_access,
+        context=agent_context(),
+    )
+
+
+def _tool_error_text(result) -> str:
+    return "\n".join(getattr(block, "text", "") for block in result.content)
+
+
+def test_mcp_server_preserves_frozen_tools_and_corpus_semantics(tmp_path: Path):
+    node = compose(tmp_path)
+    node.corpus_service.lineages["conv_node_02"] = (COMMON, FakeLineage())
+    server = build_mcp_server(adapter(node))
+
+    async def scenario() -> None:
+        async with Client(server) as client:
+            listing = await client.list_tools()
+            assert tuple(tool.name for tool in listing.tools) == EXPECTED_TOOLS
+
+            proposed = await client.call_tool(
+                "fossil.propose",
+                {
+                    "event_type": "claim.proposed",
+                    "pack_id": COMMON,
+                    "subject_refs": ["clm_node_02_mcp"],
+                    "payload": {"claim_text": "NODE-02 MCP routes through CorpusService."},
+                    "occurred_at": "2026-08-20T04:05:00Z",
+                    "recorded_at": "2026-08-20T04:05:00Z",
+                    "idempotency_key": "node-02-mcp-propose-v1",
+                },
+            )
+            assert proposed.is_error is False
+            event = proposed.structured_content
+            assert event is not None
+            assert event["actor"] == agent_context().durable_actor()
+
+            validated = await client.call_tool("fossil.validate", {"event": event})
+            assert validated.is_error is False
+            assert validated.structured_content == event
+
+            committed = await client.call_tool("fossil.commit", {"event": event})
+            assert committed.is_error is False
+            committed_event = committed.structured_content
+            assert committed_event is not None
+
+            searched = await client.call_tool(
+                "fossil.search", {"query": "NODE-02 MCP", "limit": 10}
+            )
+            assert searched.is_error is False
+            assert any(
+                item["event_id"] == committed_event["event_id"]
+                for item in searched.structured_content["result"]
+            )
+
+            read = await client.call_tool(
+                "fossil.read", {"event_id": committed_event["event_id"]}
+            )
+            assert read.is_error is False
+            assert read.structured_content["event_id"] == committed_event["event_id"]
+
+            lineage = await client.call_tool(
+                "fossil.lineage", {"conversation_id": "conv_node_02"}
+            )
+            assert lineage.is_error is False
+            assert lineage.structured_content["conversation_id"] == "conv_node_02"
+
+    asyncio.run(scenario())
+
+
+def test_mcp_server_fails_closed_on_pack_scope_and_graph_escape(tmp_path: Path):
+    server = build_mcp_server(adapter(compose(tmp_path)))
+
+    async def scenario() -> None:
+        async with Client(server) as client:
+            denied = await client.call_tool(
+                "fossil.propose",
+                {
+                    "event_type": "claim.proposed",
+                    "pack_id": "pack_forbidden_node_02",
+                    "subject_refs": ["clm_forbidden"],
+                    "payload": {"claim_text": "must not cross pack boundary"},
+                    "occurred_at": "2026-08-20T04:06:00Z",
+                    "recorded_at": "2026-08-20T04:06:00Z",
+                    "idempotency_key": "node-02-forbidden-v1",
+                },
+            )
+            assert denied.is_error is True
+            assert "unauthorized_pack" in _tool_error_text(denied)
+
+            graph_escape = await client.call_tool(
+                "neo4j.cypher", {"query": "MATCH (n) DETACH DELETE n"}
+            )
+            assert graph_escape.is_error is True
+            assert "Unknown tool" in _tool_error_text(graph_escape)
+
+    asyncio.run(scenario())
+
+
+def test_streamable_http_transport_and_health_readiness_are_independent(tmp_path: Path):
+    node = compose(tmp_path)
+
+    async def projection_down() -> None:
+        raise RuntimeError("neo4j unavailable")
+
+    app = create_node_network_app(
+        node,
+        context=agent_context(),
+        readiness_probe=NodeReadinessProbe(node, projection_check=projection_down),
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        ),
+    )
+
+    with TestClient(app, base_url="http://localhost") as client:
+        health = client.get("/healthz")
+        assert health.status_code == 200
+        assert health.json()["status"] == "ok"
+
+        ready = client.get("/readyz")
+        assert ready.status_code == 503
+        assert ready.json()["status"] == "not_ready"
+        assert ready.json()["durable_truth"] == "available"
+        assert ready.json()["canonical"]["status"] == "available"
+        assert ready.json()["projection"]["status"] == "unavailable"
+        assert ready.json()["projection"]["reason"] == "projection_unavailable"
+
+        envelope = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientInfo": {
+                        "name": "fossil-node-02-test",
+                        "version": "1",
+                    },
+                    "io.modelcontextprotocol/clientCapabilities": {},
+                }
+            },
+        }
+        response = client.post(
+            "/mcp",
+            headers={
+                "content-type": "application/json",
+                "accept": "application/json, text/event-stream",
+                "mcp-protocol-version": "2026-07-28",
+                "mcp-method": "tools/list",
+            },
+            json=envelope,
+        )
+        assert response.status_code == 200
+        tool_names = [tool["name"] for tool in response.json()["result"]["tools"]]
+        assert tuple(tool_names) == EXPECTED_TOOLS
+
+
+def test_reviewed_http_ingest_is_durable_before_projection(tmp_path: Path):
+    node = compose(tmp_path)
+    app = create_node_network_app(
+        node,
+        context=agent_context(),
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        ),
+    )
+    evidence = b"Reviewed evidence says canonical events survive projection outages.\n"
+    payload = {
+        "pack_id": COMMON,
+        "source": {
+            "data_b64": base64.b64encode(evidence).decode("ascii"),
+            "source_kind": "research",
+            "source_role": "primary",
+            "locator": {"identifier": "node-02-reviewed-http-fixture"},
+            "retrieved_at": "2026-08-20T04:07:00Z",
+            "published_at": "2026-08-20T04:06:00Z",
+            "media_type": "text/plain",
+            "quality": {
+                "authority": 0.8,
+                "directness": 1.0,
+                "independence": 0.7,
+                "reproducibility": 0.9,
+                "timeliness": 1.0,
+                "notes": "reviewed NODE-02 fixture",
+            },
+        },
+        "claims": [
+            {
+                "subject_ref": "clm_node_02_reviewed_ingest",
+                "claim_text": "Canonical events survive projection outages.",
+                "reason": "reviewed NODE-02 transport fixture",
+            }
+        ],
+        "review_ref": "review:node-02:http-ingest",
+        "occurred_at": "2026-08-20T04:07:01Z",
+        "recorded_at": "2026-08-20T04:07:02Z",
+        "correlation_id": "node-02-reviewed-http-v1",
+    }
+
+    with TestClient(app, base_url="http://localhost") as client:
+        response = client.post("/ingest", json=payload)
+        assert response.status_code == 201
+        receipt = response.json()
+
+    assert receipt["status"] == "proposed"
+    assert receipt["pack_id"] == COMMON
+    assert receipt["source"]["preserved"] is True
+    assert node.artifact_store.read_bytes(receipt["source"]["artifact_id"]) == evidence
+    event_id = receipt["proposal_event_ids"][0]
+    event = node.event_store.get(event_id)
+    assert event["evidence_refs"] == [receipt["source"]["artifact_id"]]
+    assert event["source_snapshot_refs"] == [receipt["source"]["snapshot_id"]]
+    assert event["actor"] == agent_context().durable_actor()
+    assert node.projection.ledger.is_applied(event_id) is False
+
+    cycle = asyncio.run(node.projector.run_once_async())
+    assert cycle.applied == 1
+    assert node.projection.ledger.is_applied(event_id) is True
+
+
+def test_reviewed_http_ingest_rejects_pack_spoofing_and_invalid_payload(tmp_path: Path):
+    node = compose(tmp_path)
+    app = create_node_network_app(
+        node,
+        context=agent_context(),
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        ),
+    )
+
+    with TestClient(app, base_url="http://localhost") as client:
+        denied = client.post(
+            "/ingest",
+            json={
+                "pack_id": "pack_forbidden_node_02",
+                "source": {},
+                "claims": [],
+                "review_ref": "review:denied",
+                "occurred_at": "2026-08-20T04:08:00Z",
+                "recorded_at": "2026-08-20T04:08:00Z",
+                "correlation_id": "node-02-denied",
+            },
+        )
+        assert denied.status_code == 403
+        assert denied.json()["error"]["code"] == "unauthorized_pack"
+
+        invalid = client.post("/ingest", content=b"not-json")
+        assert invalid.status_code == 400
+        assert invalid.json()["error"]["code"] == "invalid_json"
+
+    assert list(node.event_store.iter_events()) == []

--- a/tests/test_fossil_node_network.py
+++ b/tests/test_fossil_node_network.py
@@ -104,11 +104,21 @@ def agent_context() -> AgentContext:
     )
 
 
-def adapter(node) -> ThinMCPAdapter:
+def read_context() -> AgentContext:
+    return AgentContext(
+        actor_id="node-02-reader",
+        model_id="fixture-model-v2",
+        harness_version="fixture-harness-v2",
+        skill_id="skill_corpus-search",
+        skill_version="1.0.0",
+    )
+
+
+def adapter(node, *, context: AgentContext | None = None) -> ThinMCPAdapter:
     return ThinMCPAdapter(
         service=node.corpus_service,
         access=node.pack_access,
-        context=agent_context(),
+        context=context or agent_context(),
     )
 
 
@@ -119,10 +129,11 @@ def _tool_error_text(result) -> str:
 def test_mcp_server_preserves_frozen_tools_and_corpus_semantics(tmp_path: Path):
     node = compose(tmp_path)
     node.corpus_service.lineages["conv_node_02"] = (COMMON, FakeLineage())
-    server = build_mcp_server(adapter(node))
+    write_server = build_mcp_server(adapter(node, context=agent_context()))
+    read_server = build_mcp_server(adapter(node, context=read_context()))
 
     async def scenario() -> None:
-        async with Client(server) as client:
+        async with Client(write_server) as client:
             listing = await client.list_tools()
             assert tuple(tool.name for tool in listing.tools) == EXPECTED_TOOLS
 
@@ -151,6 +162,10 @@ def test_mcp_server_preserves_frozen_tools_and_corpus_semantics(tmp_path: Path):
             assert committed.is_error is False
             committed_event = committed.structured_content
             assert committed_event is not None
+
+        async with Client(read_server) as client:
+            listing = await client.list_tools()
+            assert tuple(tool.name for tool in listing.tools) == EXPECTED_TOOLS
 
             searched = await client.call_tool(
                 "fossil.search", {"query": "NODE-02 MCP", "limit": 10}


### PR DESCRIPTION
Implements Phase 2 of #231: the persistent FOSSIL Node network boundary.

Scope delivered:
- official MCP SDK v2 server wrapping the canonical `ThinMCPAdapter` seven-tool allowlist,
- Streamable HTTP at `/mcp`,
- `/healthz` liveness independent from dependency readiness,
- `/readyz` that reports canonical durable truth separately from projection availability/lag,
- `/ingest` backed by `ReviewedEvidenceIngestService`, using the node-owned validated pack and configured durable actor rather than caller-supplied authority,
- bounded request bodies and stable transport error mapping,
- pack spoofing and arbitrary graph-tool escape fail closed,
- real least-privilege skill contexts preserved (`research-ingestion` for write path; `corpus-search` for search/lineage path).

RED evidence:
- head `06c17af8986b0063fe6e63874f7aadbbbe677527`
- DKG run `32330892568` — expected collection failure because `fossil_core.adapters.mcp.server` did not yet exist.

Implementation debugging evidence:
- run `32331054802` exposed optional MCP proposal fields being forwarded as explicit `None`; wrapper fixed without changing domain authorization.
- run `32331196053` then exposed the test fixture incorrectly asking the ingestion-only skill to search; acceptance was split across the real least-privilege skill manifests rather than widening capabilities.

GREEN exact head: `eca0c9371e8e66c95f679e79e729476a60356187`
- DKG run `32331358859` — SUCCESS, 703 passed / 1 skipped.
- Dependency Integrity run `32331358681` — SUCCESS.
- Agent authorization mutation run `32331358720` — SUCCESS.
- Architecture boundary mutation run `32331358840` — SUCCESS.
- Engineering assurance run `32331358775` — SUCCESS.
- Generic mutation assurance run `32331358917` — SUCCESS.
- Query context security mutation run `32331358696` — SUCCESS.
- Identity mutation run `32331358677` — SUCCESS.
- Filesystem event-store mutation run `32331358914` — SUCCESS.
- Filesystem artifact-store mutation run `32331358725` — SUCCESS.
- S3 storage mutation run `32331358695` — SUCCESS.
- Source citation mutation run `32331358834` — SUCCESS.
- Promotion mutation run `32331358686` — SUCCESS.
- S3-compatible service fixture run `32331358713` — SUCCESS.
- Graphiti live run `32331358688` — SUCCESS, including exact-target checkout, durable→ProjectorWorker→Graphiti→Neo4j smoke, live redaction/non-resurrection, and proof upload.

Acceptance proof in DKG:
- exact frozen MCP tool surface: search/read/lineage/propose/validate/commit/manage,
- propose→validate→commit through MCP and canonical `CorpusService`,
- search/read/lineage through MCP under the real corpus-search skill,
- unauthorized pack proposal is rejected,
- `neo4j.cypher` is not a registered tool,
- actual Streamable HTTP `tools/list` succeeds at `/mcp`,
- `/healthz` stays 200 while injected projection outage makes `/readyz` 503 and explicitly reports `durable_truth=available`,
- reviewed `/ingest` preserves source bytes and commits a durable proposal event before projection,
- projector later applies that already-durable event,
- pack spoofing and invalid JSON fail closed without committing events.

Head tree: `9df4cccb21366eba788d1e8ab65d7ae745b40a41`.
Reviews: 0; review threads: 0.
Acceptance weakened: no.

No durable schema/identity/pack/lifecycle semantics changed. No Podman/Quadlet/Tailscale deployment is included; that remains NODE-03.

Task: FOSSIL-NODE-02
Issue: #231
Ledger: #94
Base main: `0ff3938617085a268ee155022e3573ad1991a8e7`