### PR TITLE
Add read-only ChatGPT Action/OpenAPI adapter

### DIFF
--- a/.github/workflows/chatgpt-action-container.yml
+++ b/.github/workflows/chatgpt-action-container.yml
@@ -30,39 +30,49 @@ jobs:
             -t fossil-chatgpt-action:ci \
             .
 
-      - name: Prepare read-only canonical fixture
+      - name: Assert image has no runtime credential
+        run: |
+          test "$(docker image inspect fossil-chatgpt-action:ci --format '{{.Config.User}}')" = "fossil"
+          if docker history --no-trunc fossil-chatgpt-action:ci | grep -F 'ci-only-not-a-secret-0123456789abcdef'; then
+            echo 'synthetic runtime token unexpectedly present in image history' >&2
+            exit 1
+          fi
+          if docker image inspect fossil-chatgpt-action:ci | grep -F 'ci-only-not-a-secret-0123456789abcdef'; then
+            echo 'synthetic runtime token unexpectedly present in image configuration' >&2
+            exit 1
+          fi
+
+      - name: Prepare empty canonical fixture
         run: |
           mkdir -p "$RUNNER_TEMP/fossil-data/canonical/events"
           chmod -R a+rX "$RUNNER_TEMP/fossil-data"
 
-      - name: Start Action container
+      - name: Start loopback-only Action container
         run: |
           docker run -d \
             --name fossil-chatgpt-action \
             -e FOSSIL_ACTION_BEARER_TOKEN=ci-only-not-a-secret-0123456789abcdef \
             -e FOSSIL_ACTION_PUBLIC_BASE_URL=https://fossil-action.ci.invalid \
-            -e FOSSIL_ACTION_MAX_REQUEST_BYTES=65536 \
             -p 127.0.0.1:8787:8787 \
             -v "$RUNNER_TEMP/fossil-data:/var/lib/fossil:ro" \
             fossil-chatgpt-action:ci
 
-      - name: Verify non-root and read-only mount
+      - name: Inspect non-root loopback and read-only mount invariants
         run: |
           test "$(docker exec fossil-chatgpt-action id -u)" = "10001"
           test "$(docker exec fossil-chatgpt-action id -g)" = "10001"
-          docker exec fossil-chatgpt-action sh -c 'test ! -w /var/lib/fossil/canonical/events'
-          if docker exec fossil-chatgpt-action sh -c 'touch /var/lib/fossil/canonical/events/should-not-exist'; then
-            echo "canonical mount unexpectedly writable" >&2
+          test "$(docker inspect fossil-chatgpt-action --format '{{(index (index .NetworkSettings.Ports "8787/tcp") 0).HostIp}}')" = "127.0.0.1"
+          test "$(docker inspect fossil-chatgpt-action --format '{{range .Mounts}}{{if eq .Destination "/var/lib/fossil"}}{{.RW}}{{end}}{{end}}')" = "false"
+          if docker exec fossil-chatgpt-action sh -c 'echo forbidden > /var/lib/fossil/canonical/events/write-probe'; then
+            echo 'canonical mount unexpectedly writable' >&2
             exit 1
           fi
+          test ! -e "$RUNNER_TEMP/fossil-data/canonical/events/write-probe"
 
-      - name: Smoke read-only HTTP boundary
+      - name: Smoke read-only HTTP and OpenAPI boundary
         run: |
-          for attempt in $(seq 1 20); do
-            if curl --fail --silent \
-              -H 'X-Forwarded-Proto: http' \
-              -H 'X-Forwarded-Host: attacker.invalid' \
-              http://127.0.0.1:8787/openapi.json >/tmp/openapi.json; then
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent http://127.0.0.1:8787/openapi.json >/tmp/openapi.json; then
               break
             fi
             sleep 1
@@ -73,13 +83,24 @@ jobs:
           assert schema['openapi'].startswith('3.1.')
           assert schema['servers'] == [{'url': 'https://fossil-action.ci.invalid'}]
           assert isinstance(schema['components']['schemas'], dict)
+          assert schema['components']['schemas']
           assert set(schema['paths']) == {
               '/actions/search',
               '/actions/read',
               '/actions/lineage',
               '/actions/capabilities',
           }
-          assert schema['components']['schemas']['CapabilitiesResponse']['properties']['durable_writes_exposed']['const'] is False
+          assert all(not server['url'].startswith('http://') for server in schema['servers'])
+          PY
+
+          curl --fail --silent \
+            -H 'x-forwarded-proto: https' \
+            -H 'x-forwarded-host: attacker.invalid' \
+            http://127.0.0.1:8787/openapi.json >/tmp/forged-openapi.json
+          python - <<'PY'
+          import json
+          schema = json.load(open('/tmp/forged-openapi.json', encoding='utf-8'))
+          assert schema['servers'] == [{'url': 'https://fossil-action.ci.invalid'}]
           PY
 
           test "$(curl --silent --output /dev/null --write-out '%{http_code}' \
@@ -96,28 +117,58 @@ jobs:
           test "$(cat /tmp/search.json)" = "[]"
 
           for path in \
-            /mcp \
-            /ingest \
-            /actions/propose \
-            /actions/validate \
-            /actions/commit \
-            /actions/redact \
-            /neo4j \
-            /graph \
-            /filesystem; do
+            /mcp /ingest /actions/propose /actions/validate /actions/commit \
+            /actions/redact /actions/write /neo4j /graph /filesystem /admin; do
             test "$(curl --silent --output /dev/null --write-out '%{http_code}' \
               -H 'authorization: Bearer ci-only-not-a-secret-0123456789abcdef' \
               "http://127.0.0.1:8787${path}")" = "404"
           done
 
-          test "$(curl --silent --output /dev/null --write-out '%{http_code}' \
-            -X GET -H 'authorization: Bearer ci-only-not-a-secret-0123456789abcdef' \
-            http://127.0.0.1:8787/actions/search)" = "405"
+      - name: Smoke trusted-proxy HTTPS origin in a private Docker network
+        run: |
+          docker network create --subnet 172.30.235.0/24 fossil-action-proxy-test
+          docker run -d \
+            --name fossil-chatgpt-action-proxy \
+            --network fossil-action-proxy-test \
+            --ip 172.30.235.10 \
+            -e FOSSIL_ACTION_BEARER_TOKEN=ci-only-not-a-secret-0123456789abcdef \
+            -e FOSSIL_ACTION_TRUSTED_PROXY_CIDRS=172.30.235.20/32 \
+            -v "$RUNNER_TEMP/fossil-data:/var/lib/fossil:ro" \
+            fossil-chatgpt-action:ci
+
+          for attempt in $(seq 1 30); do
+            if docker run --rm \
+              --network fossil-action-proxy-test \
+              --ip 172.30.235.20 \
+              python:3.12-slim \
+              python -c "import urllib.request; r=urllib.request.Request('http://172.30.235.10:8787/openapi.json',headers={'X-Forwarded-Proto':'https','X-Forwarded-Host':'proxy-ci.example.invalid'}); print(urllib.request.urlopen(r,timeout=3).read().decode())" \
+              >/tmp/proxy-openapi.json 2>/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          python - <<'PY'
+          import json
+          schema = json.load(open('/tmp/proxy-openapi.json', encoding='utf-8'))
+          assert schema['servers'] == [{'url': 'https://proxy-ci.example.invalid'}]
+          PY
+
+      - name: Assert application logs do not contain runtime token
+        run: |
+          docker logs fossil-chatgpt-action >/tmp/action.log 2>&1 || true
+          if grep -F 'ci-only-not-a-secret-0123456789abcdef' /tmp/action.log; then
+            echo 'runtime token unexpectedly present in application logs' >&2
+            exit 1
+          fi
 
       - name: Show container logs on failure
         if: failure()
-        run: docker logs fossil-chatgpt-action || true
+        run: |
+          docker logs fossil-chatgpt-action || true
+          docker logs fossil-chatgpt-action-proxy || true
 
-      - name: Stop Action container
+      - name: Stop Action containers
         if: always()
-        run: docker rm -f fossil-chatgpt-action || true
+        run: |
+          docker rm -f fossil-chatgpt-action fossil-chatgpt-action-proxy || true
+          docker network rm fossil-action-proxy-test || true

--- a/.github/workflows/chatgpt-action-container.yml
+++ b/.github/workflows/chatgpt-action-container.yml
@@ -10,6 +10,8 @@ on:
       - "src/fossil_core/runtime/chatgpt_action.py"
       - "src/fossil_core/runtime/chatgpt_action_server.py"
       - "tests/test_chatgpt_action*.py"
+      - "tests/holdout/**"
+      - "docs/operations/CHATGPT-ACTION*.md"
   workflow_dispatch:
 
 permissions:
@@ -38,14 +40,29 @@ jobs:
           docker run -d \
             --name fossil-chatgpt-action \
             -e FOSSIL_ACTION_BEARER_TOKEN=ci-only-not-a-secret-0123456789abcdef \
+            -e FOSSIL_ACTION_PUBLIC_BASE_URL=https://fossil-action.ci.invalid \
+            -e FOSSIL_ACTION_MAX_REQUEST_BYTES=65536 \
             -p 127.0.0.1:8787:8787 \
             -v "$RUNNER_TEMP/fossil-data:/var/lib/fossil:ro" \
             fossil-chatgpt-action:ci
 
+      - name: Verify non-root and read-only mount
+        run: |
+          test "$(docker exec fossil-chatgpt-action id -u)" = "10001"
+          test "$(docker exec fossil-chatgpt-action id -g)" = "10001"
+          docker exec fossil-chatgpt-action sh -c 'test ! -w /var/lib/fossil/canonical/events'
+          if docker exec fossil-chatgpt-action sh -c 'touch /var/lib/fossil/canonical/events/should-not-exist'; then
+            echo "canonical mount unexpectedly writable" >&2
+            exit 1
+          fi
+
       - name: Smoke read-only HTTP boundary
         run: |
           for attempt in $(seq 1 20); do
-            if curl --fail --silent http://127.0.0.1:8787/openapi.json >/tmp/openapi.json; then
+            if curl --fail --silent \
+              -H 'X-Forwarded-Proto: http' \
+              -H 'X-Forwarded-Host: attacker.invalid' \
+              http://127.0.0.1:8787/openapi.json >/tmp/openapi.json; then
               break
             fi
             sleep 1
@@ -53,12 +70,16 @@ jobs:
           python - <<'PY'
           import json
           schema = json.load(open('/tmp/openapi.json', encoding='utf-8'))
+          assert schema['openapi'].startswith('3.1.')
+          assert schema['servers'] == [{'url': 'https://fossil-action.ci.invalid'}]
+          assert isinstance(schema['components']['schemas'], dict)
           assert set(schema['paths']) == {
               '/actions/search',
               '/actions/read',
               '/actions/lineage',
               '/actions/capabilities',
           }
+          assert schema['components']['schemas']['CapabilitiesResponse']['properties']['durable_writes_exposed']['const'] is False
           PY
 
           test "$(curl --silent --output /dev/null --write-out '%{http_code}' \
@@ -74,11 +95,24 @@ jobs:
             http://127.0.0.1:8787/actions/search)" = "200"
           test "$(cat /tmp/search.json)" = "[]"
 
+          for path in \
+            /mcp \
+            /ingest \
+            /actions/propose \
+            /actions/validate \
+            /actions/commit \
+            /actions/redact \
+            /neo4j \
+            /graph \
+            /filesystem; do
+            test "$(curl --silent --output /dev/null --write-out '%{http_code}' \
+              -H 'authorization: Bearer ci-only-not-a-secret-0123456789abcdef' \
+              "http://127.0.0.1:8787${path}")" = "404"
+          done
+
           test "$(curl --silent --output /dev/null --write-out '%{http_code}' \
-            http://127.0.0.1:8787/mcp)" = "404"
-          test "$(curl --silent --output /dev/null --write-out '%{http_code}' \
-            -X POST -H 'content-type: application/json' --data '{}' \
-            http://127.0.0.1:8787/ingest)" = "404"
+            -X GET -H 'authorization: Bearer ci-only-not-a-secret-0123456789abcdef' \
+            http://127.0.0.1:8787/actions/search)" = "405"
 
       - name: Show container logs on failure
         if: failure()

--- a/.github/workflows/chatgpt-action-container.yml
+++ b/.github/workflows/chatgpt-action-container.yml
@@ -42,9 +42,17 @@ jobs:
             exit 1
           fi
 
-      - name: Prepare empty canonical fixture
+      - name: Prepare canonical fixture with redaction negative control
         run: |
-          mkdir -p "$RUNNER_TEMP/fossil-data/canonical/events"
+          mkdir -p \
+            "$RUNNER_TEMP/fossil-data/canonical/events/aa" \
+            "$RUNNER_TEMP/fossil-data/canonical/events/_redactions/aa"
+          cat > "$RUNNER_TEMP/fossil-data/canonical/events/aa/evt_aaaaaaaaaaaaaaaa.json" <<'JSON'
+          {"schema_version":"dkg.event.v1","event_id":"evt_aaaaaaaaaaaaaaaa","event_type":"claim.proposed","occurred_at":"2026-08-20T12:00:00Z","recorded_at":"2026-08-20T12:00:00Z","pack_id":"pack_269099f7b2ba43b7a99b9427d64092de","actor":{"actor_type":"human","actor_id":"ci"},"subject_refs":["clm_ci"],"caused_by_event_ids":[],"correlation_id":null,"idempotency_key":"ci-redacted-event","evidence_refs":[],"source_snapshot_refs":[],"payload":{"claim_text":"container-redacted-payload-marker"}}
+          JSON
+          cat > "$RUNNER_TEMP/fossil-data/canonical/events/_redactions/aa/evt_aaaaaaaaaaaaaaaa.json" <<'JSON'
+          {"event_id":"evt_aaaaaaaaaaaaaaaa","pack_id":"pack_269099f7b2ba43b7a99b9427d64092de","reason":"container-redaction-tombstone-marker","authority":"ci","redacted_at":"2026-08-20T12:30:00Z"}
+          JSON
           chmod -R a+rX "$RUNNER_TEMP/fossil-data"
 
       - name: Start loopback-only Action container
@@ -69,7 +77,7 @@ jobs:
           fi
           test ! -e "$RUNNER_TEMP/fossil-data/canonical/events/write-probe"
 
-      - name: Smoke read-only HTTP and OpenAPI boundary
+      - name: Smoke read-only HTTP OpenAPI and redaction boundary
         run: |
           for attempt in $(seq 1 30); do
             if curl --fail --silent http://127.0.0.1:8787/openapi.json >/tmp/openapi.json; then
@@ -87,15 +95,16 @@ jobs:
           assert set(schema['paths']) == {
               '/actions/search',
               '/actions/read',
-              '/actions/lineage',
               '/actions/capabilities',
           }
+          assert '/actions/lineage' not in schema['paths']
           assert all(not server['url'].startswith('http://') for server in schema['servers'])
           PY
 
           curl --fail --silent \
             -H 'x-forwarded-proto: https' \
             -H 'x-forwarded-host: attacker.invalid' \
+            -H 'host: attacker.invalid' \
             http://127.0.0.1:8787/openapi.json >/tmp/forged-openapi.json
           python - <<'PY'
           import json
@@ -116,8 +125,35 @@ jobs:
             http://127.0.0.1:8787/actions/search)" = "200"
           test "$(cat /tmp/search.json)" = "[]"
 
+          test "$(curl --silent --output /tmp/redacted-search.json --write-out '%{http_code}' \
+            -X POST \
+            -H 'authorization: Bearer ci-only-not-a-secret-0123456789abcdef' \
+            -H 'content-type: application/json' \
+            --data '{"query":"container-redacted-payload-marker"}' \
+            http://127.0.0.1:8787/actions/search)" = "200"
+          test "$(cat /tmp/redacted-search.json)" = "[]"
+
+          test "$(curl --silent --output /tmp/tombstone-search.json --write-out '%{http_code}' \
+            -X POST \
+            -H 'authorization: Bearer ci-only-not-a-secret-0123456789abcdef' \
+            -H 'content-type: application/json' \
+            --data '{"query":"container-redaction-tombstone-marker"}' \
+            http://127.0.0.1:8787/actions/search)" = "200"
+          test "$(cat /tmp/tombstone-search.json)" = "[]"
+
+          test "$(curl --silent --output /tmp/redacted-read.json --write-out '%{http_code}' \
+            -X POST \
+            -H 'authorization: Bearer ci-only-not-a-secret-0123456789abcdef' \
+            -H 'content-type: application/json' \
+            --data '{"event_id":"evt_aaaaaaaaaaaaaaaa"}' \
+            http://127.0.0.1:8787/actions/read)" = "404"
+          if grep -qi 'redact\|container-redaction' /tmp/redacted-read.json; then
+            echo 'redaction metadata leaked through read error' >&2
+            exit 1
+          fi
+
           for path in \
-            /mcp /ingest /actions/propose /actions/validate /actions/commit \
+            /mcp /ingest /actions/lineage /actions/propose /actions/validate /actions/commit \
             /actions/redact /actions/write /neo4j /graph /filesystem /admin; do
             test "$(curl --silent --output /dev/null --write-out '%{http_code}' \
               -H 'authorization: Bearer ci-only-not-a-secret-0123456789abcdef' \

--- a/.github/workflows/chatgpt-action-container.yml
+++ b/.github/workflows/chatgpt-action-container.yml
@@ -1,0 +1,89 @@
+name: ChatGPT Action container
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/chatgpt-action-container.yml"
+      - "docker/chatgpt-action/**"
+      - "config/chatgpt-action.env.example"
+      - "pyproject.toml"
+      - "src/fossil_core/runtime/chatgpt_action.py"
+      - "src/fossil_core/runtime/chatgpt_action_server.py"
+      - "tests/test_chatgpt_action*.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  container-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build read-only Action image
+        run: |
+          docker build \
+            -f docker/chatgpt-action/Dockerfile \
+            -t fossil-chatgpt-action:ci \
+            .
+
+      - name: Prepare read-only canonical fixture
+        run: |
+          mkdir -p "$RUNNER_TEMP/fossil-data/canonical/events"
+          chmod -R a+rX "$RUNNER_TEMP/fossil-data"
+
+      - name: Start Action container
+        run: |
+          docker run -d \
+            --name fossil-chatgpt-action \
+            -e FOSSIL_ACTION_BEARER_TOKEN=ci-only-not-a-secret-0123456789abcdef \
+            -p 127.0.0.1:8787:8787 \
+            -v "$RUNNER_TEMP/fossil-data:/var/lib/fossil:ro" \
+            fossil-chatgpt-action:ci
+
+      - name: Smoke read-only HTTP boundary
+        run: |
+          for attempt in $(seq 1 20); do
+            if curl --fail --silent http://127.0.0.1:8787/openapi.json >/tmp/openapi.json; then
+              break
+            fi
+            sleep 1
+          done
+          python - <<'PY'
+          import json
+          schema = json.load(open('/tmp/openapi.json', encoding='utf-8'))
+          assert set(schema['paths']) == {
+              '/actions/search',
+              '/actions/read',
+              '/actions/lineage',
+              '/actions/capabilities',
+          }
+          PY
+
+          test "$(curl --silent --output /dev/null --write-out '%{http_code}' \
+            -X POST -H 'content-type: application/json' \
+            --data '{"query":"FOSSIL"}' \
+            http://127.0.0.1:8787/actions/search)" = "401"
+
+          test "$(curl --silent --output /tmp/search.json --write-out '%{http_code}' \
+            -X POST \
+            -H 'authorization: Bearer ci-only-not-a-secret-0123456789abcdef' \
+            -H 'content-type: application/json' \
+            --data '{"query":"FOSSIL"}' \
+            http://127.0.0.1:8787/actions/search)" = "200"
+          test "$(cat /tmp/search.json)" = "[]"
+
+          test "$(curl --silent --output /dev/null --write-out '%{http_code}' \
+            http://127.0.0.1:8787/mcp)" = "404"
+          test "$(curl --silent --output /dev/null --write-out '%{http_code}' \
+            -X POST -H 'content-type: application/json' --data '{}' \
+            http://127.0.0.1:8787/ingest)" = "404"
+
+      - name: Show container logs on failure
+        if: failure()
+        run: docker logs fossil-chatgpt-action || true
+
+      - name: Stop Action container
+        if: always()
+        run: docker rm -f fossil-chatgpt-action || true

--- a/.github/workflows/chatgpt-action-mutation.yml
+++ b/.github/workflows/chatgpt-action-mutation.yml
@@ -1,0 +1,31 @@
+name: ChatGPT Action mutation assurance
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/chatgpt-action-mutation.yml"
+      - "scripts/run_chatgpt_action_mutations.py"
+      - "src/fossil_core/runtime/chatgpt_action.py"
+      - "src/fossil_core/runtime/chatgpt_action_server.py"
+      - "docker/chatgpt-action/Dockerfile"
+      - ".github/workflows/chatgpt-action-container.yml"
+      - "tests/holdout/**"
+      - "tests/test_chatgpt_action_architecture.py"
+      - "pyproject.toml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mutation-holdout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install verification dependencies
+        run: pip install -e '.[test,node]'
+      - name: Run targeted Action mutants against holdout suite
+        run: python scripts/run_chatgpt_action_mutations.py

--- a/config/chatgpt-action.env.example
+++ b/config/chatgpt-action.env.example
@@ -1,12 +1,22 @@
-# Copy to a host-local file outside source control and replace placeholders.
-# Never commit the real bearer token or private endpoint credentials.
+# Example only. The local integrator copies this to:
+# D:\FossilBrokerWorker\chatgpt-action\secrets\chatgpt-action.env
+# and replaces placeholders locally. Never commit the real file.
 
 FOSSIL_ACTION_BEARER_TOKEN=replace-with-a-random-secret-of-at-least-32-characters
 FOSSIL_ACTION_HOST=0.0.0.0
 FOSSIL_ACTION_PORT=8787
 FOSSIL_ACTION_MAX_REQUEST_BYTES=65536
-# Public origin advertised in /openapi.json. Must be https:// and origin-only.
+
+# Safest production mode: set the externally reachable HTTPS origin explicitly.
+# This fixed origin overrides and ignores all forwarded-host/proto headers.
 FOSSIL_ACTION_PUBLIC_BASE_URL=https://fossil-action.example.invalid
+
+# Alternative trusted-proxy mode: leave FOSSIL_ACTION_PUBLIC_BASE_URL unset and
+# list only the proxy peer CIDR(s) that the container actually sees. Forwarded
+# headers from every other source are ignored and /openapi.json fails closed.
+FOSSIL_ACTION_TRUSTED_PROXY_CIDRS=
+
+# Container-internal paths; host source/data remain on D: and are bind-mounted.
 FOSSIL_REPOSITORY_ROOT=/opt/fossil-core
 FOSSIL_DATA_ROOT=/var/lib/fossil
 FOSSIL_PACK_MANIFEST=examples/packs/common/manifest.json

--- a/config/chatgpt-action.env.example
+++ b/config/chatgpt-action.env.example
@@ -1,22 +1,18 @@
-# Example only. The local integrator copies this to:
-# D:\FossilBrokerWorker\chatgpt-action\secrets\chatgpt-action.env
-# and replaces placeholders locally. Never commit the real file.
+# Example only. The local integrator copies this to a host-local path outside Git,
+# for example somewhere under D:\FossilBrokerWorker\chatgpt-action\secrets\,
+# and replaces placeholders locally. Never commit the populated file.
 
 FOSSIL_ACTION_BEARER_TOKEN=replace-with-a-random-secret-of-at-least-32-characters
 FOSSIL_ACTION_HOST=0.0.0.0
 FOSSIL_ACTION_PORT=8787
 FOSSIL_ACTION_MAX_REQUEST_BYTES=65536
 
-# Safest production mode: set the externally reachable HTTPS origin explicitly.
-# This fixed origin overrides and ignores all forwarded-host/proto headers.
+# Production mode: set the externally reachable HTTPS origin explicitly.
+# This fixed origin is used for /openapi.json; forwarded host/proto headers are
+# not trusted by the Action process.
 FOSSIL_ACTION_PUBLIC_BASE_URL=https://fossil-action.example.invalid
 
-# Alternative trusted-proxy mode: leave FOSSIL_ACTION_PUBLIC_BASE_URL unset and
-# list only the proxy peer CIDR(s) that the container actually sees. Forwarded
-# headers from every other source are ignored and /openapi.json fails closed.
-FOSSIL_ACTION_TRUSTED_PROXY_CIDRS=
-
-# Container-internal paths; host source/data remain on D: and are bind-mounted.
+# Container-internal paths; host source/data may remain on D: and be bind-mounted.
 FOSSIL_REPOSITORY_ROOT=/opt/fossil-core
 FOSSIL_DATA_ROOT=/var/lib/fossil
 FOSSIL_PACK_MANIFEST=examples/packs/common/manifest.json

--- a/config/chatgpt-action.env.example
+++ b/config/chatgpt-action.env.example
@@ -7,10 +7,15 @@ FOSSIL_ACTION_HOST=0.0.0.0
 FOSSIL_ACTION_PORT=8787
 FOSSIL_ACTION_MAX_REQUEST_BYTES=65536
 
-# Production mode: set the externally reachable HTTPS origin explicitly.
-# This fixed origin is used for /openapi.json; forwarded host/proto headers are
-# not trusted by the Action process.
+# Preferred production mode: set the externally reachable HTTPS origin explicitly.
+# This fixed origin is authoritative for /openapi.json and cannot be overridden by
+# Forwarded/X-Forwarded-* request headers.
 FOSSIL_ACTION_PUBLIC_BASE_URL=https://fossil-action.example.invalid
+
+# Advanced alternative only when FOSSIL_ACTION_PUBLIC_BASE_URL is unset:
+# comma-separated CIDRs for the actual reverse-proxy peer(s) seen by the container.
+# Use the narrow real peer range; never use 0.0.0.0/0 or ::/0 just to trust headers.
+# FOSSIL_ACTION_TRUSTED_PROXY_CIDRS=172.30.235.20/32
 
 # Container-internal paths; host source/data may remain on D: and be bind-mounted.
 FOSSIL_REPOSITORY_ROOT=/opt/fossil-core

--- a/config/chatgpt-action.env.example
+++ b/config/chatgpt-action.env.example
@@ -1,0 +1,9 @@
+# Copy to a host-local file outside source control and replace placeholders.
+# Never commit the real bearer token.
+
+FOSSIL_ACTION_BEARER_TOKEN=replace-with-a-random-secret-of-at-least-32-characters
+FOSSIL_ACTION_HOST=0.0.0.0
+FOSSIL_ACTION_PORT=8787
+FOSSIL_REPOSITORY_ROOT=/opt/fossil-core
+FOSSIL_DATA_ROOT=/var/lib/fossil
+FOSSIL_PACK_MANIFEST=examples/packs/common/manifest.json

--- a/config/chatgpt-action.env.example
+++ b/config/chatgpt-action.env.example
@@ -1,9 +1,12 @@
 # Copy to a host-local file outside source control and replace placeholders.
-# Never commit the real bearer token.
+# Never commit the real bearer token or private endpoint credentials.
 
 FOSSIL_ACTION_BEARER_TOKEN=replace-with-a-random-secret-of-at-least-32-characters
 FOSSIL_ACTION_HOST=0.0.0.0
 FOSSIL_ACTION_PORT=8787
+FOSSIL_ACTION_MAX_REQUEST_BYTES=65536
+# Public origin advertised in /openapi.json. Must be https:// and origin-only.
+FOSSIL_ACTION_PUBLIC_BASE_URL=https://fossil-action.example.invalid
 FOSSIL_REPOSITORY_ROOT=/opt/fossil-core
 FOSSIL_DATA_ROOT=/var/lib/fossil
 FOSSIL_PACK_MANIFEST=examples/packs/common/manifest.json

--- a/docker/chatgpt-action/Dockerfile
+++ b/docker/chatgpt-action/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.12-slim
+
+RUN groupadd --gid 10001 fossil \
+    && useradd --uid 10001 --gid 10001 --create-home --shell /usr/sbin/nologin fossil \
+    && install --directory --owner=fossil --group=fossil --mode=0750 /var/lib/fossil
+
+WORKDIR /opt/fossil-core
+COPY pyproject.toml ./
+COPY src ./src
+COPY schemas ./schemas
+COPY skills ./skills
+COPY examples ./examples
+
+RUN python -m venv /opt/fossil-venv \
+    && /opt/fossil-venv/bin/pip install --no-cache-dir '.[node]'
+
+ENV PATH=/opt/fossil-venv/bin:${PATH} \
+    FOSSIL_REPOSITORY_ROOT=/opt/fossil-core \
+    FOSSIL_DATA_ROOT=/var/lib/fossil \
+    FOSSIL_PACK_MANIFEST=examples/packs/common/manifest.json \
+    FOSSIL_ACTION_HOST=0.0.0.0 \
+    FOSSIL_ACTION_PORT=8787
+
+EXPOSE 8787
+USER fossil
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8787/openapi.json', timeout=3).read()"]
+
+ENTRYPOINT ["fossil-chatgpt-action"]

--- a/docker/chatgpt-action/Dockerfile
+++ b/docker/chatgpt-action/Dockerfile
@@ -19,12 +19,15 @@ ENV PATH=/opt/fossil-venv/bin:${PATH} \
     FOSSIL_DATA_ROOT=/var/lib/fossil \
     FOSSIL_PACK_MANIFEST=examples/packs/common/manifest.json \
     FOSSIL_ACTION_HOST=0.0.0.0 \
-    FOSSIL_ACTION_PORT=8787
+    FOSSIL_ACTION_PORT=8787 \
+    FOSSIL_ACTION_MAX_REQUEST_BYTES=65536
 
 EXPOSE 8787
 USER fossil
 
+# Liveness checks only the private TCP listener. It does not require a bearer
+# secret and does not weaken the public route allowlist with a health endpoint.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8787/openapi.json', timeout=3).read()"]
+    CMD ["python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8787),3); s.close()"]
 
 ENTRYPOINT ["fossil-chatgpt-action"]

--- a/docs/operations/CHATGPT-ACTION-HOLDOUT.md
+++ b/docs/operations/CHATGPT-ACTION-HOLDOUT.md
@@ -1,0 +1,122 @@
+# Holdout plan — FOSSIL read-only ChatGPT Action
+
+## Purpose
+
+The committed suite at `tests/holdout/test_chatgpt_action_holdout.py` is a black-box behavioral holdout separated from focused implementation tests. A PR cannot make committed tests literally hidden from its author, so downstream integrators should treat this file as the public holdout specification and may keep additional equivalent cases private/out-of-tree.
+
+The holdout judges only externally observable security/compatibility behavior plus deployment artifacts that can be inspected without relying on private helper logic.
+
+## Required cases
+
+### Authentication
+
+- no `Authorization` header;
+- empty value;
+- wrong scheme (`Basic`, raw token);
+- `Bearer` without token;
+- incorrect token;
+- exact token with trailing/embedded whitespace;
+- duplicate `Authorization` headers;
+- mixed-case `Bearer` scheme succeeds with the exact token;
+- token value remains case-sensitive.
+
+Expected: all invalid forms return `401` + `WWW-Authenticate: Bearer`; no token is reflected.
+
+### Proxy and HTTPS origin
+
+Fixed-origin mode:
+
+- send forged `Forwarded`, `X-Forwarded-Proto`, `X-Forwarded-Host`, and host headers;
+- expected schema server remains the configured fixed HTTPS origin.
+
+Trusted-proxy mode:
+
+- forwarded HTTPS headers from an untrusted peer -> `503`;
+- trusted peer + missing proto -> `503`;
+- trusted peer + `http` proto -> `503`;
+- trusted peer + missing host -> `503`;
+- comma-separated proto/host chains -> `503`;
+- host containing whitespace, path, userinfo, or invalid port -> `503`;
+- trusted peer + exactly one HTTPS proto and one valid host -> `200`, HTTPS server URL;
+- no case may emit `http://` in `servers`.
+
+### Request framing and validation
+
+- declared body above limit;
+- actual body above limit;
+- malformed/negative `Content-Length`;
+- invalid UTF-8/JSON;
+- JSON array/scalar instead of object;
+- extra fields attempting `commit`, `mcp`, filesystem path, or Cypher-like graph mutation;
+- empty or >8192-char search query;
+- boolean/string/zero/negative/>100 search limit;
+- path-like event/conversation/node identifiers.
+
+Expected: `400` or `413` before corpus invocation, never `500` and never a mutation.
+
+### Route/method surface
+
+For both GET and POST where meaningful, probe:
+
+- `/mcp`;
+- `/ingest`;
+- `/actions/propose`;
+- `/actions/validate`;
+- `/actions/commit`;
+- `/actions/redact`;
+- `/actions/write`;
+- `/admin`;
+- `/neo4j`;
+- `/graph`;
+- `/filesystem`;
+- arbitrary unknown path.
+
+Expected: `404` even with valid bearer auth.
+
+Probe allowed paths with unsupported methods. Expected: authenticated Action operations return `405`; `POST /openapi.json` returns `405` without auth.
+
+### Empty canonical corpus
+
+With an existing, empty `canonical/events` directory, authenticated search returns exactly `200 []`. No event file may be created and no fallback data source may fabricate content.
+
+### OpenAPI / private GPT compatibility
+
+Validate the live schema with an independent OpenAPI 3.1 validator and assert:
+
+- `components.schemas` is non-empty;
+- named request schemas exist;
+- successful response schemas resolve to objects with explicit properties;
+- `ErrorEnvelope` is used for errors;
+- exactly four Action paths exist;
+- operation IDs are unique/stable;
+- HTTP bearer security is declared;
+- no prohibited operation/path appears;
+- every advertised server URL is HTTPS;
+- no token/config/credential value appears.
+
+### Container/deployment holdout
+
+Against a built image/container, independently inspect:
+
+- effective UID/GID are 10001;
+- Docker host publication is exactly `127.0.0.1:8787`;
+- `/var/lib/fossil` mount reports `RW=false`;
+- an in-container write probe fails and creates no host file;
+- image config/history contain no runtime credential;
+- application logs do not contain the runtime credential;
+- empty authenticated search returns `[]`;
+- prohibited routes remain `404`;
+- trusted-proxy test network can produce the intended HTTPS origin only from the explicitly trusted client IP.
+
+## Out-of-tree/private extensions
+
+A local integrator may add private holdouts for:
+
+- unusual duplicate-header normalization by the selected reverse proxy;
+- IPv6 trusted proxy CIDRs;
+- non-default HTTPS ports;
+- malformed Unicode host/query values;
+- container restart/reboot behavior under Docker Desktop;
+- tunnel-specific header normalization.
+
+Those tests should preserve the same normative invariants and must never embed a real credential.

--- a/docs/operations/CHATGPT-ACTION-HOLDOUT.md
+++ b/docs/operations/CHATGPT-ACTION-HOLDOUT.md
@@ -2,121 +2,119 @@
 
 ## Purpose
 
-The committed suite at `tests/holdout/test_chatgpt_action_holdout.py` is a black-box behavioral holdout separated from focused implementation tests. A PR cannot make committed tests literally hidden from its author, so downstream integrators should treat this file as the public holdout specification and may keep additional equivalent cases private/out-of-tree.
+`tests/holdout/test_chatgpt_action_holdout.py` is a black-box behavioral suite separated from focused implementation tests. Because committed tests are visible to the implementation author, downstream integrators may maintain additional equivalent cases privately; this document defines the required behavior without coupling to helper names or internal control flow.
 
-The holdout judges only externally observable security/compatibility behavior plus deployment artifacts that can be inspected without relying on private helper logic.
-
-## Required cases
+## Required holdout families
 
 ### Authentication
 
-- no `Authorization` header;
-- empty value;
-- wrong scheme (`Basic`, raw token);
-- `Bearer` without token;
+- absent authorization;
+- empty authorization;
+- wrong scheme;
+- `Bearer` without a token;
 - incorrect token;
-- exact token with trailing/embedded whitespace;
-- duplicate `Authorization` headers;
-- mixed-case `Bearer` scheme succeeds with the exact token;
+- trailing/embedded token whitespace;
+- duplicate authorization headers;
+- mixed-case bearer scheme with exact token succeeds;
 - token value remains case-sensitive.
 
-Expected: all invalid forms return `401` + `WWW-Authenticate: Bearer`; no token is reflected.
+Expected invalid result: 401 plus `WWW-Authenticate: Bearer`; no credential reflection.
 
-### Proxy and HTTPS origin
+### Truthful public route contract
+
+The only public schema path set is:
+
+- `/actions/search`;
+- `/actions/read`;
+- `/actions/capabilities`.
+
+`/actions/lineage` must return 404 and must not appear in OpenAPI or capability metadata because the standalone composition has no lineage provider. `/mcp`, `/ingest`, write/mutation/admin/graph/filesystem and unknown paths are also 404.
+
+### OpenAPI / Custom GPT compatibility
+
+- OpenAPI 3.1 validates with `openapi-spec-validator`;
+- `components.schemas` is present and non-empty;
+- successful response object schemas declare properties;
+- all operation IDs are unique;
+- only search/read/capabilities are advertised;
+- capabilities schema is fixed to `["search", "read"]`;
+- no HTTP server URL, runtime token, local path, lineage route, mutation route, MCP route, or graph/database escape hatch appears.
+
+### HTTPS origin authority
 
 Fixed-origin mode:
 
-- send forged `Forwarded`, `X-Forwarded-Proto`, `X-Forwarded-Host`, and host headers;
-- expected schema server remains the configured fixed HTTPS origin.
+- forged `Host`, `Forwarded`, and `X-Forwarded-*` values cannot change the configured HTTPS origin.
+
+No-origin/direct-HTTPS mode:
+
+- direct HTTPS plus caller-controlled `Host` without fixed origin or trusted proxy must return 503;
+- caller-controlled host value must not be reflected.
 
 Trusted-proxy mode:
 
-- forwarded HTTPS headers from an untrusted peer -> `503`;
-- trusted peer + missing proto -> `503`;
-- trusted peer + `http` proto -> `503`;
-- trusted peer + missing host -> `503`;
-- comma-separated proto/host chains -> `503`;
-- host containing whitespace, path, userinfo, or invalid port -> `503`;
-- trusted peer + exactly one HTTPS proto and one valid host -> `200`, HTTPS server URL;
-- no case may emit `http://` in `servers`.
+- untrusted source peer -> 503;
+- missing/wrong proto -> 503;
+- missing/malformed/ambiguous host -> 503;
+- comma-chained forwarded values -> 503;
+- trusted peer + exactly one HTTPS proto + valid host -> 200 with that HTTPS origin.
 
-### Request framing and validation
+### Streaming request-size enforcement
 
-- declared body above limit;
-- actual body above limit;
-- malformed/negative `Content-Length`;
-- invalid UTF-8/JSON;
-- JSON array/scalar instead of object;
-- extra fields attempting `commit`, `mcp`, filesystem path, or Cypher-like graph mutation;
-- empty or >8192-char search query;
-- boolean/string/zero/negative/>100 search limit;
-- path-like event/conversation/node identifiers.
+With a small configured body limit, exercise:
 
-Expected: `400` or `413` before corpus invocation, never `500` and never a mutation.
+- declared oversized `Content-Length`;
+- actual body larger than the limit;
+- absent `Content-Length` with streamed/chunked body;
+- deliberately understated `Content-Length` with streamed body;
+- malformed JSON;
+- non-object JSON.
 
-### Route/method surface
+All oversize variants return 413. Focused tests additionally prove the adapter is never invoked after the limit is exceeded.
 
-For both GET and POST where meaningful, probe:
+### Input confusion / smuggling
 
-- `/mcp`;
-- `/ingest`;
-- `/actions/propose`;
-- `/actions/validate`;
-- `/actions/commit`;
-- `/actions/redact`;
-- `/actions/write`;
-- `/admin`;
-- `/neo4j`;
-- `/graph`;
-- `/filesystem`;
-- arbitrary unknown path.
+- path-traversal-like event IDs;
+- Windows paths and `file://` identifiers;
+- extra `cypher`, `commit`, mutation, or capability-looking fields;
+- boolean/string/out-of-range search limits;
+- unsupported HTTP methods.
 
-Expected: `404` even with valid bearer auth.
+Expected: fail closed with bounded 400/405 behavior, never adapter capability widening.
 
-Probe allowed paths with unsupported methods. Expected: authenticated Action operations return `405`; `POST /openapi.json` returns `405` without auth.
+### Redaction behavior
 
-### Empty canonical corpus
+Construct both an event file and its redaction tombstone to model a partial/forensic state, plus an unrelated visible event. Prove:
 
-With an existing, empty `canonical/events` directory, authenticated search returns exactly `200 []`. No event file may be created and no fallback data source may fabricate content.
+- search for text only in redacted event bytes returns `[]`;
+- search for text only in the tombstone returns `[]`;
+- the unrelated visible event remains searchable;
+- read of the redacted event returns generic 404;
+- response does not reveal redaction reason/tombstone metadata.
 
-### OpenAPI / private GPT compatibility
+This prevents both `_redactions` path leakage and stale event-byte leakage.
 
-Validate the live schema with an independent OpenAPI 3.1 validator and assert:
+### Empty corpus
 
-- `components.schemas` is non-empty;
-- named request schemas exist;
-- successful response schemas resolve to objects with explicit properties;
-- `ErrorEnvelope` is used for errors;
-- exactly four Action paths exist;
-- operation IDs are unique/stable;
-- HTTP bearer security is declared;
-- no prohibited operation/path appears;
-- every advertised server URL is HTTPS;
-- no token/config/credential value appears.
+An empty canonical event directory is valid. Authenticated search returns exactly `200 []` and never fabricated corpus content.
 
-### Container/deployment holdout
+### Secret/configuration non-leakage
 
-Against a built image/container, independently inspect:
+Across schema, capabilities, authentication failures, malformed input, missing event reads, and redaction failures, responses must not contain the synthetic test token, temporary filesystem root, local `D:` deployment path, or environment variable names that disclose secret placement.
 
-- effective UID/GID are 10001;
-- Docker host publication is exactly `127.0.0.1:8787`;
-- `/var/lib/fossil` mount reports `RW=false`;
-- an in-container write probe fails and creates no host file;
-- image config/history contain no runtime credential;
-- application logs do not contain the runtime credential;
-- empty authenticated search returns `[]`;
-- prohibited routes remain `404`;
-- trusted-proxy test network can produce the intended HTTPS origin only from the explicitly trusted client IP.
+## Container holdout
 
-## Out-of-tree/private extensions
+The container workflow is a separate deployment-shaped holdout. It builds the real image and proves:
 
-A local integrator may add private holdouts for:
+- effective UID/GID 10001;
+- Docker host publication is `127.0.0.1` only;
+- canonical mount reports `RW=false` and rejects a write probe;
+- fixed-origin schema resists forged headers;
+- search/read honor a redaction negative-control fixture;
+- lineage and mutation routes remain 404;
+- trusted-proxy HTTPS origin works only from the configured Docker-network peer;
+- synthetic runtime token is absent from image history/config and application logs.
 
-- unusual duplicate-header normalization by the selected reverse proxy;
-- IPv6 trusted proxy CIDRs;
-- non-default HTTPS ports;
-- malformed Unicode host/query values;
-- container restart/reboot behavior under Docker Desktop;
-- tunnel-specific header normalization.
+## Mutation relationship
 
-Those tests should preserve the same normative invariants and must never embed a real credential.
+The targeted mutation runner executes this holdout plus architecture checks against one deliberate defect at a time. The run fails if any mutant survives or an anchor cannot be applied. New security behavior is not considered covered until an independently stated holdout kills the corresponding mutant.

--- a/docs/operations/CHATGPT-ACTION-INVARIANTS.md
+++ b/docs/operations/CHATGPT-ACTION-INVARIANTS.md
@@ -1,0 +1,93 @@
+# Security and behavior invariants — ChatGPT Action edge
+
+These invariants are normative and machine-testable.
+
+## Route and method invariants
+
+`INV-ROUTE-01` The only public application paths are `/openapi.json`, `/actions/search`, `/actions/read`, `/actions/lineage`, and `/actions/capabilities`.
+
+`INV-ROUTE-02` `GET /openapi.json` is the only unauthenticated success path.
+
+`INV-ROUTE-03` Search/read/lineage accept `POST` only. Capabilities accepts `GET` only. Unsupported methods return `405` when the caller is authenticated; `POST /openapi.json` returns `405` without requiring authentication.
+
+`INV-ROUTE-04` `/mcp`, `/ingest`, `/actions/propose`, `/actions/validate`, `/actions/commit`, `/actions/redact`, graph/Neo4j endpoints, admin endpoints, shell/filesystem endpoints, and unknown paths return `404` and never delegate to the corpus adapter.
+
+## Authentication invariants
+
+`INV-AUTH-01` Every `/actions/*` request requires `Authorization: Bearer <exact-token>`.
+
+`INV-AUTH-02` Missing, empty, malformed, duplicated/smuggled, wrong-scheme, wrong-case token values, leading/trailing-token changes, and incorrect tokens fail closed with `401` and `WWW-Authenticate: Bearer`.
+
+`INV-AUTH-03` Token comparison is constant-time via `hmac.compare_digest`.
+
+`INV-AUTH-04` The configured token must be trimmed and at least 32 characters. It is accepted only from runtime configuration and is never emitted by `/openapi.json`, capabilities, error bodies, logs produced by the application, or example configuration.
+
+## Request-validation invariants
+
+`INV-REQ-01` JSON request bodies default to a maximum of 65,536 bytes and the configured maximum must be between 1 and 1,048,576 bytes.
+
+`INV-REQ-02` Oversized declared or actual bodies return `413` before adapter invocation.
+
+`INV-REQ-03` Invalid UTF-8/JSON, non-object JSON, invalid `Content-Length`, empty required strings, and invalid parameter types return `400` before adapter invocation.
+
+`INV-REQ-04` Search `limit` is an integer from 1 through 100; booleans, strings, zero, negative values, and values above 100 are rejected.
+
+`INV-REQ-05` Extra JSON keys never create new capabilities. They are not converted into filesystem paths, graph queries, MCP calls, writes, shell commands, or service configuration.
+
+## Error invariants
+
+`INV-ERR-01` Errors use `{ "error": { "code": string, "detail": string } }`.
+
+`INV-ERR-02` Authorization failures are `401` or `403`; malformed requests are `400`; oversized bodies are `413`; unknown resources/routes are `404`; canonical-store unavailability is `503`; unexpected errors are generic `500` responses.
+
+`INV-ERR-03` Unexpected/OSError responses do not expose bearer tokens, stack traces, arbitrary host paths, environment values, or internal exception text.
+
+## Read-only data invariants
+
+`INV-DATA-01` The standalone Action server constructs `_ReadOnlyEventStore`, not `DurableEventStore`.
+
+`INV-DATA-02` `_ReadOnlyEventStore` provides no `commit`, `prepare`, `validate`, `redact`, `put`, `delete`, or mutation method.
+
+`INV-DATA-03` The production container mount for `/var/lib/fossil` is documented and smoke-tested as read-only. Container smoke must fail if the application requires write access to canonical data.
+
+`INV-DATA-04` The Action runtime does not initialize Neo4j or Graphiti and requires no Neo4j credential.
+
+## Container invariants
+
+`INV-CTR-01` The image executes as non-root UID/GID 10001.
+
+`INV-CTR-02` No bearer token or real secret is present in the Dockerfile, image command, repository example values, or CI configuration.
+
+`INV-CTR-03` The image entrypoint is `fossil-chatgpt-action`; it exposes only the Action process.
+
+`INV-CTR-04` Production examples bind/publish only the Action port and mount canonical data read-only.
+
+## HTTPS and proxy invariants
+
+`INV-HTTPS-01` A production public origin is represented by `FOSSIL_ACTION_PUBLIC_BASE_URL`, which must be an origin-only `https://` URL.
+
+`INV-HTTPS-02` When configured, `/openapi.json.servers[0].url` exactly equals `FOSSIL_ACTION_PUBLIC_BASE_URL` with no trailing slash.
+
+`INV-HTTPS-03` Caller-supplied `Forwarded`, `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-Port` cannot override the configured public origin. Uvicorn proxy-header processing is disabled by the application entrypoint.
+
+`INV-HTTPS-04` TLS termination, tunnels, DNS, and certificates are external deployment responsibilities. The repository never provisions them.
+
+## OpenAPI / Custom GPT invariants
+
+`INV-OAI-01` The document is OpenAPI 3.1.x and contains `info`, `paths`, `components.schemas`, and `components.securitySchemes` objects.
+
+`INV-OAI-02` `components.schemas` is a valid object and defines explicit `ErrorDetail`, `ErrorEnvelope`, `FossilRecord`, `LineageResponse`, and `CapabilitiesResponse` schemas.
+
+`INV-OAI-03` Every successful Action response has an explicit JSON schema with named properties or a `$ref` to such a schema; error responses use `ErrorEnvelope`.
+
+`INV-OAI-04` Operation IDs are stable and unique: `fossilSearch`, `fossilRead`, `fossilLineage`, `fossilActionCapabilities`.
+
+`INV-OAI-05` The generated `paths` object contains only the four authenticated Action paths. `/openapi.json` is the discovery document and is not described as an Action operation.
+
+`INV-OAI-06` The OpenAPI security scheme is HTTP bearer and all Action operations inherit bearer security.
+
+`INV-OAI-07` The schema contains no MCP, ingest, proposal, validation, commit, mutation, Neo4j, graph-admin, filesystem, secret, token value, or credential operation.
+
+## Rollback invariant
+
+`INV-RBK-01` Rollback requires only stopping/removing the Action container/process and reverting the PR/commit; canonical FOSSIL data is not migrated or mutated by this feature.

--- a/docs/operations/CHATGPT-ACTION-INVARIANTS.md
+++ b/docs/operations/CHATGPT-ACTION-INVARIANTS.md
@@ -1,105 +1,71 @@
 # Security and behavior invariants — FOSSIL ChatGPT Action
 
-These invariants are normative and must be covered by automated tests or container inspection.
+These are normative, machine-testable release invariants for the standalone Custom GPT Action.
 
-## Route and method invariants
+## Public surface
 
-`INV-ROUTE-01` The externally reachable application-path allowlist is exactly `/openapi.json`, `/actions/search`, `/actions/read`, `/actions/lineage`, and `/actions/capabilities`.
+1. The complete routable surface is exactly `GET /openapi.json`, `POST /actions/search`, `POST /actions/read`, and `GET /actions/capabilities`.
+2. `/openapi.json` is the only unauthenticated route.
+3. `/actions/lineage` is not routable or advertised until the standalone composition has a genuine read-only lineage provider.
+4. `/mcp`, `/ingest`, propose, validate, commit, promote, redact, write, admin, graph, Neo4j, filesystem, shell, and unknown paths return 404 for authenticated and unauthenticated callers.
+5. Unsupported methods on an allowlisted path return 405 and do not invoke the adapter.
 
-`INV-ROUTE-02` `GET /openapi.json` is the only unauthenticated success path and is not listed as an Action operation inside `paths`.
+## Authentication
 
-`INV-ROUTE-03` Search/read/lineage accept `POST` only. Capabilities accepts `GET` only. Authenticated unsupported methods return `405`; `POST /openapi.json` returns `405` without authentication.
+6. Every `/actions/*` route requires exactly one `Authorization` header with the HTTP bearer scheme and the exact opaque token.
+7. The bearer scheme comparison is case-insensitive; the token comparison is case-sensitive and constant-time.
+8. Missing, duplicate, wrong-scheme, whitespace-confused, or incorrect credentials return 401 plus `WWW-Authenticate: Bearer`.
+9. Authentication failures never reflect the token or runtime configuration.
 
-`INV-ROUTE-04` `/mcp`, `/ingest`, proposal, validation, commit, redaction, write, admin, Neo4j/graph, filesystem/shell, and every unknown path return `404` and never delegate to the corpus adapter.
+## Request validation and resource bounds
 
-## Authentication invariants
+10. Request JSON must be a UTF-8 object; malformed JSON and non-object JSON return 400.
+11. Search accepts only `query` and optional integer `limit`; read accepts only `event_id`. Extra fields are rejected.
+12. Search query is non-empty and at most 8192 characters. Limit is a non-boolean integer from 1 through 100.
+13. Event IDs must match the opaque identifier grammar before filesystem lookup; traversal/path syntax is rejected.
+14. `FOSSIL_ACTION_MAX_REQUEST_BYTES` defaults to 65536 and is bounded by server configuration.
+15. A declared `Content-Length` above the limit is rejected before adapter invocation.
+16. Independently of `Content-Length`, chunks are counted as they are read; the request is rejected immediately when cumulative bytes exceed the limit.
+17. Absent, chunked, or understated `Content-Length` cannot bypass the body limit. Oversize rejection returns 413 and the adapter is not invoked.
+18. Production Action request handling does not call `await request.body()`.
 
-`INV-AUTH-01` Every `/actions/*` request requires exactly one `Authorization: Bearer <token>` header.
+## Canonical-data and redaction invariants
 
-`INV-AUTH-02` Missing, empty, duplicated, smuggled, wrong-scheme, whitespace-mutated, and incorrect credentials return `401` with `WWW-Authenticate: Bearer`. Bearer scheme matching is case-insensitive; token bytes are exact.
+19. The standalone event-store view has read methods only; it exposes no commit, prepare, validate, redact, put, delete, publish, or write method.
+20. Canonical data is mounted into the production container read-only.
+21. `_redactions` directories and tombstone JSON are never yielded as normal events or search results.
+22. If an event has a redaction tombstone, search suppresses it even if the old event bytes remain on disk.
+23. Read of a redacted event returns generic 404 and does not expose redaction reason, authority, tombstone contents, or the fact pattern beyond not-found.
+24. An empty canonical event store is valid and authenticated search returns `200 []` without fabricated content.
 
-`INV-AUTH-03` Token comparison uses `hmac.compare_digest`.
+## OpenAPI / Custom GPT compatibility
 
-`INV-AUTH-04` The configured token is trimmed, at least 32 characters, runtime-only, and never appears in OpenAPI, responses, application logs, image layers, committed configuration, documentation examples, or PR metadata.
+25. `/openapi.json` emits OpenAPI 3.1 and passes `openapi-spec-validator`.
+26. `components.schemas` exists and is a non-empty object.
+27. Successful object response schemas declare explicit properties; schema references resolve.
+28. OpenAPI paths are exactly search, read, and capabilities; lineage and all mutation routes are absent.
+29. The capabilities schema and runtime response both report exactly `action_capabilities: ["search", "read"]` and all write/ingest/MCP/graph-mutation flags as false.
+30. Operation IDs are unique.
+31. The schema contains no bearer-token value, local filesystem path, credential example, HTTP public server URL, MCP route, mutation route, or graph/database escape hatch.
 
-## Request/identifier invariants
+## HTTPS origin and proxy trust
 
-`INV-REQ-01` JSON bodies default to a maximum of 65,536 bytes; configured size must be 1..1,048,576 bytes.
+32. A configured `FOSSIL_ACTION_PUBLIC_BASE_URL` must be an origin-only `https://` URL and is authoritative over request headers.
+33. When no fixed public origin is configured, only validated forwarded HTTPS origin metadata from a peer inside an explicit `FOSSIL_ACTION_TRUSTED_PROXY_CIDRS` network may define `servers[0].url`.
+34. Uvicorn global proxy-header trust remains disabled.
+35. A direct HTTPS request's `Host` header is never public-origin authority by itself.
+36. Forged, ambiguous, comma-chained, malformed, or untrusted forwarded host/proto metadata cannot influence the schema origin.
+37. If no trustworthy HTTPS origin exists, `/openapi.json` returns 503 and does not emit an HTTP or caller-controlled server URL.
 
-`INV-REQ-02` Oversized declared or actual bodies return `413` before adapter invocation.
+## Container / host boundary
 
-`INV-REQ-03` Invalid UTF-8/JSON, non-object JSON, invalid/negative `Content-Length`, missing required fields, extra fields, invalid types, and invalid ranges return `400` before adapter invocation.
+38. The production image runs as non-root UID/GID 10001.
+39. Docker Desktop publication is exactly loopback-only `127.0.0.1:8787:8787` in the documented target command/workflow.
+40. The canonical host data mount is `:ro`; an in-container write probe to it fails.
+41. No real runtime credential is present in image history, image configuration, repository examples, documentation examples, application responses, or application logs.
+42. The HTTPS reverse proxy/tunnel is external to the container; the repository does not create or manage real tunnel credentials.
 
-`INV-REQ-04` Search `limit` is an integer 1..100; booleans and numeric strings are rejected. Search query is non-empty and at most 8,192 characters.
+## Mutation assurance
 
-`INV-REQ-05` Event/conversation/node identifiers are bounded opaque identifiers with no slash, backslash, whitespace, URL, or path-traversal syntax. The filesystem event-store layer independently validates durable event IDs before constructing a path.
-
-`INV-REQ-06` Caller fields cannot create filesystem paths, graph queries, MCP calls, writes, shell commands, configuration changes, or new capabilities.
-
-## Error invariants
-
-`INV-ERR-01` JSON errors use `{ "error": { "code": string, "detail": string } }`.
-
-`INV-ERR-02` Auth failures are `401`/`403`; malformed requests `400`; oversized bodies `413`; unknown routes/resources `404`; unsupported methods `405`; unavailable canonical storage or HTTPS schema origin `503`; unexpected failures generic `500`.
-
-`INV-ERR-03` Error bodies do not expose bearer values, stack traces, Windows or Linux host paths, environment values, exception internals, tunnel credentials, or Custom GPT credentials.
-
-## Read-only data invariants
-
-`INV-DATA-01` The standalone Action server constructs `_ReadOnlyEventStore`, not `DurableEventStore`.
-
-`INV-DATA-02` `_ReadOnlyEventStore` has no `commit`, `prepare`, `validate`, `redact`, `put`, `delete`, or equivalent mutation operation.
-
-`INV-DATA-03` Production/container examples mount `/var/lib/fossil` read-only. Container CI inspects the mount as `RW=false` and verifies a write attempt fails.
-
-`INV-DATA-04` The Action runtime does not initialize Graphiti/Neo4j and requires no Neo4j credential or network access.
-
-`INV-DATA-05` An existing but empty `canonical/events` directory is valid; authenticated search returns `200 []` and no synthetic content is created.
-
-## Container and Windows-host invariants
-
-`INV-CTR-01` The image and running process use UID/GID 10001, never root.
-
-`INV-CTR-02` The image entrypoint is `fossil-chatgpt-action`; liveness uses the private TCP listener and adds no unauthenticated health route.
-
-`INV-CTR-03` The Docker image contains no bearer token or real secret. CI verifies the synthetic runtime token is absent from `docker history` and image configuration.
-
-`INV-CTR-04` The Windows/Docker Desktop launch contract publishes container 8787 only as `127.0.0.1:8787`; container inspection must report host IP `127.0.0.1`.
-
-`INV-CTR-05` Persistent source, data, and secrets remain under `D:\FossilBrokerWorker\chatgpt-action\`; Docker Desktop's Linux engine is the runtime. Podman/systemd are not required.
-
-## HTTPS and proxy invariants
-
-`INV-HTTPS-01` A fixed `FOSSIL_ACTION_PUBLIC_BASE_URL`, when present, is an origin-only `https://` URL and is authoritative.
-
-`INV-HTTPS-02` Fixed public origin cannot be overridden by `Forwarded`, `X-Forwarded-Proto`, `X-Forwarded-Host`, or `X-Forwarded-Port`.
-
-`INV-HTTPS-03` Without a fixed origin, direct HTTPS may define the schema origin.
-
-`INV-HTTPS-04` On an internal HTTP hop, forwarded HTTPS origin is accepted only when the request peer matches one of the explicit `FOSSIL_ACTION_TRUSTED_PROXY_CIDRS`, `X-Forwarded-Proto` is exactly one HTTPS value, and `X-Forwarded-Host` is exactly one syntactically valid host value.
-
-`INV-HTTPS-05` Forwarded headers from untrusted peers, wildcard/spoof chains, comma-separated values, missing headers, `http` proto, malformed host, or ambiguous proxy data are ignored. If no trusted HTTPS origin remains, `/openapi.json` returns `503`; it never publishes `http://`.
-
-`INV-HTTPS-06` Uvicorn global proxy-header processing remains disabled (`proxy_headers=False`). Application code performs the bounded source-CIDR check.
-
-`INV-HTTPS-07` Tunnel/DNS/TLS/provider credentials and provisioning are outside this repository and are never created by CI.
-
-## OpenAPI / Custom GPT invariants
-
-`INV-OAI-01` Generated OpenAPI is 3.1.x and validates with `openapi-spec-validator`.
-
-`INV-OAI-02` `components.schemas` is a non-empty object defining explicit request, error, search-result, durable-event, lineage-node/citation/response, and capability schemas.
-
-`INV-OAI-03` Every successful response resolves to an object schema with declared properties (or an array of such objects); error responses resolve to `ErrorEnvelope`.
-
-`INV-OAI-04` Operation IDs are stable and unique: `fossilSearch`, `fossilRead`, `fossilLineage`, `fossilActionCapabilities`.
-
-`INV-OAI-05` `paths` contains only the four authenticated Action paths and no discovery/private/mutation path.
-
-`INV-OAI-06` The security scheme is HTTP bearer and every Action operation inherits bearer security.
-
-`INV-OAI-07` OpenAPI contains no token value, secret example, MCP/ingest/propose/validate/commit/redact/graph/filesystem/admin operation, or HTTP public server URL.
-
-## Rollback invariant
-
-`INV-RBK-01` Rollback consists of stopping/removing the Action container and reverting the image/PR commit. No canonical-data migration or reverse migration is required because this feature is read-only.
+43. The targeted mutation runner must fail the release if any defined security mutant survives or any mutation anchor cannot be applied.
+44. Mutants cover bearer bypass, route widening, lineage reintroduction, write-route exposure, declared and streaming size-check removal, validation weakening, proxy over-trust, direct-Host trust, HTTP schema origin, OpenAPI schema regressions, redaction re-inclusion, mutable store methods, root container execution, writable canonical mount, and non-loopback publication.

--- a/docs/operations/CHATGPT-ACTION-INVARIANTS.md
+++ b/docs/operations/CHATGPT-ACTION-INVARIANTS.md
@@ -1,93 +1,105 @@
-# Security and behavior invariants — ChatGPT Action edge
+# Security and behavior invariants — FOSSIL ChatGPT Action
 
-These invariants are normative and machine-testable.
+These invariants are normative and must be covered by automated tests or container inspection.
 
 ## Route and method invariants
 
-`INV-ROUTE-01` The only public application paths are `/openapi.json`, `/actions/search`, `/actions/read`, `/actions/lineage`, and `/actions/capabilities`.
+`INV-ROUTE-01` The externally reachable application-path allowlist is exactly `/openapi.json`, `/actions/search`, `/actions/read`, `/actions/lineage`, and `/actions/capabilities`.
 
-`INV-ROUTE-02` `GET /openapi.json` is the only unauthenticated success path.
+`INV-ROUTE-02` `GET /openapi.json` is the only unauthenticated success path and is not listed as an Action operation inside `paths`.
 
-`INV-ROUTE-03` Search/read/lineage accept `POST` only. Capabilities accepts `GET` only. Unsupported methods return `405` when the caller is authenticated; `POST /openapi.json` returns `405` without requiring authentication.
+`INV-ROUTE-03` Search/read/lineage accept `POST` only. Capabilities accepts `GET` only. Authenticated unsupported methods return `405`; `POST /openapi.json` returns `405` without authentication.
 
-`INV-ROUTE-04` `/mcp`, `/ingest`, `/actions/propose`, `/actions/validate`, `/actions/commit`, `/actions/redact`, graph/Neo4j endpoints, admin endpoints, shell/filesystem endpoints, and unknown paths return `404` and never delegate to the corpus adapter.
+`INV-ROUTE-04` `/mcp`, `/ingest`, proposal, validation, commit, redaction, write, admin, Neo4j/graph, filesystem/shell, and every unknown path return `404` and never delegate to the corpus adapter.
 
 ## Authentication invariants
 
-`INV-AUTH-01` Every `/actions/*` request requires `Authorization: Bearer <exact-token>`.
+`INV-AUTH-01` Every `/actions/*` request requires exactly one `Authorization: Bearer <token>` header.
 
-`INV-AUTH-02` Missing, empty, malformed, duplicated/smuggled, wrong-scheme, wrong-case token values, leading/trailing-token changes, and incorrect tokens fail closed with `401` and `WWW-Authenticate: Bearer`.
+`INV-AUTH-02` Missing, empty, duplicated, smuggled, wrong-scheme, whitespace-mutated, and incorrect credentials return `401` with `WWW-Authenticate: Bearer`. Bearer scheme matching is case-insensitive; token bytes are exact.
 
-`INV-AUTH-03` Token comparison is constant-time via `hmac.compare_digest`.
+`INV-AUTH-03` Token comparison uses `hmac.compare_digest`.
 
-`INV-AUTH-04` The configured token must be trimmed and at least 32 characters. It is accepted only from runtime configuration and is never emitted by `/openapi.json`, capabilities, error bodies, logs produced by the application, or example configuration.
+`INV-AUTH-04` The configured token is trimmed, at least 32 characters, runtime-only, and never appears in OpenAPI, responses, application logs, image layers, committed configuration, documentation examples, or PR metadata.
 
-## Request-validation invariants
+## Request/identifier invariants
 
-`INV-REQ-01` JSON request bodies default to a maximum of 65,536 bytes and the configured maximum must be between 1 and 1,048,576 bytes.
+`INV-REQ-01` JSON bodies default to a maximum of 65,536 bytes; configured size must be 1..1,048,576 bytes.
 
 `INV-REQ-02` Oversized declared or actual bodies return `413` before adapter invocation.
 
-`INV-REQ-03` Invalid UTF-8/JSON, non-object JSON, invalid `Content-Length`, empty required strings, and invalid parameter types return `400` before adapter invocation.
+`INV-REQ-03` Invalid UTF-8/JSON, non-object JSON, invalid/negative `Content-Length`, missing required fields, extra fields, invalid types, and invalid ranges return `400` before adapter invocation.
 
-`INV-REQ-04` Search `limit` is an integer from 1 through 100; booleans, strings, zero, negative values, and values above 100 are rejected.
+`INV-REQ-04` Search `limit` is an integer 1..100; booleans and numeric strings are rejected. Search query is non-empty and at most 8,192 characters.
 
-`INV-REQ-05` Extra JSON keys never create new capabilities. They are not converted into filesystem paths, graph queries, MCP calls, writes, shell commands, or service configuration.
+`INV-REQ-05` Event/conversation/node identifiers are bounded opaque identifiers with no slash, backslash, whitespace, URL, or path-traversal syntax. The filesystem event-store layer independently validates durable event IDs before constructing a path.
+
+`INV-REQ-06` Caller fields cannot create filesystem paths, graph queries, MCP calls, writes, shell commands, configuration changes, or new capabilities.
 
 ## Error invariants
 
-`INV-ERR-01` Errors use `{ "error": { "code": string, "detail": string } }`.
+`INV-ERR-01` JSON errors use `{ "error": { "code": string, "detail": string } }`.
 
-`INV-ERR-02` Authorization failures are `401` or `403`; malformed requests are `400`; oversized bodies are `413`; unknown resources/routes are `404`; canonical-store unavailability is `503`; unexpected errors are generic `500` responses.
+`INV-ERR-02` Auth failures are `401`/`403`; malformed requests `400`; oversized bodies `413`; unknown routes/resources `404`; unsupported methods `405`; unavailable canonical storage or HTTPS schema origin `503`; unexpected failures generic `500`.
 
-`INV-ERR-03` Unexpected/OSError responses do not expose bearer tokens, stack traces, arbitrary host paths, environment values, or internal exception text.
+`INV-ERR-03` Error bodies do not expose bearer values, stack traces, Windows or Linux host paths, environment values, exception internals, tunnel credentials, or Custom GPT credentials.
 
 ## Read-only data invariants
 
 `INV-DATA-01` The standalone Action server constructs `_ReadOnlyEventStore`, not `DurableEventStore`.
 
-`INV-DATA-02` `_ReadOnlyEventStore` provides no `commit`, `prepare`, `validate`, `redact`, `put`, `delete`, or mutation method.
+`INV-DATA-02` `_ReadOnlyEventStore` has no `commit`, `prepare`, `validate`, `redact`, `put`, `delete`, or equivalent mutation operation.
 
-`INV-DATA-03` The production container mount for `/var/lib/fossil` is documented and smoke-tested as read-only. Container smoke must fail if the application requires write access to canonical data.
+`INV-DATA-03` Production/container examples mount `/var/lib/fossil` read-only. Container CI inspects the mount as `RW=false` and verifies a write attempt fails.
 
-`INV-DATA-04` The Action runtime does not initialize Neo4j or Graphiti and requires no Neo4j credential.
+`INV-DATA-04` The Action runtime does not initialize Graphiti/Neo4j and requires no Neo4j credential or network access.
 
-## Container invariants
+`INV-DATA-05` An existing but empty `canonical/events` directory is valid; authenticated search returns `200 []` and no synthetic content is created.
 
-`INV-CTR-01` The image executes as non-root UID/GID 10001.
+## Container and Windows-host invariants
 
-`INV-CTR-02` No bearer token or real secret is present in the Dockerfile, image command, repository example values, or CI configuration.
+`INV-CTR-01` The image and running process use UID/GID 10001, never root.
 
-`INV-CTR-03` The image entrypoint is `fossil-chatgpt-action`; it exposes only the Action process.
+`INV-CTR-02` The image entrypoint is `fossil-chatgpt-action`; liveness uses the private TCP listener and adds no unauthenticated health route.
 
-`INV-CTR-04` Production examples bind/publish only the Action port and mount canonical data read-only.
+`INV-CTR-03` The Docker image contains no bearer token or real secret. CI verifies the synthetic runtime token is absent from `docker history` and image configuration.
+
+`INV-CTR-04` The Windows/Docker Desktop launch contract publishes container 8787 only as `127.0.0.1:8787`; container inspection must report host IP `127.0.0.1`.
+
+`INV-CTR-05` Persistent source, data, and secrets remain under `D:\FossilBrokerWorker\chatgpt-action\`; Docker Desktop's Linux engine is the runtime. Podman/systemd are not required.
 
 ## HTTPS and proxy invariants
 
-`INV-HTTPS-01` A production public origin is represented by `FOSSIL_ACTION_PUBLIC_BASE_URL`, which must be an origin-only `https://` URL.
+`INV-HTTPS-01` A fixed `FOSSIL_ACTION_PUBLIC_BASE_URL`, when present, is an origin-only `https://` URL and is authoritative.
 
-`INV-HTTPS-02` When configured, `/openapi.json.servers[0].url` exactly equals `FOSSIL_ACTION_PUBLIC_BASE_URL` with no trailing slash.
+`INV-HTTPS-02` Fixed public origin cannot be overridden by `Forwarded`, `X-Forwarded-Proto`, `X-Forwarded-Host`, or `X-Forwarded-Port`.
 
-`INV-HTTPS-03` Caller-supplied `Forwarded`, `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-Port` cannot override the configured public origin. Uvicorn proxy-header processing is disabled by the application entrypoint.
+`INV-HTTPS-03` Without a fixed origin, direct HTTPS may define the schema origin.
 
-`INV-HTTPS-04` TLS termination, tunnels, DNS, and certificates are external deployment responsibilities. The repository never provisions them.
+`INV-HTTPS-04` On an internal HTTP hop, forwarded HTTPS origin is accepted only when the request peer matches one of the explicit `FOSSIL_ACTION_TRUSTED_PROXY_CIDRS`, `X-Forwarded-Proto` is exactly one HTTPS value, and `X-Forwarded-Host` is exactly one syntactically valid host value.
+
+`INV-HTTPS-05` Forwarded headers from untrusted peers, wildcard/spoof chains, comma-separated values, missing headers, `http` proto, malformed host, or ambiguous proxy data are ignored. If no trusted HTTPS origin remains, `/openapi.json` returns `503`; it never publishes `http://`.
+
+`INV-HTTPS-06` Uvicorn global proxy-header processing remains disabled (`proxy_headers=False`). Application code performs the bounded source-CIDR check.
+
+`INV-HTTPS-07` Tunnel/DNS/TLS/provider credentials and provisioning are outside this repository and are never created by CI.
 
 ## OpenAPI / Custom GPT invariants
 
-`INV-OAI-01` The document is OpenAPI 3.1.x and contains `info`, `paths`, `components.schemas`, and `components.securitySchemes` objects.
+`INV-OAI-01` Generated OpenAPI is 3.1.x and validates with `openapi-spec-validator`.
 
-`INV-OAI-02` `components.schemas` is a valid object and defines explicit `ErrorDetail`, `ErrorEnvelope`, `FossilRecord`, `LineageResponse`, and `CapabilitiesResponse` schemas.
+`INV-OAI-02` `components.schemas` is a non-empty object defining explicit request, error, search-result, durable-event, lineage-node/citation/response, and capability schemas.
 
-`INV-OAI-03` Every successful Action response has an explicit JSON schema with named properties or a `$ref` to such a schema; error responses use `ErrorEnvelope`.
+`INV-OAI-03` Every successful response resolves to an object schema with declared properties (or an array of such objects); error responses resolve to `ErrorEnvelope`.
 
 `INV-OAI-04` Operation IDs are stable and unique: `fossilSearch`, `fossilRead`, `fossilLineage`, `fossilActionCapabilities`.
 
-`INV-OAI-05` The generated `paths` object contains only the four authenticated Action paths. `/openapi.json` is the discovery document and is not described as an Action operation.
+`INV-OAI-05` `paths` contains only the four authenticated Action paths and no discovery/private/mutation path.
 
-`INV-OAI-06` The OpenAPI security scheme is HTTP bearer and all Action operations inherit bearer security.
+`INV-OAI-06` The security scheme is HTTP bearer and every Action operation inherits bearer security.
 
-`INV-OAI-07` The schema contains no MCP, ingest, proposal, validation, commit, mutation, Neo4j, graph-admin, filesystem, secret, token value, or credential operation.
+`INV-OAI-07` OpenAPI contains no token value, secret example, MCP/ingest/propose/validate/commit/redact/graph/filesystem/admin operation, or HTTP public server URL.
 
 ## Rollback invariant
 
-`INV-RBK-01` Rollback requires only stopping/removing the Action container/process and reverting the PR/commit; canonical FOSSIL data is not migrated or mutated by this feature.
+`INV-RBK-01` Rollback consists of stopping/removing the Action container and reverting the image/PR commit. No canonical-data migration or reverse migration is required because this feature is read-only.

--- a/docs/operations/CHATGPT-ACTION-PDD.md
+++ b/docs/operations/CHATGPT-ACTION-PDD.md
@@ -1,12 +1,42 @@
-# PDD — Read-only ChatGPT Action edge
+# PDD — FOSSIL read-only ChatGPT Action
 
-## User-visible problem
+## Problem statement and intended users
 
-A private ChatGPT Custom GPT needs a narrow, auditable way to retrieve knowledge from FOSSIL without gaining any durable write, ingestion, MCP, database, graph-mutation, or filesystem capability. The integration must be deployable by a local integrator while preserving FOSSIL as the canonical authority and keeping all credentials host-local.
+A private ChatGPT Custom GPT needs a narrow, auditable retrieval interface to FOSSIL without receiving any durable-write, ingestion, MCP, graph-mutation, shell, or arbitrary-filesystem capability. The intended operator is a local integrator running `Pukujan/fossil-core` on one Windows PC and exposing only this bounded Action service through an independently managed HTTPS reverse proxy or tunnel.
 
-## Scope
+The visible user experience is limited to asking the private GPT to search readable FOSSIL knowledge, read a known durable event, inspect conversation lineage, or describe the Action's read-only capabilities.
 
-The Action edge provides exactly five user-visible capabilities:
+## Target environment
+
+The supported target for PR #235 is specific:
+
+- host OS: Windows;
+- Linux container runtime: Docker Desktop with the WSL 2 backend;
+- installed WSL distributions include Ubuntu and Ubuntu-22.04 on `D:`;
+- Docker Desktop WSL storage is on `D:\DockerDesktopWSL`;
+- Docker integration inside the Ubuntu distribution is **not required** and must not be assumed;
+- Podman is not installed and is not a dependency;
+- Linux-native systemd/Quadlet and cloud-VM deployment are non-goals;
+- Docker lifecycle commands are expected to run from Windows/PowerShell against Docker Desktop's Linux engine;
+- source, canonical data, and local runtime secret material remain under `D:\FossilBrokerWorker\chatgpt-action\`.
+
+Required host layout:
+
+```text
+D:\FossilBrokerWorker\chatgpt-action\
+  fossil-core\
+  data\
+    canonical\
+      events\
+  secrets\
+    chatgpt-action.env
+```
+
+The populated `secrets\chatgpt-action.env` is local-only and must never be committed.
+
+## Scope: normative read-only boundary
+
+The Action edge provides exactly five externally visible paths:
 
 1. unauthenticated OpenAPI discovery at `GET /openapi.json`;
 2. bearer-authenticated search at `POST /actions/search`;
@@ -14,63 +44,99 @@ The Action edge provides exactly five user-visible capabilities:
 4. bearer-authenticated lineage read at `POST /actions/lineage`;
 5. bearer-authenticated capability metadata at `GET /actions/capabilities`.
 
-The edge reuses FOSSIL pack authorization and corpus read semantics. It does not introduce a second semantic authority and does not require Neo4j or Graphiti.
+The OpenAPI document contains only the four authenticated Action operations. `/openapi.json` is discovery, not an Action operation.
 
-## Non-goals
+The service reuses FOSSIL pack and skill authorization and reads canonical event files through an Action-specific read-only event-store view. It does not require Neo4j or Graphiti.
+
+## Non-goals and explicit prohibitions
 
 The Action edge MUST NOT expose or implement:
 
-- MCP transport or `/mcp`;
+- MCP transport, `/mcp`, MCP discovery, or MCP tool execution;
 - reviewed ingestion or `/ingest`;
-- proposal, validation, commit, redaction, or other durable mutation;
-- Graphiti or Neo4j query/mutation APIs;
-- arbitrary graph traversal outside the canonical lineage/search contracts;
-- arbitrary filesystem paths, file reads, file writes, shell execution, or process control;
-- credential creation, storage, display, logging, or transport beyond the bearer header supplied by the caller;
-- tunnel, DNS, TLS certificate, reverse-proxy, Custom GPT, or account provisioning;
-- public deployment from CI.
+- proposal, validation, commit, redaction, deletion, or any durable mutation;
+- write, admin, management, shell, process-control, or arbitrary command endpoints;
+- Graphiti or Neo4j query/mutation/admin APIs;
+- arbitrary graph mutation or unrestricted graph-query strings;
+- caller-selected filesystem paths, arbitrary file reads/writes, directory listing, or path traversal;
+- runtime configuration, environment-variable, bearer-token, tunnel credential, account credential, or Custom GPT credential disclosure;
+- creation or operation of a public tunnel, DNS name, TLS certificate, reverse proxy, or Custom GPT;
+- public deployment from CI;
+- Podman, systemd, Quadlet, Kubernetes, or a cloud VM.
+
+These prohibitions remain in force for authenticated callers.
 
 ## Threat model
 
-### Adversaries and failure modes
+The public HTTPS origin is assumed to receive hostile traffic. Relevant threats include:
 
-The boundary assumes an internet-reachable HTTPS origin may receive hostile requests. Relevant threats include:
+- missing, malformed, duplicated, smuggled, or incorrect bearer authorization;
+- unsupported HTTP methods and unknown/prohibited route probing;
+- oversized bodies, invalid UTF-8, malformed JSON, type/range confusion, and extra-field capability smuggling;
+- path traversal through event/conversation/node identifiers;
+- attempts to smuggle graph queries or write instructions through otherwise valid JSON;
+- forged `Forwarded`/`X-Forwarded-*` headers intended to make `/openapi.json` advertise an attacker-controlled or plain-HTTP origin;
+- accidental root execution;
+- accidental writable canonical-data mounts;
+- accidental public binding of the container port to all host interfaces;
+- exception/error leakage of local Windows/Linux paths, environment data, secrets, or stack traces;
+- OpenAPI regressions that make GPT Action import ambiguous or silently widen capabilities;
+- image-layer, CI-log, documentation, or fixture leakage of a real secret;
+- implementation drift that enables MCP, ingest, proposal, validation, commit, redaction, graph mutation, or filesystem access.
 
-- unauthenticated callers attempting corpus reads;
-- malformed or ambiguous bearer headers;
-- oversized bodies intended to consume memory;
-- requests to hidden/private FOSSIL routes;
-- method confusion such as `GET /actions/search` or `POST /openapi.json`;
-- payload fields attempting to smuggle filesystem paths, graph queries, write commands, or MCP instructions;
-- forged `X-Forwarded-*` headers intended to alter the OpenAPI origin;
-- accidental execution as root or with a writable canonical-data mount;
-- error messages leaking secrets, local paths, or internal exception details;
-- OpenAPI regressions that make the schema unsuitable for Custom GPT Action import;
-- implementation drift that silently widens the route or capability allowlist.
-
-### Out of scope threats
-
-Host compromise, compromise of the reverse proxy/tunnel provider, theft of a real bearer token, or compromise of the ChatGPT account are deployment/operator concerns. The package documents mitigations but does not provision or operate those systems.
+Host compromise, reverse-proxy/tunnel-provider compromise, theft of a real bearer token, and compromise of the ChatGPT account remain operator/security-operations concerns. This PR reduces blast radius but cannot solve a compromised trusted host or credential.
 
 ## Trust boundaries
 
-1. **Public HTTPS boundary** — an operator-managed reverse proxy or tunnel terminates TLS. It MUST forward only to the Action process.
-2. **Action process boundary** — the process accepts only the five scoped capabilities above. It MUST ignore untrusted forwarded headers for schema generation.
-3. **Authentication boundary** — every `/actions/*` operation requires one configured bearer token. `/openapi.json` is deliberately public and contains no secret.
-4. **Authorization boundary** — authorized requests still pass through FOSSIL pack and skill authorization.
-5. **Canonical-data boundary** — the container/process receives the canonical event tree read-only. The Action-specific event-store adapter exposes only `get`, `iter_events`, and redaction-state reads; no commit/redact API exists on that adapter.
-6. **Projection boundary** — Neo4j/Graphiti are not dependencies of the Action edge and are never exposed through it.
-7. **Operator boundary** — real secrets, public endpoint provisioning, DNS/TLS, and Custom GPT credentials remain outside Git and outside this package.
+1. **Public HTTPS boundary.** An operator-managed tunnel/reverse proxy terminates TLS and forwards only to the Windows loopback listener for this Action service.
+2. **Windows loopback boundary.** Docker publishes container port 8787 only as `127.0.0.1:8787`; it must not be bound to `0.0.0.0`, `::`, or a LAN address on the Windows host.
+3. **Proxy-origin boundary.** The OpenAPI origin is either a fixed operator-configured `https://` origin or is derived from `X-Forwarded-Proto` + `X-Forwarded-Host` only when the request peer is inside an explicit trusted proxy CIDR. Uvicorn's global proxy-header trust remains disabled.
+4. **Authentication boundary.** Every `/actions/*` request requires exactly one valid bearer header. `/openapi.json` is public and contains no secret.
+5. **Authorization boundary.** Authenticated requests still pass through FOSSIL skill and pack-read authorization.
+6. **Canonical-data boundary.** `D:\...\data` is bind-mounted at `/var/lib/fossil` read-only. The Action event-store view provides read operations only and has no commit/redact API.
+7. **Projection boundary.** Neo4j/Graphiti are not initialized and are not reachable through this service.
+8. **Operator-secret boundary.** Real bearer/tunnel/Custom-GPT credentials exist only in operator-controlled local systems and are outside Git, CI, docs, tests, issues, and this implementation package.
+
+## Secret handling
+
+The repository contains only variable names and clearly non-secret example placeholders. The real bearer token is generated and stored by the local integrator after code review in:
+
+```text
+D:\FossilBrokerWorker\chatgpt-action\secrets\chatgpt-action.env
+```
+
+The application does not return the token, log request authorization headers, add token examples to OpenAPI, or embed a token in the image. CI may use a clearly synthetic test-only string that is not a credential.
+
+## HTTPS/reverse-proxy assumptions
+
+The Action process itself listens on HTTP inside the Docker/host-local boundary. The public endpoint MUST be HTTPS.
+
+Schema-origin precedence is fail-closed:
+
+1. a configured `FOSSIL_ACTION_PUBLIC_BASE_URL` (must be origin-only HTTPS) is authoritative and forwarded headers cannot override it;
+2. otherwise a direct HTTPS request may define the origin;
+3. otherwise `X-Forwarded-Proto: https` plus one `X-Forwarded-Host` may define the origin only when the request peer matches `FOSSIL_ACTION_TRUSTED_PROXY_CIDRS`;
+4. otherwise `GET /openapi.json` returns `503` rather than advertising an internal HTTP URL.
+
+Never configure a wildcard trusted proxy CIDR merely to make schema generation work.
+
+## Data availability and empty-corpus behavior
+
+The current target canonical event directory is empty. That is valid. If `data\canonical\events` exists and is readable but contains no events, authenticated `POST /actions/search` returns HTTP `200` with `[]`. The service must not fabricate corpus content, seed fake events, query Neo4j as a fallback, or convert an empty corpus into an error.
+
+If the canonical event directory itself is missing or inaccessible, startup/reads fail rather than silently creating or mutating canonical state.
 
 ## Deployment assumptions
 
-- A local integrator may clone the PR from Windows/WSL with the repository and canonical data located on `D:` and bind-mounted into Linux/Podman/Docker paths.
-- The Action container runs as a non-root UID.
-- Canonical data is mounted read-only.
-- TLS is terminated upstream; the Action service itself can listen on a private/loopback or container-network HTTP socket.
-- `FOSSIL_ACTION_PUBLIC_BASE_URL` is set to the externally reachable `https://` origin. The service does not trust caller-supplied `X-Forwarded-Proto` or `X-Forwarded-Host` when generating OpenAPI.
-- The operator supplies the bearer token at runtime from a host-local secret mechanism; no real value belongs in Git, CI, issue comments, docs, or chat transcripts.
+The local integrator will:
 
-## Read-only boundary
+- clone/check out PR #235 under the required `D:` layout;
+- run the verification suite;
+- build the Linux image using Docker Desktop from Windows;
+- create the real local env file and secret outside source control;
+- mount `D:\...\data` read-only;
+- publish the container port only to Windows `127.0.0.1:8787`;
+- establish the public HTTPS reverse-proxy/tunnel separately;
+- import `/openapi.json` into a private Custom GPT and configure authentication there.
 
-The boundary is normative: only OpenAPI discovery, search, durable-event read, lineage, and capability metadata are permitted. MCP, ingest, proposal, validation, commit, graph mutation, arbitrary filesystem access, and secret exposure are prohibited even for authenticated callers.
+This PR performs none of those deployment/account/credential actions.

--- a/docs/operations/CHATGPT-ACTION-PDD.md
+++ b/docs/operations/CHATGPT-ACTION-PDD.md
@@ -1,0 +1,76 @@
+# PDD — Read-only ChatGPT Action edge
+
+## User-visible problem
+
+A private ChatGPT Custom GPT needs a narrow, auditable way to retrieve knowledge from FOSSIL without gaining any durable write, ingestion, MCP, database, graph-mutation, or filesystem capability. The integration must be deployable by a local integrator while preserving FOSSIL as the canonical authority and keeping all credentials host-local.
+
+## Scope
+
+The Action edge provides exactly five user-visible capabilities:
+
+1. unauthenticated OpenAPI discovery at `GET /openapi.json`;
+2. bearer-authenticated search at `POST /actions/search`;
+3. bearer-authenticated durable-event read at `POST /actions/read`;
+4. bearer-authenticated lineage read at `POST /actions/lineage`;
+5. bearer-authenticated capability metadata at `GET /actions/capabilities`.
+
+The edge reuses FOSSIL pack authorization and corpus read semantics. It does not introduce a second semantic authority and does not require Neo4j or Graphiti.
+
+## Non-goals
+
+The Action edge MUST NOT expose or implement:
+
+- MCP transport or `/mcp`;
+- reviewed ingestion or `/ingest`;
+- proposal, validation, commit, redaction, or other durable mutation;
+- Graphiti or Neo4j query/mutation APIs;
+- arbitrary graph traversal outside the canonical lineage/search contracts;
+- arbitrary filesystem paths, file reads, file writes, shell execution, or process control;
+- credential creation, storage, display, logging, or transport beyond the bearer header supplied by the caller;
+- tunnel, DNS, TLS certificate, reverse-proxy, Custom GPT, or account provisioning;
+- public deployment from CI.
+
+## Threat model
+
+### Adversaries and failure modes
+
+The boundary assumes an internet-reachable HTTPS origin may receive hostile requests. Relevant threats include:
+
+- unauthenticated callers attempting corpus reads;
+- malformed or ambiguous bearer headers;
+- oversized bodies intended to consume memory;
+- requests to hidden/private FOSSIL routes;
+- method confusion such as `GET /actions/search` or `POST /openapi.json`;
+- payload fields attempting to smuggle filesystem paths, graph queries, write commands, or MCP instructions;
+- forged `X-Forwarded-*` headers intended to alter the OpenAPI origin;
+- accidental execution as root or with a writable canonical-data mount;
+- error messages leaking secrets, local paths, or internal exception details;
+- OpenAPI regressions that make the schema unsuitable for Custom GPT Action import;
+- implementation drift that silently widens the route or capability allowlist.
+
+### Out of scope threats
+
+Host compromise, compromise of the reverse proxy/tunnel provider, theft of a real bearer token, or compromise of the ChatGPT account are deployment/operator concerns. The package documents mitigations but does not provision or operate those systems.
+
+## Trust boundaries
+
+1. **Public HTTPS boundary** — an operator-managed reverse proxy or tunnel terminates TLS. It MUST forward only to the Action process.
+2. **Action process boundary** — the process accepts only the five scoped capabilities above. It MUST ignore untrusted forwarded headers for schema generation.
+3. **Authentication boundary** — every `/actions/*` operation requires one configured bearer token. `/openapi.json` is deliberately public and contains no secret.
+4. **Authorization boundary** — authorized requests still pass through FOSSIL pack and skill authorization.
+5. **Canonical-data boundary** — the container/process receives the canonical event tree read-only. The Action-specific event-store adapter exposes only `get`, `iter_events`, and redaction-state reads; no commit/redact API exists on that adapter.
+6. **Projection boundary** — Neo4j/Graphiti are not dependencies of the Action edge and are never exposed through it.
+7. **Operator boundary** — real secrets, public endpoint provisioning, DNS/TLS, and Custom GPT credentials remain outside Git and outside this package.
+
+## Deployment assumptions
+
+- A local integrator may clone the PR from Windows/WSL with the repository and canonical data located on `D:` and bind-mounted into Linux/Podman/Docker paths.
+- The Action container runs as a non-root UID.
+- Canonical data is mounted read-only.
+- TLS is terminated upstream; the Action service itself can listen on a private/loopback or container-network HTTP socket.
+- `FOSSIL_ACTION_PUBLIC_BASE_URL` is set to the externally reachable `https://` origin. The service does not trust caller-supplied `X-Forwarded-Proto` or `X-Forwarded-Host` when generating OpenAPI.
+- The operator supplies the bearer token at runtime from a host-local secret mechanism; no real value belongs in Git, CI, issue comments, docs, or chat transcripts.
+
+## Read-only boundary
+
+The boundary is normative: only OpenAPI discovery, search, durable-event read, lineage, and capability metadata are permitted. MCP, ingest, proposal, validation, commit, graph mutation, arbitrary filesystem access, and secret exposure are prohibited even for authenticated callers.

--- a/docs/operations/CHATGPT-ACTION-PDD.md
+++ b/docs/operations/CHATGPT-ACTION-PDD.md
@@ -1,26 +1,67 @@
 # PDD — FOSSIL read-only ChatGPT Action
 
+## Status
+
+This document describes the standalone Custom GPT Action deployed from PR #235. It is a security boundary, not a general FOSSIL HTTP API.
+
 ## Problem statement and intended users
 
-A private ChatGPT Custom GPT needs a narrow, auditable retrieval interface to FOSSIL without receiving any durable-write, ingestion, MCP, graph-mutation, shell, or arbitrary-filesystem capability. The intended operator is a local integrator running `Pukujan/fossil-core` on one Windows PC and exposing only this bounded Action service through an independently managed HTTPS reverse proxy or tunnel.
+A private ChatGPT Custom GPT needs a narrow, auditable retrieval interface to FOSSIL without receiving durable-write, ingestion, MCP, graph-mutation, shell, or arbitrary-filesystem capability. The intended operator is a local integrator running `Pukujan/fossil-core` with Docker Desktop's WSL 2 Linux engine on Windows and exposing only the loopback-bound Action service through an independently managed HTTPS reverse proxy or tunnel.
 
-The visible user experience is limited to asking the private GPT to search readable FOSSIL knowledge, read a known durable event, inspect conversation lineage, or describe the Action's read-only capabilities.
+The user-visible behavior is intentionally small: search readable durable FOSSIL events, read one known durable event, and inspect bounded capability metadata.
 
-## Target environment
+## Product scope
 
-The supported target for PR #235 is specific:
+The standalone public contract is exactly:
 
-- host OS: Windows;
-- Linux container runtime: Docker Desktop with the WSL 2 backend;
-- installed WSL distributions include Ubuntu and Ubuntu-22.04 on `D:`;
-- Docker Desktop WSL storage is on `D:\DockerDesktopWSL`;
-- Docker integration inside the Ubuntu distribution is **not required** and must not be assumed;
-- Podman is not installed and is not a dependency;
-- Linux-native systemd/Quadlet and cloud-VM deployment are non-goals;
-- Docker lifecycle commands are expected to run from Windows/PowerShell against Docker Desktop's Linux engine;
-- source, canonical data, and local runtime secret material remain under `D:\FossilBrokerWorker\chatgpt-action\`.
+- public, unauthenticated `GET /openapi.json`;
+- bearer-authenticated `POST /actions/search`;
+- bearer-authenticated `POST /actions/read`;
+- bearer-authenticated `GET /actions/capabilities`.
 
-Required host layout:
+The Action uses the existing pack/Skill-gated `ThinMCPAdapter` / `CorpusService` read boundary, but it does not expose MCP itself.
+
+### Lineage decision
+
+FOSSIL's domain service and MCP boundary support lineage when a lineage provider is configured. The standalone Action composition in this release has no durable lineage provider. Therefore `/actions/lineage` is deliberately **not** part of the public Action contract, OpenAPI schema, capabilities response, or route allowlist.
+
+A future release may add lineage only after a real read-only lineage source is wired into the standalone composition and exercised end to end. An advertised route that deterministically cannot succeed is prohibited.
+
+## Non-goals and prohibited capabilities
+
+This service must not expose:
+
+- `/mcp` or any MCP transport;
+- `/ingest`;
+- proposal, validation, commit, promotion, redaction, write, or administrative operations;
+- Graphiti or Neo4j mutation/query escape hatches;
+- arbitrary graph mutation;
+- arbitrary filesystem reads or path-based retrieval;
+- shell/command execution;
+- runtime configuration, environment-variable dumps, bearer tokens, tunnel credentials, or Custom GPT credentials;
+- current-project orchestration state or other mutable application state.
+
+The service is not an ingestion API, knowledge-management UI, FOSSIL node replacement, or generic remote-control surface.
+
+## Data semantics
+
+The canonical durable event store remains authoritative. Graph/search projections remain rebuildable downstream representations and are not required by this standalone Action composition.
+
+Search iterates only canonical event objects from normal event buckets. `_redactions` is metadata and is never a search corpus. If a redaction tombstone exists for an event, the event is suppressed from search even if its old bytes still exist because of a partial or forensic filesystem state. A read of a redacted event returns the same bounded not-found behavior used for unavailable resources and does not disclose redaction metadata.
+
+An empty canonical events directory is valid. Authenticated search against an empty corpus returns HTTP 200 with `[]`; the service must never fabricate content to make a smoke test non-empty.
+
+## Target deployment assumptions
+
+Target host:
+
+- Windows;
+- Docker Desktop using its WSL 2 Linux engine;
+- no Podman requirement;
+- no assumption that the application runs as a Linux-native systemd service;
+- source, canonical data, and local secret file retained on `D:`.
+
+Expected local layout:
 
 ```text
 D:\FossilBrokerWorker\chatgpt-action\
@@ -32,111 +73,68 @@ D:\FossilBrokerWorker\chatgpt-action\
     chatgpt-action.env
 ```
 
-The populated `secrets\chatgpt-action.env` is local-only and must never be committed.
+The container publishes `8787/tcp` only as `127.0.0.1:8787` on the Windows host. Canonical data is bind-mounted at `/var/lib/fossil` read-only. The container executes as a non-root user.
 
-## Scope: normative read-only boundary
+## Public HTTPS assumption
 
-The Action edge provides exactly five externally visible paths:
+The container itself serves HTTP on the loopback/private side. A separately managed HTTPS reverse proxy or tunnel is the only intended public exposure point.
 
-1. unauthenticated OpenAPI discovery at `GET /openapi.json`;
-2. bearer-authenticated search at `POST /actions/search`;
-3. bearer-authenticated durable-event read at `POST /actions/read`;
-4. bearer-authenticated lineage read at `POST /actions/lineage`;
-5. bearer-authenticated capability metadata at `GET /actions/capabilities`.
+OpenAPI discovery must advertise an HTTPS public origin. Origin authority is fail-closed:
 
-The OpenAPI document contains only the four authenticated Action operations. `/openapi.json` is discovery, not an Action operation.
+1. preferred: a fixed `FOSSIL_ACTION_PUBLIC_BASE_URL=https://...`; or
+2. advanced: validated `X-Forwarded-Proto: https` + `X-Forwarded-Host` from a peer whose source address matches an explicit `FOSSIL_ACTION_TRUSTED_PROXY_CIDRS` entry.
 
-The service reuses FOSSIL pack and skill authorization and reads canonical event files through an Action-specific read-only event-store view. It does not require Neo4j or Graphiti.
-
-## Non-goals and explicit prohibitions
-
-The Action edge MUST NOT expose or implement:
-
-- MCP transport, `/mcp`, MCP discovery, or MCP tool execution;
-- reviewed ingestion or `/ingest`;
-- proposal, validation, commit, redaction, deletion, or any durable mutation;
-- write, admin, management, shell, process-control, or arbitrary command endpoints;
-- Graphiti or Neo4j query/mutation/admin APIs;
-- arbitrary graph mutation or unrestricted graph-query strings;
-- caller-selected filesystem paths, arbitrary file reads/writes, directory listing, or path traversal;
-- runtime configuration, environment-variable, bearer-token, tunnel credential, account credential, or Custom GPT credential disclosure;
-- creation or operation of a public tunnel, DNS name, TLS certificate, reverse proxy, or Custom GPT;
-- public deployment from CI;
-- Podman, systemd, Quadlet, Kubernetes, or a cloud VM.
-
-These prohibitions remain in force for authenticated callers.
-
-## Threat model
-
-The public HTTPS origin is assumed to receive hostile traffic. Relevant threats include:
-
-- missing, malformed, duplicated, smuggled, or incorrect bearer authorization;
-- unsupported HTTP methods and unknown/prohibited route probing;
-- oversized bodies, invalid UTF-8, malformed JSON, type/range confusion, and extra-field capability smuggling;
-- path traversal through event/conversation/node identifiers;
-- attempts to smuggle graph queries or write instructions through otherwise valid JSON;
-- forged `Forwarded`/`X-Forwarded-*` headers intended to make `/openapi.json` advertise an attacker-controlled or plain-HTTP origin;
-- accidental root execution;
-- accidental writable canonical-data mounts;
-- accidental public binding of the container port to all host interfaces;
-- exception/error leakage of local Windows/Linux paths, environment data, secrets, or stack traces;
-- OpenAPI regressions that make GPT Action import ambiguous or silently widen capabilities;
-- image-layer, CI-log, documentation, or fixture leakage of a real secret;
-- implementation drift that enables MCP, ingest, proposal, validation, commit, redaction, graph mutation, or filesystem access.
-
-Host compromise, reverse-proxy/tunnel-provider compromise, theft of a real bearer token, and compromise of the ChatGPT account remain operator/security-operations concerns. This PR reduces blast radius but cannot solve a compromised trusted host or credential.
+A direct HTTPS request's `Host` header is not trusted as public-origin authority. Without a fixed origin or trusted proxy-derived origin, `/openapi.json` returns 503.
 
 ## Trust boundaries
 
-1. **Public HTTPS boundary.** An operator-managed tunnel/reverse proxy terminates TLS and forwards only to the Windows loopback listener for this Action service.
-2. **Windows loopback boundary.** Docker publishes container port 8787 only as `127.0.0.1:8787`; it must not be bound to `0.0.0.0`, `::`, or a LAN address on the Windows host.
-3. **Proxy-origin boundary.** The OpenAPI origin is either a fixed operator-configured `https://` origin or is derived from `X-Forwarded-Proto` + `X-Forwarded-Host` only when the request peer is inside an explicit trusted proxy CIDR. Uvicorn's global proxy-header trust remains disabled.
-4. **Authentication boundary.** Every `/actions/*` request requires exactly one valid bearer header. `/openapi.json` is public and contains no secret.
-5. **Authorization boundary.** Authenticated requests still pass through FOSSIL skill and pack-read authorization.
-6. **Canonical-data boundary.** `D:\...\data` is bind-mounted at `/var/lib/fossil` read-only. The Action event-store view provides read operations only and has no commit/redact API.
-7. **Projection boundary.** Neo4j/Graphiti are not initialized and are not reachable through this service.
-8. **Operator-secret boundary.** Real bearer/tunnel/Custom-GPT credentials exist only in operator-controlled local systems and are outside Git, CI, docs, tests, issues, and this implementation package.
+### Boundary A — Custom GPT / public Internet to HTTPS edge
 
-## Secret handling
+Untrusted input includes paths, methods, headers, authorization text, JSON bodies, forwarded headers, host headers, and request framing. Only the documented route/method allowlist is processed.
 
-The repository contains only variable names and clearly non-secret example placeholders. The real bearer token is generated and stored by the local integrator after code review in:
+### Boundary B — HTTPS edge to loopback Action container
 
-```text
-D:\FossilBrokerWorker\chatgpt-action\secrets\chatgpt-action.env
-```
+The proxy/tunnel should forward only to `127.0.0.1:8787`. The Docker port must not be published on all interfaces. Forwarded origin headers are trusted only when the immediate peer address is explicitly configured as trusted.
 
-The application does not return the token, log request authorization headers, add token examples to OpenAPI, or embed a token in the image. CI may use a clearly synthetic test-only string that is not a credential.
+### Boundary C — Action process to canonical data
 
-## HTTPS/reverse-proxy assumptions
+The process sees canonical data through a read-only bind mount and an application object exposing only `get`, `iter_events`, and redaction-state checks required for reads. No event commit/redact method is present on the Action store view.
 
-The Action process itself listens on HTTP inside the Docker/host-local boundary. The public endpoint MUST be HTTPS.
+### Boundary D — Action adapter to FOSSIL domain service
 
-Schema-origin precedence is fail-closed:
+Pack read permissions and the `skill_corpus-search` capability gate remain in force. Transport code cannot bypass pack authorization or gain arbitrary projection/database mutation.
 
-1. a configured `FOSSIL_ACTION_PUBLIC_BASE_URL` (must be origin-only HTTPS) is authoritative and forwarded headers cannot override it;
-2. otherwise a direct HTTPS request may define the origin;
-3. otherwise `X-Forwarded-Proto: https` plus one `X-Forwarded-Host` may define the origin only when the request peer matches `FOSSIL_ACTION_TRUSTED_PROXY_CIDRS`;
-4. otherwise `GET /openapi.json` returns `503` rather than advertising an internal HTTP URL.
+### Boundary E — local operator secret material
 
-Never configure a wildcard trusted proxy CIDR merely to make schema generation work.
+The real bearer token and any tunnel/provider credentials are local deployment state. They are not repository artifacts and must not appear in source, fixtures, image layers, logs, OpenAPI examples, PR comments, or generated responses.
 
-## Data availability and empty-corpus behavior
+## Threat model
 
-The current target canonical event directory is empty. That is valid. If `data\canonical\events` exists and is readable but contains no events, authenticated `POST /actions/search` returns HTTP `200` with `[]`. The service must not fabricate corpus content, seed fake events, query Neo4j as a fallback, or convert an empty corpus into an error.
+Threats explicitly addressed include:
 
-If the canonical event directory itself is missing or inaccessible, startup/reads fail rather than silently creating or mutating canonical state.
+- unauthenticated or malformed bearer requests;
+- duplicate/confused authorization headers;
+- accidental route widening;
+- write-capability smuggling through extra JSON fields;
+- path traversal through event identifiers;
+- oversized, chunked, or under-declared request bodies;
+- forged `Host`, `Forwarded`, or `X-Forwarded-*` metadata;
+- accidental HTTP public origin in the GPT Action schema;
+- redaction tombstone or redacted-event leakage through search/read;
+- root container execution;
+- writable canonical-data mounts;
+- non-loopback host publication;
+- runtime secret reflection in responses or logs;
+- OpenAPI regressions that make the GPT editor misinterpret response shapes.
 
-## Deployment assumptions
+## Request-size policy
 
-The local integrator will:
+The default request body limit is 64 KiB and is configurable only within the bounded server settings. A declared `Content-Length` above the limit is rejected immediately. Independently, body chunks are counted while streaming and the request is rejected as soon as the accumulated bytes exceed the limit. This prevents absent, chunked, or understated `Content-Length` from forcing full-body buffering before rejection.
 
-- clone/check out PR #235 under the required `D:` layout;
-- run the verification suite;
-- build the Linux image using Docker Desktop from Windows;
-- create the real local env file and secret outside source control;
-- mount `D:\...\data` read-only;
-- publish the container port only to Windows `127.0.0.1:8787`;
-- establish the public HTTPS reverse-proxy/tunnel separately;
-- import `/openapi.json` into a private Custom GPT and configure authentication there.
+## Error philosophy
 
-This PR performs none of those deployment/account/credential actions.
+Errors are bounded JSON envelopes. Authorization failures return 401 with `WWW-Authenticate: Bearer`. Unauthorized packs/capabilities return 403. Missing or redacted resources return a generic 404. Malformed input returns 400, oversized bodies 413, and missing trustworthy HTTPS origin 503. Internal filesystem paths, token values, redaction reasons, and stack traces are not returned.
+
+## Acceptance boundary
+
+This package is build-ready only when focused, standalone integration, architecture, container, holdout, OpenAPI validation, and mutation-assurance checks pass on the exact PR head. Passing CI does not deploy the service, create a real secret, establish a tunnel, or configure a Custom GPT; those remain local integrator actions.

--- a/docs/operations/CHATGPT-ACTION-SDD.md
+++ b/docs/operations/CHATGPT-ACTION-SDD.md
@@ -1,0 +1,179 @@
+# SDD — Read-only ChatGPT Action edge
+
+## Architecture
+
+```text
+Private Custom GPT
+      |
+      | HTTPS + Bearer
+      v
+operator-managed TLS proxy/tunnel
+      |
+      | HTTP on loopback/private container network
+      v
+fossil-chatgpt-action (non-root)
+      |
+      | ThinMCPAdapter used only as an internal protocol adapter
+      v
+CorpusService + PackAccess + SkillRegistry
+      |
+      v
+_ReadOnlyEventStore
+      |
+      | read-only mount
+      v
+canonical/events
+```
+
+The Action process is independent of the private FOSSIL Node transport. It does not publish MCP and does not initialize Graphiti/Neo4j. The use of `ThinMCPAdapter` is internal code reuse only; no MCP endpoint or MCP wire protocol is reachable.
+
+## Public API contract
+
+### `GET /openapi.json`
+
+- unauthenticated by design;
+- returns OpenAPI 3.1 JSON;
+- advertises only the authenticated Action operations;
+- contains no bearer value or host-local secret;
+- when `FOSSIL_ACTION_PUBLIC_BASE_URL` is configured, `servers[0].url` equals that exact HTTPS origin;
+- unsupported methods return `405`.
+
+### `POST /actions/search`
+
+Bearer required. Body:
+
+```json
+{"query":"text", "limit":20}
+```
+
+`query` is a non-empty string. `limit` is an integer 1..100. Returns an array of authorized FOSSIL records.
+
+### `POST /actions/read`
+
+Bearer required. Body:
+
+```json
+{"event_id":"evt_..."}
+```
+
+Returns one pack-authorized durable event or `404`.
+
+### `POST /actions/lineage`
+
+Bearer required. Body:
+
+```json
+{"conversation_id":"conv_...", "node_id":"optional"}
+```
+
+Returns the canonical lineage view authorized by the existing FOSSIL service.
+
+### `GET /actions/capabilities`
+
+Bearer required. Returns explicit metadata showing only `search`, `read`, and `lineage` capabilities and Boolean false values for durable writes, ingestion, MCP exposure, and arbitrary graph mutation.
+
+## Prohibited network surface
+
+The Action ASGI app has no routes for `/mcp`, `/ingest`, proposal, validation, commit, redaction, graph mutation, Neo4j, filesystem access, admin operations, shell execution, or arbitrary query languages. Unknown paths are `404`.
+
+## OpenAPI design
+
+The schema is produced by `chatgpt_action_openapi_schema` and uses OpenAPI 3.1. It contains:
+
+- `components.schemas.ErrorDetail`;
+- `components.schemas.ErrorEnvelope`;
+- `components.schemas.FossilRecord` with explicit common event properties;
+- `components.schemas.LineageResponse` with explicit lineage properties;
+- `components.schemas.CapabilitiesResponse` with explicit read-only flags;
+- `components.securitySchemes.BearerAuth` using HTTP bearer;
+- stable unique operation IDs.
+
+The `paths` object contains only the four authenticated Action paths. OpenAPI discovery itself is intentionally outside `paths` so importing the document does not cause ChatGPT to treat schema discovery as a callable Action.
+
+## Environment variables
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `FOSSIL_ACTION_BEARER_TOKEN` | yes | none | runtime-only bearer secret, minimum 32 chars |
+| `FOSSIL_ACTION_HOST` | no | `127.0.0.1` | listen host inside local/container deployment |
+| `FOSSIL_ACTION_PORT` | no | `8787` | listen port |
+| `FOSSIL_ACTION_MAX_REQUEST_BYTES` | no | `65536` | body-size limit; bounded to 1..1048576 |
+| `FOSSIL_ACTION_PUBLIC_BASE_URL` | production | none | origin-only `https://` URL emitted in OpenAPI |
+| `FOSSIL_REPOSITORY_ROOT` | no | current directory | schemas/skills/package root |
+| `FOSSIL_DATA_ROOT` | no | `<repo>/data` | root containing `canonical/events` |
+| `FOSSIL_PACK_MANIFEST` | no | common example manifest | pack authorization manifest |
+
+No variable is populated with a real value in Git. `config/chatgpt-action.env.example` contains placeholders only.
+
+## Container behavior
+
+The Dockerfile:
+
+- builds the package with the node runtime dependency set;
+- creates UID/GID 10001;
+- runs as user `fossil`, not root;
+- uses `fossil-chatgpt-action` as entrypoint;
+- contains no credential;
+- expects `/var/lib/fossil` to be supplied at runtime;
+- is verified with a read-only canonical-data mount in CI.
+
+The Action-specific `_ReadOnlyEventStore` never creates directories and exposes no mutation methods. This is deliberate: the process must boot with canonical data mounted read-only.
+
+## Reverse proxy / tunnel assumptions
+
+The repository does not choose or provision a reverse proxy, tunnel, hostname, DNS record, TLS certificate, or external provider credential.
+
+The external component has one responsibility: terminate HTTPS and forward only the Action origin to the internal Action listener. The application does not trust `Forwarded`/`X-Forwarded-*` to determine its public URL. Instead, the operator sets:
+
+```text
+FOSSIL_ACTION_PUBLIC_BASE_URL=https://<public-action-origin>
+```
+
+Uvicorn is launched with `proxy_headers=False`. Therefore forged forwarded headers cannot rewrite the generated schema. This also makes deployments behind Cloudflare Tunnel, Caddy, nginx, a managed reverse proxy, or another HTTPS edge deterministic: the externally visible origin comes from explicit local configuration, not from caller-controlled headers.
+
+## Windows / WSL `D:` deployment handoff
+
+This repository prepares but does not execute deployment. A local integrator can use a layout such as:
+
+```text
+Windows: D:\fossil\fossil-core
+Windows: D:\fossil\data
+WSL:     /mnt/d/fossil/fossil-core
+WSL:     /mnt/d/fossil/data
+```
+
+Example verification from WSL after cloning/checking out the PR:
+
+```bash
+cd /mnt/d/fossil/fossil-core
+python -m venv .venv
+. .venv/bin/activate
+pip install -e '.[test,node]'
+pytest -q tests/test_chatgpt_action.py tests/test_chatgpt_action_server.py tests/holdout/test_chatgpt_action_holdout.py
+```
+
+Container build only:
+
+```bash
+docker build -f docker/chatgpt-action/Dockerfile -t fossil-chatgpt-action:local .
+```
+
+A real deployment must use a host-local env/secret source, a read-only canonical mount, and a local port binding. Real values are intentionally omitted here.
+
+## Operational runbook
+
+1. Clone/check out the exact PR SHA.
+2. Run the focused and holdout verification commands.
+3. Build the container.
+4. Inspect image user and entrypoint.
+5. Prepare a host-local environment file outside Git; never paste the real bearer value into source, issues, CI, or chat.
+6. Mount only the canonical FOSSIL data required by the Action, read-only.
+7. Bind the Action listener to loopback/private container networking where practical.
+8. Configure the external HTTPS edge to forward only to the Action listener.
+9. Set the explicit HTTPS public base URL locally.
+10. Verify `/openapi.json`, unauthenticated `401`, authenticated search/read/lineage/capabilities, `404` prohibited routes, and forged forwarded-header resistance.
+11. Only after those checks should a private Custom GPT import the schema and use the same locally managed bearer credential.
+
+## Rollback
+
+There is no schema migration and no Action-side durable write. Rollback is: stop/remove the Action process/container, remove the external route, and revert/checkout the previous repository SHA. Canonical events and projections require no rollback because this feature never mutates them.

--- a/docs/operations/CHATGPT-ACTION-SDD.md
+++ b/docs/operations/CHATGPT-ACTION-SDD.md
@@ -1,179 +1,332 @@
-# SDD — Read-only ChatGPT Action edge
+# SDD — FOSSIL read-only ChatGPT Action
 
-## Architecture
+## 1. Architecture
 
 ```text
 Private Custom GPT
-      |
-      | HTTPS + Bearer
-      v
-operator-managed TLS proxy/tunnel
-      |
-      | HTTP on loopback/private container network
-      v
-fossil-chatgpt-action (non-root)
-      |
-      | ThinMCPAdapter used only as an internal protocol adapter
-      v
-CorpusService + PackAccess + SkillRegistry
-      |
-      v
-_ReadOnlyEventStore
-      |
-      | read-only mount
-      v
-canonical/events
+        |
+        | HTTPS + bearer token
+        v
+Operator-managed HTTPS reverse proxy / tunnel
+        |
+        | forwards only to Windows loopback
+        v
+127.0.0.1:8787 on Windows
+        |
+        | Docker Desktop WSL2 Linux engine
+        v
+fossil-chatgpt-action container (UID/GID 10001)
+        |
+        +-- /opt/fossil-core       immutable image content
+        +-- /var/lib/fossil        host D:\...\data, read-only bind mount
+                 |
+                 +-- canonical/events
 ```
 
-The Action process is independent of the private FOSSIL Node transport. It does not publish MCP and does not initialize Graphiti/Neo4j. The use of `ThinMCPAdapter` is internal code reuse only; no MCP endpoint or MCP wire protocol is reachable.
+The Action service is a protocol adapter over existing FOSSIL read semantics. It is not the FOSSIL Node network service and does not mount MCP, ingest, projector, Graphiti, Neo4j, or write/admin routes.
 
-## Public API contract
+### Module boundaries
 
-### `GET /openapi.json`
+- `src/fossil_core/runtime/chatgpt_action.py`
+  - exact HTTP route allowlist;
+  - bearer authentication;
+  - bounded request parsing and identifier validation;
+  - trusted HTTPS public-origin derivation;
+  - OpenAPI 3.1 generation;
+  - dispatch only to `fossil.search`, `fossil.read`, and `fossil.lineage`.
+- `src/fossil_core/runtime/chatgpt_action_server.py`
+  - runtime environment parsing;
+  - trusted proxy CIDR validation;
+  - canonical read-only event-store composition;
+  - `CorpusService` + read-only skill context;
+  - Uvicorn startup with global proxy-header trust disabled.
+- `docker/chatgpt-action/Dockerfile`
+  - non-root Linux image;
+  - no secret baked into image;
+  - Action-only entrypoint;
+  - TCP liveness without a new HTTP route.
+- `config/chatgpt-action.env.example`
+  - field-name and non-secret placeholder template only.
 
-- unauthenticated by design;
+## 2. Public API contract
+
+### Public discovery — `GET /openapi.json`
+
+- unauthenticated;
+- succeeds only when a trusted public HTTPS origin can be derived;
 - returns OpenAPI 3.1 JSON;
-- advertises only the authenticated Action operations;
-- contains no bearer value or host-local secret;
-- when `FOSSIL_ACTION_PUBLIC_BASE_URL` is configured, `servers[0].url` equals that exact HTTPS origin;
+- never contains a real bearer token/runtime secret;
+- `paths` describes only the four authenticated Action operations;
 - unsupported methods return `405`.
 
-### `POST /actions/search`
+### Authenticated operations
 
-Bearer required. Body:
-
-```json
-{"query":"text", "limit":20}
-```
-
-`query` is a non-empty string. `limit` is an integer 1..100. Returns an array of authorized FOSSIL records.
-
-### `POST /actions/read`
-
-Bearer required. Body:
-
-```json
-{"event_id":"evt_..."}
-```
-
-Returns one pack-authorized durable event or `404`.
-
-### `POST /actions/lineage`
-
-Bearer required. Body:
-
-```json
-{"conversation_id":"conv_...", "node_id":"optional"}
-```
-
-Returns the canonical lineage view authorized by the existing FOSSIL service.
-
-### `GET /actions/capabilities`
-
-Bearer required. Returns explicit metadata showing only `search`, `read`, and `lineage` capabilities and Boolean false values for durable writes, ingestion, MCP exposure, and arbitrary graph mutation.
-
-## Prohibited network surface
-
-The Action ASGI app has no routes for `/mcp`, `/ingest`, proposal, validation, commit, redaction, graph mutation, Neo4j, filesystem access, admin operations, shell execution, or arbitrary query languages. Unknown paths are `404`.
-
-## OpenAPI design
-
-The schema is produced by `chatgpt_action_openapi_schema` and uses OpenAPI 3.1. It contains:
-
-- `components.schemas.ErrorDetail`;
-- `components.schemas.ErrorEnvelope`;
-- `components.schemas.FossilRecord` with explicit common event properties;
-- `components.schemas.LineageResponse` with explicit lineage properties;
-- `components.schemas.CapabilitiesResponse` with explicit read-only flags;
-- `components.securitySchemes.BearerAuth` using HTTP bearer;
-- stable unique operation IDs.
-
-The `paths` object contains only the four authenticated Action paths. OpenAPI discovery itself is intentionally outside `paths` so importing the document does not cause ChatGPT to treat schema discovery as a callable Action.
-
-## Environment variables
-
-| Variable | Required | Default | Purpose |
-| --- | --- | --- | --- |
-| `FOSSIL_ACTION_BEARER_TOKEN` | yes | none | runtime-only bearer secret, minimum 32 chars |
-| `FOSSIL_ACTION_HOST` | no | `127.0.0.1` | listen host inside local/container deployment |
-| `FOSSIL_ACTION_PORT` | no | `8787` | listen port |
-| `FOSSIL_ACTION_MAX_REQUEST_BYTES` | no | `65536` | body-size limit; bounded to 1..1048576 |
-| `FOSSIL_ACTION_PUBLIC_BASE_URL` | production | none | origin-only `https://` URL emitted in OpenAPI |
-| `FOSSIL_REPOSITORY_ROOT` | no | current directory | schemas/skills/package root |
-| `FOSSIL_DATA_ROOT` | no | `<repo>/data` | root containing `canonical/events` |
-| `FOSSIL_PACK_MANIFEST` | no | common example manifest | pack authorization manifest |
-
-No variable is populated with a real value in Git. `config/chatgpt-action.env.example` contains placeholders only.
-
-## Container behavior
-
-The Dockerfile:
-
-- builds the package with the node runtime dependency set;
-- creates UID/GID 10001;
-- runs as user `fossil`, not root;
-- uses `fossil-chatgpt-action` as entrypoint;
-- contains no credential;
-- expects `/var/lib/fossil` to be supplied at runtime;
-- is verified with a read-only canonical-data mount in CI.
-
-The Action-specific `_ReadOnlyEventStore` never creates directories and exposes no mutation methods. This is deliberate: the process must boot with canonical data mounted read-only.
-
-## Reverse proxy / tunnel assumptions
-
-The repository does not choose or provision a reverse proxy, tunnel, hostname, DNS record, TLS certificate, or external provider credential.
-
-The external component has one responsibility: terminate HTTPS and forward only the Action origin to the internal Action listener. The application does not trust `Forwarded`/`X-Forwarded-*` to determine its public URL. Instead, the operator sets:
+Every `/actions/*` request requires exactly one:
 
 ```text
-FOSSIL_ACTION_PUBLIC_BASE_URL=https://<public-action-origin>
+Authorization: Bearer <opaque runtime token>
 ```
 
-Uvicorn is launched with `proxy_headers=False`. Therefore forged forwarded headers cannot rewrite the generated schema. This also makes deployments behind Cloudflare Tunnel, Caddy, nginx, a managed reverse proxy, or another HTTPS edge deterministic: the externally visible origin comes from explicit local configuration, not from caller-controlled headers.
+The scheme is case-insensitive; token bytes are exact and compared with `hmac.compare_digest`.
 
-## Windows / WSL `D:` deployment handoff
+#### `POST /actions/search`
 
-This repository prepares but does not execute deployment. A local integrator can use a layout such as:
+```json
+{
+  "query": "authentication decision",
+  "limit": 20
+}
+```
+
+- `query`: required non-empty string, max 8,192 characters;
+- `limit`: optional integer 1..100;
+- additional properties are rejected;
+- success: array of explicit `SearchResult` objects;
+- existing-but-empty canonical event directory: `200 []`.
+
+#### `POST /actions/read`
+
+```json
+{
+  "event_id": "evt_exampleopaqueidentifier"
+}
+```
+
+- event ID is a bounded opaque identifier with no path separators/whitespace/URL syntax;
+- the filesystem adapter independently validates FOSSIL event-ID format before path construction;
+- success: explicit `FossilEvent`;
+- missing/redacted resource: generic `404`.
+
+#### `POST /actions/lineage`
+
+```json
+{
+  "conversation_id": "conv_example",
+  "node_id": "ln_example"
+}
+```
+
+- `conversation_id` required;
+- `node_id` optional;
+- both bounded opaque identifiers;
+- success: explicit `LineageResponse` with typed nodes and citations.
+
+#### `GET /actions/capabilities`
+
+Structurally fixed success body:
+
+```json
+{
+  "service_version": "1",
+  "action_capabilities": ["search", "read", "lineage"],
+  "durable_writes_exposed": false,
+  "ingestion_exposed": false,
+  "mcp_exposed": false,
+  "arbitrary_graph_mutation": false
+}
+```
+
+### Prohibited network surface
+
+`/mcp`, `/ingest`, proposal, validation, commit, redaction, write/admin, Neo4j/graph, filesystem/shell, and unknown paths return JSON `404` and never delegate to the corpus adapter.
+
+## 3. Error contract
+
+```json
+{
+  "error": {
+    "code": "machine_code",
+    "detail": "sanitized message"
+  }
+}
+```
+
+Status mapping:
+
+- `400`: malformed/invalid request;
+- `401`: missing/invalid bearer credential;
+- `403`: FOSSIL pack/capability denial;
+- `404`: missing resource or prohibited/unknown route;
+- `405`: unsupported method on an allowed route;
+- `413`: body over configured limit;
+- `500`: unexpected internal failure, generic text only;
+- `503`: canonical storage unavailable or no trusted HTTPS schema origin.
+
+No response includes stack traces, local Windows/Linux paths, environment data, token values, or provider credentials.
+
+## 4. OpenAPI / private Custom GPT compatibility
+
+The document is OpenAPI `3.1.0` and is validated with `openapi-spec-validator`.
+
+Compatibility contract:
+
+- `components.schemas` is a non-empty object;
+- request schemas are named: `SearchRequest`, `ReadRequest`, `LineageRequest`;
+- success response schemas have declared object properties: `SearchResult`, `FossilEvent`, `LineageNode`, `Citation`, `LineageResponse`, `CapabilitiesResponse`;
+- errors use `ErrorEnvelope`;
+- operation IDs are stable/unique: `fossilSearch`, `fossilRead`, `fossilLineage`, `fossilActionCapabilities`;
+- security is HTTP bearer;
+- no private or mutation route appears in `paths`;
+- `servers[0].url` is HTTPS only.
+
+Event-type-specific `payload` and `provenance` remain explicitly declared object properties whose inner keys vary by durable event type. The Action response itself is never an anonymous property-less object.
+
+## 5. HTTPS and reverse-proxy behavior
+
+Uvicorn runs with:
 
 ```text
-Windows: D:\fossil\fossil-core
-Windows: D:\fossil\data
-WSL:     /mnt/d/fossil/fossil-core
-WSL:     /mnt/d/fossil/data
+proxy_headers=False
 ```
 
-Example verification from WSL after cloning/checking out the PR:
+The application performs all proxy-origin trust decisions.
+
+### Mode A — fixed public origin (preferred when known)
+
+```text
+FOSSIL_ACTION_PUBLIC_BASE_URL=https://<public-origin>
+```
+
+Requirements:
+
+- HTTPS;
+- origin only: no path/query/fragment/userinfo;
+- authoritative;
+- forwarded headers cannot override it.
+
+### Mode B — explicit trusted proxy CIDRs
+
+Leave the fixed origin unset and configure:
+
+```text
+FOSSIL_ACTION_TRUSTED_PROXY_CIDRS=<comma-separated peer CIDRs>
+```
+
+Only a request whose actual peer IP is in one configured network may supply:
+
+```text
+X-Forwarded-Proto: https
+X-Forwarded-Host: <single valid host>
+```
+
+Comma-separated/chained values, `http`, missing host/proto, whitespace, path/userinfo syntax, malformed ports, or headers from untrusted peers do not define the public origin.
+
+Origin precedence:
+
+1. fixed `FOSSIL_ACTION_PUBLIC_BASE_URL`;
+2. direct HTTPS request origin;
+3. validated trusted-proxy HTTPS origin;
+4. otherwise `/openapi.json` returns `503` rather than emitting internal HTTP.
+
+Never use `0.0.0.0/0` or `::/0` merely to accept forwarded headers.
+
+## 6. Environment variables
+
+| Variable | Required | Default | Contract |
+|---|---|---|---|
+| `FOSSIL_ACTION_BEARER_TOKEN` | yes | none | trimmed, >=32 chars, runtime-only |
+| `FOSSIL_ACTION_HOST` | no | `127.0.0.1` | image sets `0.0.0.0`; Windows publish remains loopback-only |
+| `FOSSIL_ACTION_PORT` | no | `8787` | 1..65535 |
+| `FOSSIL_ACTION_MAX_REQUEST_BYTES` | no | `65536` | 1..1048576 |
+| `FOSSIL_ACTION_PUBLIC_BASE_URL` | conditional | none | fixed origin-only HTTPS URL |
+| `FOSSIL_ACTION_TRUSTED_PROXY_CIDRS` | conditional | empty | exact proxy peer networks; used only when fixed origin absent |
+| `FOSSIL_REPOSITORY_ROOT` | no | cwd | image: `/opt/fossil-core` |
+| `FOSSIL_DATA_ROOT` | no | `<repo>/data` | image: `/var/lib/fossil` |
+| `FOSSIL_PACK_MANIFEST` | no | common example manifest | read-pack authorization |
+
+A deployment needs a fixed origin, direct HTTPS, or a valid trusted-proxy origin before `/openapi.json` is importable.
+
+## 7. Container behavior
+
+PowerShell build from the required host layout:
+
+```powershell
+Set-Location 'D:\FossilBrokerWorker\chatgpt-action\fossil-core'
+docker build --file docker/chatgpt-action/Dockerfile --tag fossil-chatgpt-action:pr235 .
+```
+
+Image invariants:
+
+- Docker Desktop Linux image;
+- runtime UID/GID 10001;
+- entrypoint `fossil-chatgpt-action`;
+- no real token/provider credential in image config/layers;
+- no unauthenticated health route;
+- canonical data supplied only at runtime.
+
+Deployment shape (documentation only; real env file is created by the local integrator):
+
+```powershell
+docker run --detach `
+  --name fossil-chatgpt-action `
+  --restart unless-stopped `
+  --env-file 'D:\FossilBrokerWorker\chatgpt-action\secrets\chatgpt-action.env' `
+  --publish 127.0.0.1:8787:8787 `
+  --mount 'type=bind,source=D:\FossilBrokerWorker\chatgpt-action\data,target=/var/lib/fossil,readonly' `
+  fossil-chatgpt-action:pr235
+```
+
+The host publication must remain `127.0.0.1`; the external HTTPS component is the only public exposure.
+
+## 8. Windows / Docker Desktop / WSL 2 runbook
+
+Required layout:
+
+```text
+D:\FossilBrokerWorker\chatgpt-action\
+  fossil-core\
+  data\canonical\events\
+  secrets\chatgpt-action.env
+```
+
+Create non-secret directories in PowerShell:
+
+```powershell
+New-Item -ItemType Directory -Force 'D:\FossilBrokerWorker\chatgpt-action\data\canonical\events' | Out-Null
+New-Item -ItemType Directory -Force 'D:\FossilBrokerWorker\chatgpt-action\secrets' | Out-Null
+```
+
+Docker commands run from Windows against Docker Desktop's WSL2 engine. Docker integration inside Ubuntu/Ubuntu-22.04 is not required.
+
+Optional Python verification from WSL (no Docker command required there):
 
 ```bash
-cd /mnt/d/fossil/fossil-core
-python -m venv .venv
-. .venv/bin/activate
+cd /mnt/d/FossilBrokerWorker/chatgpt-action/fossil-core
+python3 -m venv .venv-linux
+. .venv-linux/bin/activate
 pip install -e '.[test,node]'
-pytest -q tests/test_chatgpt_action.py tests/test_chatgpt_action_server.py tests/holdout/test_chatgpt_action_holdout.py
+pytest -q tests/test_chatgpt_action.py tests/test_chatgpt_action_server.py tests/test_chatgpt_action_architecture.py tests/holdout/test_chatgpt_action_holdout.py
+python scripts/run_chatgpt_action_mutations.py
 ```
 
-Container build only:
+## 9. Startup/operational checks
 
-```bash
-docker build -f docker/chatgpt-action/Dockerfile -t fossil-chatgpt-action:local .
-```
+Before connecting a private Custom GPT, verify:
 
-A real deployment must use a host-local env/secret source, a read-only canonical mount, and a local port binding. Real values are intentionally omitted here.
+1. effective container UID is 10001;
+2. Docker host binding is exactly `127.0.0.1:8787`;
+3. `/var/lib/fossil` has `RW=false`;
+4. an in-container write attempt under `/var/lib/fossil` fails;
+5. no Neo4j credential/connectivity is required;
+6. unauthenticated Action request is `401`;
+7. authenticated search against the current empty corpus is `200 []`;
+8. prohibited routes are `404`;
+9. `/openapi.json` validates and advertises only the intended HTTPS origin;
+10. forged forwarded headers cannot alter a fixed origin, and trusted-proxy mode rejects untrusted peers;
+11. image history/application logs contain no real credential.
 
-## Operational runbook
+## 10. Rollback
 
-1. Clone/check out the exact PR SHA.
-2. Run the focused and holdout verification commands.
-3. Build the container.
-4. Inspect image user and entrypoint.
-5. Prepare a host-local environment file outside Git; never paste the real bearer value into source, issues, CI, or chat.
-6. Mount only the canonical FOSSIL data required by the Action, read-only.
-7. Bind the Action listener to loopback/private container networking where practical.
-8. Configure the external HTTPS edge to forward only to the Action listener.
-9. Set the explicit HTTPS public base URL locally.
-10. Verify `/openapi.json`, unauthenticated `401`, authenticated search/read/lineage/capabilities, `404` prohibited routes, and forged forwarded-header resistance.
-11. Only after those checks should a private Custom GPT import the schema and use the same locally managed bearer credential.
+1. disable the external HTTPS route if configured;
+2. stop/remove `fossil-chatgpt-action`;
+3. restore the previous image/tag or checkout the prior commit;
+4. leave `D:\...\data` unchanged;
+5. remove/rotate the local secret separately if desired.
 
-## Rollback
+No database migration, projection rebuild, or reverse data migration is required.
 
-There is no schema migration and no Action-side durable write. Rollback is: stop/remove the Action process/container, remove the external route, and revert/checkout the previous repository SHA. Canonical events and projections require no rollback because this feature never mutates them.
+## 11. Known limitations
+
+- This package does not provision/test a real tunnel provider, DNS name, TLS certificate, or Custom GPT account configuration.
+- Trusted-proxy mode requires the integrator to configure the actual proxy peer CIDR observed by the container; Docker Desktop network addressing can vary.
+- The target canonical event directory is currently empty, so deployment smoke proves empty read behavior but not semantic retrieval quality until real canonical events exist.

--- a/docs/operations/CHATGPT-ACTION-SDD.md
+++ b/docs/operations/CHATGPT-ACTION-SDD.md
@@ -5,328 +5,215 @@
 ```text
 Private Custom GPT
         |
-        | HTTPS + bearer token
+        | HTTPS + bearer authentication
         v
-Operator-managed HTTPS reverse proxy / tunnel
+operator-managed HTTPS reverse proxy / tunnel
         |
-        | forwards only to Windows loopback
+        | HTTP to loopback/private Docker endpoint only
         v
-127.0.0.1:8787 on Windows
+127.0.0.1:8787 on Windows host
         |
-        | Docker Desktop WSL2 Linux engine
         v
-fossil-chatgpt-action container (UID/GID 10001)
+non-root fossil-chatgpt-action container
         |
-        +-- /opt/fossil-core       immutable image content
-        +-- /var/lib/fossil        host D:\...\data, read-only bind mount
-                 |
-                 +-- canonical/events
+        +-- /opt/fossil-core        application/contracts/skills
+        +-- /var/lib/fossil         D:\...\data, bind-mounted read-only
 ```
 
-The Action service is a protocol adapter over existing FOSSIL read semantics. It is not the FOSSIL Node network service and does not mount MCP, ingest, projector, Graphiti, Neo4j, or write/admin routes.
+The public Action is a compatibility edge over the protocol-independent FOSSIL corpus service. It does not expose the FOSSIL node's `/mcp` or `/ingest` surfaces and does not construct Graphiti or Neo4j.
 
-### Module boundaries
+## 2. Standalone composition
 
-- `src/fossil_core/runtime/chatgpt_action.py`
-  - exact HTTP route allowlist;
-  - bearer authentication;
-  - bounded request parsing and identifier validation;
-  - trusted HTTPS public-origin derivation;
-  - OpenAPI 3.1 generation;
-  - dispatch only to `fossil.search`, `fossil.read`, and `fossil.lineage`.
-- `src/fossil_core/runtime/chatgpt_action_server.py`
-  - runtime environment parsing;
-  - trusted proxy CIDR validation;
-  - canonical read-only event-store composition;
-  - `CorpusService` + read-only skill context;
-  - Uvicorn startup with global proxy-header trust disabled.
-- `docker/chatgpt-action/Dockerfile`
-  - non-root Linux image;
-  - no secret baked into image;
-  - Action-only entrypoint;
-  - TCP liveness without a new HTTP route.
-- `config/chatgpt-action.env.example`
-  - field-name and non-secret placeholder template only.
+`chatgpt_action_server.py` loads:
 
-## 2. Public API contract
+1. the selected pack manifest through `KnowledgePackValidator`;
+2. `PackAccess` from that manifest;
+3. a `_ReadOnlyEventStore` over `data/canonical/events`;
+4. the Skill registry;
+5. `CorpusService`;
+6. `ThinMCPAdapter` using `skill_corpus-search` provenance;
+7. the dedicated Starlette Action middleware.
 
-### Public discovery — `GET /openapi.json`
+The event-store view exposes reads only. It never instantiates `DurableEventStore`, Graphiti, Neo4j, projector, ingestion, or write APIs.
 
-- unauthenticated;
-- succeeds only when a trusted public HTTPS origin can be derived;
-- returns OpenAPI 3.1 JSON;
-- never contains a real bearer token/runtime secret;
-- `paths` describes only the four authenticated Action operations;
-- unsupported methods return `405`.
+### Lineage composition
 
-### Authenticated operations
+The standalone service currently has no durable lineage mapping/provider. Consequently the Action contract deliberately excludes lineage. FOSSIL may still expose lineage over other correctly configured boundaries, including MCP/domain callers. Reintroducing `/actions/lineage` requires a real read-only standalone provider plus end-to-end tests first.
 
-Every `/actions/*` request requires exactly one:
+## 3. Public API contract
 
-```text
-Authorization: Bearer <opaque runtime token>
-```
+### Public, no bearer required
 
-The scheme is case-insensitive; token bytes are exact and compared with `hmac.compare_digest`.
+`GET /openapi.json`
 
-#### `POST /actions/search`
+Returns OpenAPI 3.1 only when a trustworthy HTTPS public origin can be established.
+
+### Bearer-protected
+
+`POST /actions/search`
+
+Request:
 
 ```json
-{
-  "query": "authentication decision",
-  "limit": 20
-}
+{"query":"search terms","limit":20}
 ```
 
-- `query`: required non-empty string, max 8,192 characters;
-- `limit`: optional integer 1..100;
-- additional properties are rejected;
-- success: array of explicit `SearchResult` objects;
-- existing-but-empty canonical event directory: `200 []`.
+`query` is required, non-empty, maximum 8192 characters. `limit` is optional, integer 1-100, default 20. No extra fields are accepted.
 
-#### `POST /actions/read`
+Response: JSON array of pack-authorized search result objects. Empty corpus/miss returns `[]`.
+
+`POST /actions/read`
+
+Request:
 
 ```json
-{
-  "event_id": "evt_exampleopaqueidentifier"
-}
+{"event_id":"evt_exampleopaqueid123"}
 ```
 
-- event ID is a bounded opaque identifier with no path separators/whitespace/URL syntax;
-- the filesystem adapter independently validates FOSSIL event-ID format before path construction;
-- success: explicit `FossilEvent`;
-- missing/redacted resource: generic `404`.
+Only a validated opaque event identifier is accepted. The result is the pack-authorized durable event. Missing or redacted events return generic 404.
 
-#### `POST /actions/lineage`
+`GET /actions/capabilities`
 
-```json
-{
-  "conversation_id": "conv_example",
-  "node_id": "ln_example"
-}
-```
+Response shape is bounded metadata with `action_capabilities` exactly `["search", "read"]` and write/ingest/MCP/graph-mutation exposure flags fixed to false.
 
-- `conversation_id` required;
-- `node_id` optional;
-- both bounded opaque identifiers;
-- success: explicit `LineageResponse` with typed nodes and citations.
+### Non-routable
 
-#### `GET /actions/capabilities`
+`/actions/lineage`, `/mcp`, `/ingest`, proposal, validation, commit, promotion, redaction, write/admin, graph/Neo4j, filesystem, and unknown paths are 404.
 
-Structurally fixed success body:
+## 4. OpenAPI contract
 
-```json
-{
-  "service_version": "1",
-  "action_capabilities": ["search", "read", "lineage"],
-  "durable_writes_exposed": false,
-  "ingestion_exposed": false,
-  "mcp_exposed": false,
-  "arbitrary_graph_mutation": false
-}
-```
+The generated document is OpenAPI `3.1.0`. `components.schemas` is always a non-empty object. Request and response schemas use explicit object properties so the Custom GPT importer does not infer unbounded objects from missing schema structure.
 
-### Prohibited network surface
+The only Action operation IDs are:
 
-`/mcp`, `/ingest`, proposal, validation, commit, redaction, write/admin, Neo4j/graph, filesystem/shell, and unknown paths return JSON `404` and never delegate to the corpus adapter.
+- `fossilSearch`;
+- `fossilRead`;
+- `fossilActionCapabilities`.
 
-## 3. Error contract
+`BearerAuth` is an HTTP bearer security scheme. The actual token never appears in the document.
 
-```json
-{
-  "error": {
-    "code": "machine_code",
-    "detail": "sanitized message"
-  }
-}
-```
+### Public server origin
 
-Status mapping:
+Two origin modes are supported:
 
-- `400`: malformed/invalid request;
-- `401`: missing/invalid bearer credential;
-- `403`: FOSSIL pack/capability denial;
-- `404`: missing resource or prohibited/unknown route;
-- `405`: unsupported method on an allowed route;
-- `413`: body over configured limit;
-- `500`: unexpected internal failure, generic text only;
-- `503`: canonical storage unavailable or no trusted HTTPS schema origin.
+**Fixed-origin mode (preferred)**
 
-No response includes stack traces, local Windows/Linux paths, environment data, token values, or provider credentials.
+`FOSSIL_ACTION_PUBLIC_BASE_URL=https://public-name.example`
 
-## 4. OpenAPI / private Custom GPT compatibility
+The configured origin must be HTTPS and origin-only. It is authoritative regardless of `Host`, `Forwarded`, or `X-Forwarded-*` supplied by callers.
 
-The document is OpenAPI `3.1.0` and is validated with `openapi-spec-validator`.
+**Trusted-proxy mode**
 
-Compatibility contract:
+Leave `FOSSIL_ACTION_PUBLIC_BASE_URL` unset and configure one or more exact/narrow proxy peer networks in `FOSSIL_ACTION_TRUSTED_PROXY_CIDRS`. The request's immediate peer must match one of those networks, and the middleware must receive one unambiguous `X-Forwarded-Proto: https` and one validated `X-Forwarded-Host`.
 
-- `components.schemas` is a non-empty object;
-- request schemas are named: `SearchRequest`, `ReadRequest`, `LineageRequest`;
-- success response schemas have declared object properties: `SearchResult`, `FossilEvent`, `LineageNode`, `Citation`, `LineageResponse`, `CapabilitiesResponse`;
-- errors use `ErrorEnvelope`;
-- operation IDs are stable/unique: `fossilSearch`, `fossilRead`, `fossilLineage`, `fossilActionCapabilities`;
-- security is HTTP bearer;
-- no private or mutation route appears in `paths`;
-- `servers[0].url` is HTTPS only.
+Uvicorn itself runs with `proxy_headers=False`; application middleware performs the explicit CIDR check.
 
-Event-type-specific `payload` and `provenance` remain explicitly declared object properties whose inner keys vary by durable event type. The Action response itself is never an anonymous property-less object.
+**Unsupported origin mode**
 
-## 5. HTTPS and reverse-proxy behavior
+Direct HTTPS plus an arbitrary `Host` header is not authority. If neither fixed origin nor trusted-proxy origin is available, `GET /openapi.json` returns 503. The service never guesses or publishes an `http://` origin.
 
-Uvicorn runs with:
+## 5. Request-body handling
 
-```text
-proxy_headers=False
-```
+The server checks a valid non-negative `Content-Length` when present and rejects declared oversize immediately. It then consumes `request.stream()` incrementally, counting cumulative bytes. As soon as the configured limit is exceeded it returns 413 without invoking the FOSSIL adapter.
 
-The application performs all proxy-origin trust decisions.
+This second check is authoritative for chunked requests, missing `Content-Length`, and deliberately understated `Content-Length`. The Action request path does not use `await request.body()`.
 
-### Mode A — fixed public origin (preferred when known)
+## 6. Redaction semantics
 
-```text
-FOSSIL_ACTION_PUBLIC_BASE_URL=https://<public-origin>
-```
+`_ReadOnlyEventStore.iter_events()` traverses only direct canonical event buckets and explicitly excludes `_redactions`. Tombstone JSON is metadata, never corpus content.
 
-Requirements:
+For every candidate event, the read-only store also checks for a matching tombstone and suppresses the event if redacted. That remains true if old event bytes still exist on disk. `get()` checks redaction before reading event bytes and raises the established `EventRedactedError`, which is normalized to generic not-found at the public Action boundary.
 
-- HTTPS;
-- origin only: no path/query/fragment/userinfo;
-- authoritative;
-- forwarded headers cannot override it.
+## 7. Environment variables
 
-### Mode B — explicit trusted proxy CIDRs
+Runtime variables:
 
-Leave the fixed origin unset and configure:
+- `FOSSIL_ACTION_BEARER_TOKEN` — required, local runtime secret, minimum 32 characters;
+- `FOSSIL_ACTION_HOST` — container listener, image default `0.0.0.0`;
+- `FOSSIL_ACTION_PORT` — default `8787`;
+- `FOSSIL_ACTION_MAX_REQUEST_BYTES` — default `65536`, server maximum 1048576;
+- `FOSSIL_ACTION_PUBLIC_BASE_URL` — preferred fixed public HTTPS origin;
+- `FOSSIL_ACTION_TRUSTED_PROXY_CIDRS` — optional comma-separated proxy peer networks when fixed origin is absent;
+- `FOSSIL_REPOSITORY_ROOT` — image default `/opt/fossil-core`;
+- `FOSSIL_DATA_ROOT` — image default `/var/lib/fossil`;
+- `FOSSIL_PACK_MANIFEST` — default common-pack manifest in the image.
 
-```text
-FOSSIL_ACTION_TRUSTED_PROXY_CIDRS=<comma-separated peer CIDRs>
-```
+The committed `.env.example` contains placeholders only. A populated env file must stay outside Git.
 
-Only a request whose actual peer IP is in one configured network may supply:
+## 8. Container contract
 
-```text
-X-Forwarded-Proto: https
-X-Forwarded-Host: <single valid host>
-```
+The image uses Python 3.12 slim, installs the project into an image-local virtual environment, and runs `fossil-chatgpt-action` as user/group `fossil` UID/GID 10001.
 
-Comma-separated/chained values, `http`, missing host/proto, whitespace, path/userinfo syntax, malformed ports, or headers from untrusted peers do not define the public origin.
+The Dockerfile does not bake a bearer token into an `ARG`, `ENV`, layer, or file. The canonical data mount is external and read-only.
 
-Origin precedence:
-
-1. fixed `FOSSIL_ACTION_PUBLIC_BASE_URL`;
-2. direct HTTPS request origin;
-3. validated trusted-proxy HTTPS origin;
-4. otherwise `/openapi.json` returns `503` rather than emitting internal HTTP.
-
-Never use `0.0.0.0/0` or `::/0` merely to accept forwarded headers.
-
-## 6. Environment variables
-
-| Variable | Required | Default | Contract |
-|---|---|---|---|
-| `FOSSIL_ACTION_BEARER_TOKEN` | yes | none | trimmed, >=32 chars, runtime-only |
-| `FOSSIL_ACTION_HOST` | no | `127.0.0.1` | image sets `0.0.0.0`; Windows publish remains loopback-only |
-| `FOSSIL_ACTION_PORT` | no | `8787` | 1..65535 |
-| `FOSSIL_ACTION_MAX_REQUEST_BYTES` | no | `65536` | 1..1048576 |
-| `FOSSIL_ACTION_PUBLIC_BASE_URL` | conditional | none | fixed origin-only HTTPS URL |
-| `FOSSIL_ACTION_TRUSTED_PROXY_CIDRS` | conditional | empty | exact proxy peer networks; used only when fixed origin absent |
-| `FOSSIL_REPOSITORY_ROOT` | no | cwd | image: `/opt/fossil-core` |
-| `FOSSIL_DATA_ROOT` | no | `<repo>/data` | image: `/var/lib/fossil` |
-| `FOSSIL_PACK_MANIFEST` | no | common example manifest | read-pack authorization |
-
-A deployment needs a fixed origin, direct HTTPS, or a valid trusted-proxy origin before `/openapi.json` is importable.
-
-## 7. Container behavior
-
-PowerShell build from the required host layout:
+Target Windows publication is loopback only:
 
 ```powershell
-Set-Location 'D:\FossilBrokerWorker\chatgpt-action\fossil-core'
-docker build --file docker/chatgpt-action/Dockerfile --tag fossil-chatgpt-action:pr235 .
-```
-
-Image invariants:
-
-- Docker Desktop Linux image;
-- runtime UID/GID 10001;
-- entrypoint `fossil-chatgpt-action`;
-- no real token/provider credential in image config/layers;
-- no unauthenticated health route;
-- canonical data supplied only at runtime.
-
-Deployment shape (documentation only; real env file is created by the local integrator):
-
-```powershell
-docker run --detach `
+docker run -d `
   --name fossil-chatgpt-action `
   --restart unless-stopped `
-  --env-file 'D:\FossilBrokerWorker\chatgpt-action\secrets\chatgpt-action.env' `
-  --publish 127.0.0.1:8787:8787 `
-  --mount 'type=bind,source=D:\FossilBrokerWorker\chatgpt-action\data,target=/var/lib/fossil,readonly' `
-  fossil-chatgpt-action:pr235
+  --env-file "D:\FossilBrokerWorker\chatgpt-action\secrets\chatgpt-action.env" `
+  -p 127.0.0.1:8787:8787 `
+  -v "D:\FossilBrokerWorker\chatgpt-action\data:/var/lib/fossil:ro" `
+  fossil-chatgpt-action:<reviewed-tag>
 ```
 
-The host publication must remain `127.0.0.1`; the external HTTPS component is the only public exposure.
+This is an operator example only; the repository does not create the env file or its real values.
 
-## 8. Windows / Docker Desktop / WSL 2 runbook
+## 9. Docker Desktop / WSL 2 assumptions
 
-Required layout:
+The deployment is driven from Windows against Docker Desktop's Linux engine. Ubuntu WSL distributions do not need Docker integration enabled and the service is not started inside the Ubuntu distribution as a systemd unit. Source, data, and secret material remain on `D:`.
+
+Expected layout:
 
 ```text
 D:\FossilBrokerWorker\chatgpt-action\
   fossil-core\
-  data\canonical\events\
-  secrets\chatgpt-action.env
+  data\
+    canonical\
+      events\
+  secrets\
+    chatgpt-action.env
 ```
 
-Create non-secret directories in PowerShell:
+## 10. Startup validation
 
-```powershell
-New-Item -ItemType Directory -Force 'D:\FossilBrokerWorker\chatgpt-action\data\canonical\events' | Out-Null
-New-Item -ItemType Directory -Force 'D:\FossilBrokerWorker\chatgpt-action\secrets' | Out-Null
-```
+Before any public exposure, the local integrator should verify the reviewed SHA and run the documented Python test, OpenAPI validation, mutation, and Docker smoke suites.
 
-Docker commands run from Windows against Docker Desktop's WSL2 engine. Docker integration inside Ubuntu/Ubuntu-22.04 is not required.
+After starting the local container, verify mechanically:
 
-Optional Python verification from WSL (no Docker command required there):
+- image/container effective UID/GID are 10001;
+- Docker `HostIp` for `8787/tcp` is `127.0.0.1`;
+- `/var/lib/fossil` reports `RW=false`;
+- an in-container write probe to the canonical mount fails;
+- `GET /openapi.json` advertises the intended HTTPS public origin once the proxy configuration exists;
+- unauthenticated Action call returns 401;
+- authenticated search on the currently empty target corpus returns `200 []`;
+- `/actions/lineage`, `/mcp`, `/ingest`, and mutation-like paths return 404.
 
-```bash
-cd /mnt/d/FossilBrokerWorker/chatgpt-action/fossil-core
-python3 -m venv .venv-linux
-. .venv-linux/bin/activate
-pip install -e '.[test,node]'
-pytest -q tests/test_chatgpt_action.py tests/test_chatgpt_action_server.py tests/test_chatgpt_action_architecture.py tests/holdout/test_chatgpt_action_holdout.py
-python scripts/run_chatgpt_action_mutations.py
-```
+Do not invent fixture corpus content on the real machine to make the empty search non-empty.
 
-## 9. Startup/operational checks
+## 11. Reverse proxy / tunnel contract
 
-Before connecting a private Custom GPT, verify:
+The external component owns TLS, public DNS/hostname, certificate handling, rate limiting if desired, and any provider credentials. It forwards only to the loopback-bound Action port. It must not expose a Docker/Neo4j/FOSSIL admin surface.
 
-1. effective container UID is 10001;
-2. Docker host binding is exactly `127.0.0.1:8787`;
-3. `/var/lib/fossil` has `RW=false`;
-4. an in-container write attempt under `/var/lib/fossil` fails;
-5. no Neo4j credential/connectivity is required;
-6. unauthenticated Action request is `401`;
-7. authenticated search against the current empty corpus is `200 []`;
-8. prohibited routes are `404`;
-9. `/openapi.json` validates and advertises only the intended HTTPS origin;
-10. forged forwarded headers cannot alter a fixed origin, and trusted-proxy mode rejects untrusted peers;
-11. image history/application logs contain no real credential.
+When using trusted-proxy origin mode, configure `FOSSIL_ACTION_TRUSTED_PROXY_CIDRS` to the actual immediate proxy peer range seen by the container. Do not use `0.0.0.0/0` or `::/0` merely to make forwarded headers work.
 
-## 10. Rollback
+## 12. Error behavior
 
-1. disable the external HTTPS route if configured;
-2. stop/remove `fossil-chatgpt-action`;
-3. restore the previous image/tag or checkout the prior commit;
-4. leave `D:\...\data` unchanged;
-5. remove/rotate the local secret separately if desired.
+Public errors are bounded JSON envelopes `{ "error": { "code": ..., "detail": ... } }`. The mapping intentionally avoids stack traces, filesystem paths, bearer tokens, redaction metadata, and local deployment details.
 
-No database migration, projection rebuild, or reverse data migration is required.
+## 13. Operational rollback
 
-## 11. Known limitations
+Because the Action cannot write canonical data, rollback is operationally simple:
 
-- This package does not provision/test a real tunnel provider, DNS name, TLS certificate, or Custom GPT account configuration.
-- Trusted-proxy mode requires the integrator to configure the actual proxy peer CIDR observed by the container; Docker Desktop network addressing can vary.
-- The target canonical event directory is currently empty, so deployment smoke proves empty read behavior but not semantic retrieval quality until real canonical events exist.
+1. disable/remove the external route if it was configured locally;
+2. stop and remove the Action container;
+3. restore/run the previously reviewed image/SHA if needed;
+4. leave canonical data untouched.
+
+No data migration is required for rollback of this edge.
+
+## 14. Verification ownership
+
+Repository CI proves code/package invariants on a specific commit. The local integrator separately proves Windows/Docker Desktop filesystem mapping, local-only secret handling, actual HTTPS endpoint behavior, and private Custom GPT configuration. Neither side may substitute self-report for the other's evidence.

--- a/docs/operations/CHATGPT-ACTION-VERIFICATION.md
+++ b/docs/operations/CHATGPT-ACTION-VERIFICATION.md
@@ -85,7 +85,7 @@ Current required mutants:
 | `widen_route_allowlist` | prohibited/unknown route reaches dispatcher |
 | `enable_commit_route` | durable write route becomes addressable |
 | `remove_body_size_guards` | oversized bodies accepted |
-| `weaken_search_limit_validation` | >100 limit accepted |
+| `weaken_search_limit_validation` | boolean/ambiguous limit accepted as an integer |
 | `allow_extra_capability_fields` | extra JSON fields smuggle new capability |
 | `trust_forwarded_headers_from_any_peer` | forged proxy origin accepted from untrusted peer |
 | `remove_trusted_proxy_origin_support` | correctly configured proxy cannot produce HTTPS schema origin |
@@ -95,7 +95,7 @@ Current required mutants:
 | `enable_uvicorn_global_proxy_headers` | Uvicorn globally trusts forwarded headers |
 | `add_write_method_to_read_store` | read-only event store gains mutation API |
 | `run_container_as_root` | image executes as root |
-| `make_canonical_mount_writable` | canonical Docker mount becomes writable |
+| `make_canonical_mount_writable` | canonical Docker mounts become writable |
 | `remove_loopback_host_binding` | container port becomes publicly/all-interface bound |
 
 The final PR description records the exact killed/surviving/harness-error result from the final workflow. A build-ready result requires no unjustified survivor and no harness error.

--- a/docs/operations/CHATGPT-ACTION-VERIFICATION.md
+++ b/docs/operations/CHATGPT-ACTION-VERIFICATION.md
@@ -1,8 +1,8 @@
-# Verification package — Read-only ChatGPT Action edge
+# Verification package — FOSSIL read-only ChatGPT Action
 
 ## Verification layers
 
-### Focused unit/integration
+### Focused unit / integration / architecture
 
 ```bash
 pytest -q \
@@ -11,129 +11,168 @@ pytest -q \
   tests/test_chatgpt_action_architecture.py
 ```
 
-Covers authentication, request validation, route isolation, canonical delegation, identifier/path safety, environment parsing, explicit HTTPS-origin behavior, non-Neo4j bootstrap, no mutation methods, container/source architecture contracts, and secretless examples.
+These tests cover:
 
-### Independent holdout
+- exact route/method allowlist;
+- bearer authentication, duplicate-header/scheme/token handling, and constant-time comparison contract;
+- request-size, JSON, type/range, extra-field, and opaque-identifier validation;
+- canonical search/read/lineage delegation through the existing authorization boundary;
+- empty canonical data returning `200 []`;
+- sanitized errors and credential/path non-reflection;
+- OpenAPI 3.1 validation using `openapi-spec-validator`;
+- non-empty `components.schemas`, stable operation IDs, explicit successful-response object properties, and bearer security;
+- fixed HTTPS origin and explicit trusted-proxy CIDR behavior;
+- no Graphiti/Neo4j composition and no mutable event-store API;
+- Docker artifact rules for non-root execution, loopback publication, and read-only canonical mount.
+
+### Separately maintainable holdout
 
 ```bash
 pytest -q tests/holdout/test_chatgpt_action_holdout.py
 ```
 
-The holdout suite uses only the public settings/app boundary and observable HTTP behavior where practical. It deliberately does not assert private helper implementations. It covers:
+The holdout suite is black-box separated from focused implementation tests. Its normative plan is `CHATGPT-ACTION-HOLDOUT.md`. It covers absent/malformed/wrong/duplicated credentials, authorization-scheme confusion, forged/missing proxy headers, accidental HTTP schema origin, oversized/malformed payloads, unsupported methods, prohibited/unknown paths, filesystem/capability smuggling, schema regressions, empty-data behavior, and token/configuration leakage.
 
-- malformed/missing/wrong/duplicated authorization;
-- forged `Forwarded` and `X-Forwarded-*` headers;
-- OpenAPI 3.1 validation using `openapi-spec-validator`;
-- valid `components.schemas` and explicit response-object properties;
-- oversized declared and actual request bodies;
-- unknown paths and all prohibited routes;
-- unsupported HTTP methods;
-- filesystem path traversal through `event_id`;
-- read-only event-store surface and boot against a non-writable event directory;
-- invalid search-limit types/ranges;
-- secret non-reflection in schema/capability/error responses.
+Committed tests cannot literally be hidden from the implementation author; downstream integrators may keep additional tests private using the same behavioral plan.
 
-This suite is separated from the focused tests so an external integrator can copy the behavioral cases into a private holdout runner without depending on implementation internals. Because tests committed in a PR cannot literally be secret from the implementation author, the security property is **black-box separation**, not obscurity. A downstream organization may keep an additional copy private using the same behavioral plan.
+### Container / deployment smoke
 
-### Container/deployment smoke
+GitHub workflow:
 
-GitHub workflow: `.github/workflows/chatgpt-action-container.yml`.
+```text
+.github/workflows/chatgpt-action-container.yml
+```
 
-It mechanically verifies:
+The workflow builds the same Linux image used by Docker Desktop and mechanically verifies:
 
-- image builds;
-- process starts with a read-only `/var/lib/fossil` mount;
-- runtime UID/GID are `10001`;
-- canonical event directory is not writable and a write attempt fails;
-- forged forwarded headers do not change the configured HTTPS OpenAPI server URL;
-- unauthenticated search is `401`;
-- authenticated search succeeds;
-- MCP, ingest, write-like, graph, and filesystem routes are `404`;
-- unsupported methods are `405`.
+- image runtime user is non-root;
+- synthetic runtime token is absent from image history/config;
+- effective UID/GID are `10001`;
+- Docker host publication is exactly `127.0.0.1:8787`;
+- `/var/lib/fossil` reports `RW=false`;
+- an in-container canonical-data write probe fails and creates no host file;
+- an existing empty `canonical/events` directory boots successfully;
+- unauthenticated search returns `401`;
+- authenticated empty-corpus search returns exactly `[]`;
+- all prohibited routes remain `404`;
+- fixed HTTPS origin resists forged forwarded headers;
+- a second private Docker-network smoke proves trusted-proxy origin generation works only from the configured proxy peer IP;
+- application logs do not contain the synthetic runtime token.
 
-No real secret is used. The workflow token string is a clearly labeled non-secret CI fixture and is not suitable for deployment.
+The CI token is an obvious non-secret fixture and is never a deployment credential.
 
 ### Mutation assurance
 
+Command:
+
 ```bash
 python scripts/run_chatgpt_action_mutations.py
 ```
 
-GitHub workflow: `.github/workflows/chatgpt-action-mutation.yml`.
+GitHub workflow:
 
-The harness mutates the checked-out files one mutant at a time, runs the independent holdout plus architecture tests in a fresh Python subprocess, and restores the original file after each run. A mutant is **killed** when verification fails as expected; any surviving mutant fails the mutation workflow.
+```text
+.github/workflows/chatgpt-action-mutation.yml
+```
 
-Defined mutants:
+The deterministic harness changes one security property at a time, runs the holdout + architecture suites in a fresh Python subprocess, restores the source file, and fails if a mutant survives or an anchor cannot be applied.
 
-| Mutant | Security regression expected to be killed |
+Current required mutants:
+
+| Mutant | Regression that must be killed |
 | --- | --- |
-| `bypass_bearer_check` | unauthenticated reads enabled |
-| `widen_route_allowlist` | unknown/prohibited routes enter Action dispatcher |
+| `bypass_bearer_check` | authentication bypass |
+| `widen_route_allowlist` | prohibited/unknown route reaches dispatcher |
 | `enable_commit_route` | durable write route becomes addressable |
-| `remove_body_size_guards` | oversized requests accepted |
-| `weaken_search_limit_validation` | ambiguous/out-of-range limits accepted |
-| `trust_request_origin_for_openapi` | public schema origin becomes caller/proxy-header dependent |
-| `remove_components_schemas` | GPT-import schema loses required schema object |
-| `erase_response_properties` | response contract becomes opaque |
-| `enable_proxy_headers` | uvicorn begins trusting forwarded headers |
-| `add_write_method_to_read_store` | Action event-store gains a mutation method |
+| `remove_body_size_guards` | oversized bodies accepted |
+| `weaken_search_limit_validation` | >100 limit accepted |
+| `allow_extra_capability_fields` | extra JSON fields smuggle new capability |
+| `trust_forwarded_headers_from_any_peer` | forged proxy origin accepted from untrusted peer |
+| `remove_trusted_proxy_origin_support` | correctly configured proxy cannot produce HTTPS schema origin |
+| `publish_http_schema_origin` | OpenAPI server regresses to HTTP |
+| `remove_components_schemas` | GPT/OpenAPI schema loses `components.schemas` |
+| `erase_search_response_properties` | successful response object becomes opaque |
+| `enable_uvicorn_global_proxy_headers` | Uvicorn globally trusts forwarded headers |
+| `add_write_method_to_read_store` | read-only event store gains mutation API |
 | `run_container_as_root` | image executes as root |
-| `make_canonical_mount_writable` | deployment contract permits canonical writes |
+| `make_canonical_mount_writable` | canonical Docker mount becomes writable |
+| `remove_loopback_host_binding` | container port becomes publicly/all-interface bound |
 
-The PR delivery evidence records killed/surviving counts from the final mutation workflow run. Surviving mutants must be either fixed or explicitly justified before this package is considered build-ready.
+The final PR description records the exact killed/surviving/harness-error result from the final workflow. A build-ready result requires no unjustified survivor and no harness error.
 
-## OpenAPI / private Custom GPT compatibility
+## OpenAPI / private Custom GPT compatibility checks
 
-`/openapi.json` must pass `openapi-spec-validator` and preserve:
+`/openapi.json` must pass an independent OpenAPI 3.1 validator and preserve:
 
 - OpenAPI 3.1.x;
-- `components.schemas` as an object;
-- HTTP bearer security scheme;
-- unique operation IDs;
-- explicit response schemas/properties;
-- exactly four Action operation paths;
-- HTTPS `servers[0].url` when `FOSSIL_ACTION_PUBLIC_BASE_URL` is configured;
-- no MCP/ingest/write/mutation operations.
+- a non-empty `components.schemas` object;
+- named request schemas;
+- explicit successful-response object properties;
+- explicit `ErrorEnvelope` responses;
+- HTTP bearer security;
+- four unique/stable operation IDs;
+- exactly four authenticated Action paths;
+- an HTTPS `servers[0].url` only;
+- no MCP, ingest, proposal, validation, commit, redaction, graph/filesystem/admin operation;
+- no runtime token/configuration value.
 
-No CI test logs into ChatGPT, creates a GPT, uploads a credential, provisions a tunnel, or uses a real token. Final UI import/auth is a local integrator step after repository verification.
+No automated test logs into ChatGPT, creates a GPT, provisions a tunnel/DNS/TLS endpoint, or handles a real credential.
 
-## Windows / WSL `D:` acceptance recipe
+## Windows / Docker Desktop / WSL 2 acceptance recipe
+
+Required checkout and persistent layout:
+
+```text
+D:\FossilBrokerWorker\chatgpt-action\
+  fossil-core\
+  data\canonical\events\
+  secrets\chatgpt-action.env
+```
+
+Optional Python verification from WSL:
 
 ```bash
-cd /mnt/d/fossil/fossil-core
+cd /mnt/d/FossilBrokerWorker/chatgpt-action/fossil-core
 git fetch origin pull/235/head:pr-235
 git checkout pr-235
-python -m venv .venv
-. .venv/bin/activate
+python3 -m venv .venv-linux
+. .venv-linux/bin/activate
 pip install -e '.[test,node]'
 pytest -q tests/test_chatgpt_action.py tests/test_chatgpt_action_server.py tests/test_chatgpt_action_architecture.py tests/holdout/test_chatgpt_action_holdout.py
 python scripts/run_chatgpt_action_mutations.py
-docker build -f docker/chatgpt-action/Dockerfile -t fossil-chatgpt-action:pr235 .
 ```
 
-The local integrator then uses `/mnt/d/...` (or an equivalent WSL path) for the canonical data bind and keeps all populated environment/secret material outside the repository. Deployment itself is not part of this package.
+Docker Desktop verification/build from Windows PowerShell:
+
+```powershell
+Set-Location 'D:\FossilBrokerWorker\chatgpt-action\fossil-core'
+docker build --file docker/chatgpt-action/Dockerfile --tag fossil-chatgpt-action:pr235 .
+```
+
+Docker commands do not require Docker integration inside the Ubuntu WSL distribution. The local integrator later creates the real `D:\...\secrets\chatgpt-action.env`, bind-mounts `D:\...\data` read-only, publishes only `127.0.0.1:8787`, establishes the HTTPS edge, and configures the private Custom GPT. Those steps are deliberately not executed by this PR.
 
 ## Known limitations
 
-- The Action is deliberately read-only; it cannot ingest or persist new knowledge.
-- Standalone lineage availability depends on lineage data being available through the existing `CorpusService` composition; this PR does not add a projection/database query path.
-- TLS/proxy/tunnel uptime, DNS, certificates, and rate limiting at the public edge are operator responsibilities.
-- One static bearer credential is the v1 auth model. OAuth/multi-user identity is out of scope.
-- CI validates the API/schema and container behavior but cannot prove an actual private Custom GPT account configuration without handling credentials, which this package explicitly forbids.
-- The committed holdout is behaviorally independent but not literally hidden; downstream integrators can run the documented cases privately.
+- The Action is deliberately read-only and cannot ingest or persist new knowledge.
+- The target canonical event directory is currently empty; smoke validation proves correct empty behavior but not semantic retrieval quality.
+- Standalone lineage availability depends on lineage data being present in the existing `CorpusService` composition; this PR does not add a new graph/projection query path.
+- TLS/tunnel/DNS uptime and edge rate limiting remain operator responsibilities.
+- Trusted-proxy mode requires the local integrator to identify the actual proxy peer CIDR observed by the container; Docker Desktop network addressing may differ by installation.
+- One static bearer credential is the v1 auth model; OAuth/multi-user identity is out of scope.
+- CI cannot prove a real private Custom GPT account configuration without handling credentials, which is explicitly prohibited.
 
-## Rollback plan
+## Rollback
 
-There are no migrations and no Action-side writes. Rollback is:
+There are no data migrations and no Action-side writes. Rollback is:
 
-1. do not import/use the Action schema, or remove the Action from the private GPT if already configured locally;
-2. stop/remove the Action process/container;
-3. remove the external HTTPS route locally;
-4. checkout/revert to the pre-PR repository SHA;
-5. leave canonical FOSSIL data untouched.
+1. disable/remove the external HTTPS route if one was configured locally;
+2. stop/remove the Action container;
+3. restore the previous image/tag or repository SHA;
+4. leave `D:\FossilBrokerWorker\chatgpt-action\data` untouched;
+5. locally remove/rotate a runtime token if desired.
 
-No durable event, projection, Neo4j state, or pack contract requires rollback because this feature has no write capability.
+No durable event, projection, or Neo4j state requires reversal.
 
 ## Delivery evidence
 
-The exact final PR head SHA, workflow run IDs/results, mutation killed/survived count, and any remaining limitations are recorded in the PR description/conversation after the final CI pass. This avoids a self-referential commit-SHA problem inside a file whose own update would change that SHA.
+The exact final PR head SHA, workflow run IDs/results, mutation killed/survived count, and remaining limitations are recorded in PR #235 after the final CI pass. Keeping that evidence in the PR avoids a self-referential commit-SHA change inside this tracked document.

--- a/docs/operations/CHATGPT-ACTION-VERIFICATION.md
+++ b/docs/operations/CHATGPT-ACTION-VERIFICATION.md
@@ -1,0 +1,139 @@
+# Verification package — Read-only ChatGPT Action edge
+
+## Verification layers
+
+### Focused unit/integration
+
+```bash
+pytest -q \
+  tests/test_chatgpt_action.py \
+  tests/test_chatgpt_action_server.py \
+  tests/test_chatgpt_action_architecture.py
+```
+
+Covers authentication, request validation, route isolation, canonical delegation, identifier/path safety, environment parsing, explicit HTTPS-origin behavior, non-Neo4j bootstrap, no mutation methods, container/source architecture contracts, and secretless examples.
+
+### Independent holdout
+
+```bash
+pytest -q tests/holdout/test_chatgpt_action_holdout.py
+```
+
+The holdout suite uses only the public settings/app boundary and observable HTTP behavior where practical. It deliberately does not assert private helper implementations. It covers:
+
+- malformed/missing/wrong/duplicated authorization;
+- forged `Forwarded` and `X-Forwarded-*` headers;
+- OpenAPI 3.1 validation using `openapi-spec-validator`;
+- valid `components.schemas` and explicit response-object properties;
+- oversized declared and actual request bodies;
+- unknown paths and all prohibited routes;
+- unsupported HTTP methods;
+- filesystem path traversal through `event_id`;
+- read-only event-store surface and boot against a non-writable event directory;
+- invalid search-limit types/ranges;
+- secret non-reflection in schema/capability/error responses.
+
+This suite is separated from the focused tests so an external integrator can copy the behavioral cases into a private holdout runner without depending on implementation internals. Because tests committed in a PR cannot literally be secret from the implementation author, the security property is **black-box separation**, not obscurity. A downstream organization may keep an additional copy private using the same behavioral plan.
+
+### Container/deployment smoke
+
+GitHub workflow: `.github/workflows/chatgpt-action-container.yml`.
+
+It mechanically verifies:
+
+- image builds;
+- process starts with a read-only `/var/lib/fossil` mount;
+- runtime UID/GID are `10001`;
+- canonical event directory is not writable and a write attempt fails;
+- forged forwarded headers do not change the configured HTTPS OpenAPI server URL;
+- unauthenticated search is `401`;
+- authenticated search succeeds;
+- MCP, ingest, write-like, graph, and filesystem routes are `404`;
+- unsupported methods are `405`.
+
+No real secret is used. The workflow token string is a clearly labeled non-secret CI fixture and is not suitable for deployment.
+
+### Mutation assurance
+
+```bash
+python scripts/run_chatgpt_action_mutations.py
+```
+
+GitHub workflow: `.github/workflows/chatgpt-action-mutation.yml`.
+
+The harness mutates the checked-out files one mutant at a time, runs the independent holdout plus architecture tests in a fresh Python subprocess, and restores the original file after each run. A mutant is **killed** when verification fails as expected; any surviving mutant fails the mutation workflow.
+
+Defined mutants:
+
+| Mutant | Security regression expected to be killed |
+| --- | --- |
+| `bypass_bearer_check` | unauthenticated reads enabled |
+| `widen_route_allowlist` | unknown/prohibited routes enter Action dispatcher |
+| `enable_commit_route` | durable write route becomes addressable |
+| `remove_body_size_guards` | oversized requests accepted |
+| `weaken_search_limit_validation` | ambiguous/out-of-range limits accepted |
+| `trust_request_origin_for_openapi` | public schema origin becomes caller/proxy-header dependent |
+| `remove_components_schemas` | GPT-import schema loses required schema object |
+| `erase_response_properties` | response contract becomes opaque |
+| `enable_proxy_headers` | uvicorn begins trusting forwarded headers |
+| `add_write_method_to_read_store` | Action event-store gains a mutation method |
+| `run_container_as_root` | image executes as root |
+| `make_canonical_mount_writable` | deployment contract permits canonical writes |
+
+The PR delivery evidence records killed/surviving counts from the final mutation workflow run. Surviving mutants must be either fixed or explicitly justified before this package is considered build-ready.
+
+## OpenAPI / private Custom GPT compatibility
+
+`/openapi.json` must pass `openapi-spec-validator` and preserve:
+
+- OpenAPI 3.1.x;
+- `components.schemas` as an object;
+- HTTP bearer security scheme;
+- unique operation IDs;
+- explicit response schemas/properties;
+- exactly four Action operation paths;
+- HTTPS `servers[0].url` when `FOSSIL_ACTION_PUBLIC_BASE_URL` is configured;
+- no MCP/ingest/write/mutation operations.
+
+No CI test logs into ChatGPT, creates a GPT, uploads a credential, provisions a tunnel, or uses a real token. Final UI import/auth is a local integrator step after repository verification.
+
+## Windows / WSL `D:` acceptance recipe
+
+```bash
+cd /mnt/d/fossil/fossil-core
+git fetch origin pull/235/head:pr-235
+git checkout pr-235
+python -m venv .venv
+. .venv/bin/activate
+pip install -e '.[test,node]'
+pytest -q tests/test_chatgpt_action.py tests/test_chatgpt_action_server.py tests/test_chatgpt_action_architecture.py tests/holdout/test_chatgpt_action_holdout.py
+python scripts/run_chatgpt_action_mutations.py
+docker build -f docker/chatgpt-action/Dockerfile -t fossil-chatgpt-action:pr235 .
+```
+
+The local integrator then uses `/mnt/d/...` (or an equivalent WSL path) for the canonical data bind and keeps all populated environment/secret material outside the repository. Deployment itself is not part of this package.
+
+## Known limitations
+
+- The Action is deliberately read-only; it cannot ingest or persist new knowledge.
+- Standalone lineage availability depends on lineage data being available through the existing `CorpusService` composition; this PR does not add a projection/database query path.
+- TLS/proxy/tunnel uptime, DNS, certificates, and rate limiting at the public edge are operator responsibilities.
+- One static bearer credential is the v1 auth model. OAuth/multi-user identity is out of scope.
+- CI validates the API/schema and container behavior but cannot prove an actual private Custom GPT account configuration without handling credentials, which this package explicitly forbids.
+- The committed holdout is behaviorally independent but not literally hidden; downstream integrators can run the documented cases privately.
+
+## Rollback plan
+
+There are no migrations and no Action-side writes. Rollback is:
+
+1. do not import/use the Action schema, or remove the Action from the private GPT if already configured locally;
+2. stop/remove the Action process/container;
+3. remove the external HTTPS route locally;
+4. checkout/revert to the pre-PR repository SHA;
+5. leave canonical FOSSIL data untouched.
+
+No durable event, projection, Neo4j state, or pack contract requires rollback because this feature has no write capability.
+
+## Delivery evidence
+
+The exact final PR head SHA, workflow run IDs/results, mutation killed/survived count, and any remaining limitations are recorded in the PR description/conversation after the final CI pass. This avoids a self-referential commit-SHA problem inside a file whose own update would change that SHA.

--- a/docs/operations/CHATGPT-ACTION-VERIFICATION.md
+++ b/docs/operations/CHATGPT-ACTION-VERIFICATION.md
@@ -5,174 +5,139 @@
 ### Focused unit / integration / architecture
 
 ```bash
+pip install -e '.[test,node]'
 pytest -q \
   tests/test_chatgpt_action.py \
   tests/test_chatgpt_action_server.py \
-  tests/test_chatgpt_action_architecture.py
+  tests/test_chatgpt_action_architecture.py \
+  tests/holdout/test_chatgpt_action_holdout.py
 ```
 
-These tests cover:
+These tests cover the exact search/read/capabilities route boundary, bearer authentication, input validation, OpenAPI 3.1 compatibility, the real standalone environment composition, redaction suppression, empty-corpus behavior, bounded streaming request reads, trusted-proxy origin handling, forged direct-HTTPS Host rejection, and non-leakage behavior.
 
-- exact route/method allowlist;
-- bearer authentication, duplicate-header/scheme/token handling, and constant-time comparison contract;
-- request-size, JSON, type/range, extra-field, and opaque-identifier validation;
-- canonical search/read/lineage delegation through the existing authorization boundary;
-- empty canonical data returning `200 []`;
-- sanitized errors and credential/path non-reflection;
-- OpenAPI 3.1 validation using `openapi-spec-validator`;
-- non-empty `components.schemas`, stable operation IDs, explicit successful-response object properties, and bearer security;
-- fixed HTTPS origin and explicit trusted-proxy CIDR behavior;
-- no Graphiti/Neo4j composition and no mutable event-store API;
-- Docker artifact rules for non-root execution, loopback publication, and read-only canonical mount.
+OpenAPI validation is performed in both focused and holdout tests with `openapi-spec-validator`. The schema must contain a non-empty `components.schemas` object, explicit successful-response properties, unique operation IDs, and no `/actions/lineage` or mutation routes.
 
-### Separately maintainable holdout
+### Targeted mutation assurance
 
 ```bash
-pytest -q tests/holdout/test_chatgpt_action_holdout.py
+python scripts/run_chatgpt_action_mutations.py
 ```
 
-The holdout suite is black-box separated from focused implementation tests. Its normative plan is `CHATGPT-ACTION-HOLDOUT.md`. It covers absent/malformed/wrong/duplicated credentials, authorization-scheme confusion, forged/missing proxy headers, accidental HTTP schema origin, oversized/malformed payloads, unsupported methods, prohibited/unknown paths, filesystem/capability smuggling, schema regressions, empty-data behavior, and token/configuration leakage.
+The command runs the independent holdout plus architecture checks against each deliberate mutant. It returns non-zero if any mutant survives or any mutation anchor cannot be applied.
 
-Committed tests cannot literally be hidden from the implementation author; downstream integrators may keep additional tests private using the same behavioral plan.
+Current mutant families include:
 
-### Container / deployment smoke
+- bearer bypass;
+- route-allowlist widening;
+- lineage-route reintroduction without a provider;
+- accidental durable commit route;
+- removal of declared body-size guard;
+- removal of streaming body-size guard;
+- weakened search-limit validation;
+- extra-field capability smuggling;
+- forwarded-header trust from untrusted peers;
+- loss of trusted-proxy HTTPS support;
+- caller-controlled direct HTTPS `Host` trusted as origin;
+- HTTP schema origin;
+- missing `components.schemas`;
+- erased response properties;
+- redacted event bytes made searchable;
+- `_redactions` paths reintroduced into event iteration;
+- global Uvicorn proxy-header trust;
+- write method added to the read-only event store;
+- root container execution;
+- writable canonical mount;
+- non-loopback Docker publication.
 
-GitHub workflow:
+No surviving mutant is an acceptable release result.
+
+### Container smoke
+
+Reference workflow:
 
 ```text
 .github/workflows/chatgpt-action-container.yml
 ```
 
-The workflow builds the same Linux image used by Docker Desktop and mechanically verifies:
+It builds the actual Docker image and proves:
 
-- image runtime user is non-root;
-- synthetic runtime token is absent from image history/config;
-- effective UID/GID are `10001`;
-- Docker host publication is exactly `127.0.0.1:8787`;
-- `/var/lib/fossil` reports `RW=false`;
-- an in-container canonical-data write probe fails and creates no host file;
-- an existing empty `canonical/events` directory boots successfully;
-- unauthenticated search returns `401`;
-- authenticated empty-corpus search returns exactly `[]`;
-- all prohibited routes remain `404`;
-- fixed HTTPS origin resists forged forwarded headers;
-- a second private Docker-network smoke proves trusted-proxy origin generation works only from the configured proxy peer IP;
-- application logs do not contain the synthetic runtime token.
+- image/config contains no synthetic runtime credential;
+- effective UID/GID is 10001;
+- host publication is `127.0.0.1` only;
+- `/var/lib/fossil` is `RW=false` and rejects a write probe;
+- OpenAPI contains only search/read/capabilities and an HTTPS public origin;
+- forged host/forwarded values cannot override fixed origin;
+- unauthenticated Action access returns 401;
+- search remains empty for an unrelated query;
+- redacted event bytes and tombstone markers are not searchable;
+- redacted read returns generic 404 without redaction metadata;
+- `/actions/lineage`, MCP, ingest and mutation-like routes return 404;
+- explicitly trusted proxy peer can generate the forwarded HTTPS origin;
+- runtime token does not appear in application logs.
 
-The CI token is an obvious non-secret fixture and is never a deployment credential.
+### Repository regression gates
 
-### Mutation assurance
+The exact candidate head must also pass:
 
-Command:
+- `DKG contract tests`;
+- `Dependency integrity` including architecture-boundary and metadata/reproducible-install jobs;
+- `ChatGPT Action container`;
+- `ChatGPT Action mutation assurance`.
 
-```bash
-python scripts/run_chatgpt_action_mutations.py
-```
+Other repository workflows may run as normal; delivery evidence must distinguish required Action gates from unrelated optional/live integrations.
 
-GitHub workflow:
+## Windows / D: local integrator verification
 
-```text
-.github/workflows/chatgpt-action-mutation.yml
-```
-
-The deterministic harness changes one security property at a time, runs the holdout + architecture suites in a fresh Python subprocess, restores the source file, and fails if a mutant survives or an anchor cannot be applied.
-
-Current required mutants:
-
-| Mutant | Regression that must be killed |
-| --- | --- |
-| `bypass_bearer_check` | authentication bypass |
-| `widen_route_allowlist` | prohibited/unknown route reaches dispatcher |
-| `enable_commit_route` | durable write route becomes addressable |
-| `remove_body_size_guards` | oversized bodies accepted |
-| `weaken_search_limit_validation` | boolean/ambiguous limit accepted as an integer |
-| `allow_extra_capability_fields` | extra JSON fields smuggle new capability |
-| `trust_forwarded_headers_from_any_peer` | forged proxy origin accepted from untrusted peer |
-| `remove_trusted_proxy_origin_support` | correctly configured proxy cannot produce HTTPS schema origin |
-| `publish_http_schema_origin` | OpenAPI server regresses to HTTP |
-| `remove_components_schemas` | GPT/OpenAPI schema loses `components.schemas` |
-| `erase_search_response_properties` | successful response object becomes opaque |
-| `enable_uvicorn_global_proxy_headers` | Uvicorn globally trusts forwarded headers |
-| `add_write_method_to_read_store` | read-only event store gains mutation API |
-| `run_container_as_root` | image executes as root |
-| `make_canonical_mount_writable` | canonical Docker mounts become writable |
-| `remove_loopback_host_binding` | container port becomes publicly/all-interface bound |
-
-The final PR description records the exact killed/surviving/harness-error result from the final workflow. A build-ready result requires no unjustified survivor and no harness error.
-
-## OpenAPI / private Custom GPT compatibility checks
-
-`/openapi.json` must pass an independent OpenAPI 3.1 validator and preserve:
-
-- OpenAPI 3.1.x;
-- a non-empty `components.schemas` object;
-- named request schemas;
-- explicit successful-response object properties;
-- explicit `ErrorEnvelope` responses;
-- HTTP bearer security;
-- four unique/stable operation IDs;
-- exactly four authenticated Action paths;
-- an HTTPS `servers[0].url` only;
-- no MCP, ingest, proposal, validation, commit, redaction, graph/filesystem/admin operation;
-- no runtime token/configuration value.
-
-No automated test logs into ChatGPT, creates a GPT, provisions a tunnel/DNS/TLS endpoint, or handles a real credential.
-
-## Windows / Docker Desktop / WSL 2 acceptance recipe
-
-Required checkout and persistent layout:
+Target layout:
 
 ```text
 D:\FossilBrokerWorker\chatgpt-action\
   fossil-core\
-  data\canonical\events\
-  secrets\chatgpt-action.env
+  data\
+    canonical\
+      events\
+  secrets\
+    chatgpt-action.env
 ```
 
-Optional Python verification from WSL:
+The integrator should clone/checkout the exact reviewed PR head under `D:\FossilBrokerWorker\chatgpt-action\fossil-core`, run the Python/mutation suite, build the image with Docker Desktop, and inspect the same UID, bind address, and read-only mount properties as CI.
 
-```bash
-cd /mnt/d/FossilBrokerWorker/chatgpt-action/fossil-core
-git fetch origin pull/235/head:pr-235
-git checkout pr-235
-python3 -m venv .venv-linux
-. .venv-linux/bin/activate
-pip install -e '.[test,node]'
-pytest -q tests/test_chatgpt_action.py tests/test_chatgpt_action_server.py tests/test_chatgpt_action_architecture.py tests/holdout/test_chatgpt_action_holdout.py
-python scripts/run_chatgpt_action_mutations.py
-```
+The target canonical data directory may be empty. The expected authenticated search result in that state is exactly `200 []`.
 
-Docker Desktop verification/build from Windows PowerShell:
+Do not create a real bearer token until local deployment/configuration work begins. Real tunnel/provider and Custom GPT credentials are outside this repository package.
 
-```powershell
-Set-Location 'D:\FossilBrokerWorker\chatgpt-action\fossil-core'
-docker build --file docker/chatgpt-action/Dockerfile --tag fossil-chatgpt-action:pr235 .
-```
+## Required delivery evidence
 
-Docker commands do not require Docker integration inside the Ubuntu WSL distribution. The local integrator later creates the real `D:\...\secrets\chatgpt-action.env`, bind-mounts `D:\...\data` read-only, publishes only `127.0.0.1:8787`, establishes the HTTPS edge, and configures the private Custom GPT. Those steps are deliberately not executed by this PR.
+The PR conversation must record, for the final code/documentation head:
+
+- exact commit SHA;
+- DKG contract-test run ID/result;
+- ChatGPT Action container run ID/result;
+- Dependency integrity run ID/results;
+- ChatGPT Action mutation run ID/result and killed/surviving/harness-error counts;
+- any known limitations;
+- rollback procedure;
+- confirmation that no real bearer secret, tunnel/provider credential, or Custom GPT credential was created, handled, or committed.
+
+Do not reuse green evidence from an earlier SHA after changing production code, tests, workflows, or normative documentation.
 
 ## Known limitations
 
 - The Action is deliberately read-only and cannot ingest or persist new knowledge.
-- The target canonical event directory is currently empty; smoke validation proves correct empty behavior but not semantic retrieval quality.
-- Standalone lineage availability depends on lineage data being present in the existing `CorpusService` composition; this PR does not add a new graph/projection query path.
-- TLS/tunnel/DNS uptime and edge rate limiting remain operator responsibilities.
-- Trusted-proxy mode requires the local integrator to identify the actual proxy peer CIDR observed by the container; Docker Desktop network addressing may differ by installation.
-- One static bearer credential is the v1 auth model; OAuth/multi-user identity is out of scope.
-- CI cannot prove a real private Custom GPT account configuration without handling credentials, which is explicitly prohibited.
+- `/actions/lineage` is intentionally absent because the standalone composition has no durable lineage provider. FOSSIL domain/MCP lineage support is unchanged.
+- The target canonical event directory is currently empty; smoke validation proves correct empty behavior, not semantic retrieval quality.
+- TLS/tunnel/DNS uptime, public-edge rate limiting, and real Custom GPT configuration remain local-operator responsibilities.
+- Trusted-proxy mode requires the operator to identify the actual immediate proxy peer CIDR seen by the container.
+- One static bearer credential is the v1 Action authentication model; OAuth/multi-user identity is out of scope.
+- CI cannot prove the operator's real Windows `D:` filesystem permissions, tunnel configuration, or private Custom GPT account without handling local credentials, which this package explicitly does not do.
 
 ## Rollback
 
-There are no data migrations and no Action-side writes. Rollback is:
+If a locally deployed candidate fails integration:
 
-1. disable/remove the external HTTPS route if one was configured locally;
+1. remove/disable the public route if it was configured;
 2. stop/remove the Action container;
-3. restore the previous image/tag or repository SHA;
-4. leave `D:\FossilBrokerWorker\chatgpt-action\data` untouched;
-5. locally remove/rotate a runtime token if desired.
+3. return to the previously reviewed image/SHA;
+4. leave canonical data untouched.
 
-No durable event, projection, or Neo4j state requires reversal.
-
-## Delivery evidence
-
-The exact final PR head SHA, workflow run IDs/results, mutation killed/survived count, and remaining limitations are recorded in PR #235 after the final CI pass. Keeping that evidence in the PR avoids a self-referential commit-SHA change inside this tracked document.
+The Action cannot mutate canonical data, so rollback requires no knowledge-store migration.

--- a/docs/operations/CHATGPT-ACTION.md
+++ b/docs/operations/CHATGPT-ACTION.md
@@ -1,97 +1,65 @@
-# ChatGPT Custom GPT Action boundary
+# FOSSIL read-only ChatGPT Action — operator entrypoint
 
-This is the operator entrypoint for the **read-only compatibility edge** used by a private ChatGPT Custom GPT. Detailed design and verification live in:
+This PR packages a private, bearer-authenticated, read-only GPT Action edge. It does **not** deploy, create secrets, create tunnels, or configure a Custom GPT.
 
-- `CHATGPT-ACTION-PDD.md` — user problem, threat model, trust boundaries, non-goals;
+Design/verification documents:
+
+- `CHATGPT-ACTION-PDD.md` — problem, scope, threat model, trust boundaries, exact Windows target;
 - `CHATGPT-ACTION-INVARIANTS.md` — normative machine-testable invariants;
-- `CHATGPT-ACTION-SDD.md` — architecture, API, environment, container, proxy, WSL handoff;
-- `CHATGPT-ACTION-VERIFICATION.md` — focused/holdout/mutation verification and delivery evidence.
+- `CHATGPT-ACTION-SDD.md` — architecture, API/OpenAPI contract, proxy rules, Docker Desktop runbook;
+- `CHATGPT-ACTION-HOLDOUT.md` — separately maintainable black-box holdout plan;
+- `CHATGPT-ACTION-VERIFICATION.md` — focused/container/mutation verification and delivery evidence.
 
-The Action edge does not change FOSSIL truth authority, pack authorization, provenance, or the MCP contract.
+## Exact read-only boundary
 
-## Security boundary
+Public, unauthenticated:
 
-The dedicated Action service exposes only:
+- `GET /openapi.json`
 
-- `GET /openapi.json` — public OpenAPI discovery;
-- `POST /actions/search` — authenticated FOSSIL search;
-- `POST /actions/read` — authenticated durable-event read;
-- `POST /actions/lineage` — authenticated lineage read;
-- `GET /actions/capabilities` — authenticated read-only capability metadata.
+Bearer-protected:
 
-It deliberately exposes **no** MCP, ingest, proposal, validation, commit, redaction, Graphiti/Neo4j API, graph mutation, arbitrary filesystem access, shell/admin operation, or credential surface.
+- `POST /actions/search`
+- `POST /actions/read`
+- `POST /actions/lineage`
+- `GET /actions/capabilities`
 
-All `/actions/*` operations require bearer authentication. `/openapi.json` is intentionally unauthenticated and contains no secret.
+Prohibited even when authenticated:
 
-## Standalone runtime
+- MCP and `/mcp`;
+- ingest and `/ingest`;
+- proposal, validation, commit, redaction, write, admin, or management routes;
+- Neo4j/Graphiti query or mutation surfaces;
+- arbitrary graph mutation/query language;
+- arbitrary filesystem access, shell/process control, or runtime-configuration disclosure;
+- secret/token/credential disclosure.
 
-The entrypoint is:
+## Target environment
+
+The build-ready target is:
+
+- Windows host;
+- Docker Desktop Linux engine with WSL 2 backend;
+- Ubuntu/Ubuntu-22.04 may be used for Python verification, but Docker integration inside those distros is not required;
+- no Podman/systemd/Quadlet/cloud-VM assumption;
+- all persistent material under:
 
 ```text
-fossil-chatgpt-action
+D:\FossilBrokerWorker\chatgpt-action\
+  fossil-core\
+  data\canonical\events\
+  secrets\chatgpt-action.env
 ```
 
-It boots directly from canonical FOSSIL events plus pack and skill contracts. It does not initialize Graphiti or Neo4j. The Action-specific event-store view has read methods only and is designed to boot against a physically read-only canonical mount.
+The current target `data\canonical\events` is empty. Authenticated search must therefore return `200 []`, never fabricated content.
 
-Runtime variables:
+## Build and verification
 
-```text
-FOSSIL_ACTION_BEARER_TOKEN      required; runtime-only; at least 32 characters
-FOSSIL_ACTION_HOST              default 127.0.0.1
-FOSSIL_ACTION_PORT              default 8787
-FOSSIL_ACTION_MAX_REQUEST_BYTES default 65536
-FOSSIL_ACTION_PUBLIC_BASE_URL   production HTTPS origin advertised in OpenAPI
-FOSSIL_REPOSITORY_ROOT          default current working directory
-FOSSIL_DATA_ROOT                default <repository>/data
-FOSSIL_PACK_MANIFEST            default examples/packs/common/manifest.json
-```
-
-This package does not create, receive, print, or deploy any real token or endpoint credential. The operator supplies those locally after code review.
-
-## Container build
-
-From the repository root:
+From WSL, Python-only verification can run against the checkout on `D:`:
 
 ```bash
-podman build \
-  -f docker/chatgpt-action/Dockerfile \
-  -t localhost/fossil-chatgpt-action:local \
-  .
-```
-
-The container runs as UID/GID 10001. Production launch must mount canonical data read-only at `/var/lib/fossil`; the expected event path is `/var/lib/fossil/canonical/events`.
-
-No real launch command with a credential is included here. Use `config/chatgpt-action.env.example` only as a field-name template and keep the populated file outside source control.
-
-## Public HTTPS edge
-
-ChatGPT reaches the Action through operator-managed HTTPS. Tailscale is not required for this Action path. The reverse proxy/tunnel, DNS, TLS certificate, and provider credentials are all out of scope for this PR.
-
-The Action process **does not trust `Forwarded` or `X-Forwarded-*` headers** to determine its public origin. Uvicorn proxy-header processing is disabled. Instead the local operator sets an explicit origin:
-
-```text
-FOSSIL_ACTION_PUBLIC_BASE_URL=https://<public-action-origin>
-```
-
-That value must be an origin-only `https://` URL. `/openapi.json` then emits it exactly in `servers[0].url`, so the schema remains correct even when the internal hop is plain HTTP and even if a caller forges forwarded headers.
-
-The external HTTPS edge must forward only the Action service. It must not publish the private FOSSIL Node, MCP, ingestion, Neo4j, or admin surfaces.
-
-## Windows / WSL `D:` integrator handoff
-
-A supported local layout is:
-
-```text
-D:\fossil\fossil-core   -> /mnt/d/fossil/fossil-core
-D:\fossil\data          -> /mnt/d/fossil/data
-```
-
-From WSL:
-
-```bash
-cd /mnt/d/fossil/fossil-core
-python -m venv .venv
-. .venv/bin/activate
+cd /mnt/d/FossilBrokerWorker/chatgpt-action/fossil-core
+python3 -m venv .venv-linux
+. .venv-linux/bin/activate
 pip install -e '.[test,node]'
 pytest -q \
   tests/test_chatgpt_action.py \
@@ -99,29 +67,75 @@ pytest -q \
   tests/test_chatgpt_action_architecture.py \
   tests/holdout/test_chatgpt_action_holdout.py
 python scripts/run_chatgpt_action_mutations.py
-docker build -f docker/chatgpt-action/Dockerfile -t fossil-chatgpt-action:local .
 ```
 
-The local integrator can then perform machine-specific configuration with locally generated secrets and an HTTPS endpoint. Those actions are intentionally not performed by this PR or its CI.
+Docker commands run from Windows PowerShell against Docker Desktop:
 
-## Private Custom GPT setup boundary
+```powershell
+Set-Location 'D:\FossilBrokerWorker\chatgpt-action\fossil-core'
+docker build --file docker/chatgpt-action/Dockerfile --tag fossil-chatgpt-action:pr235 .
+```
 
-After the local endpoint passes verification, the operator may import `https://<public-action-origin>/openapi.json` into a private Custom GPT and configure the same locally managed bearer credential in the GPT Action authentication UI.
+The image runs as UID/GID 10001. Canonical data is mounted read-only at `/var/lib/fossil`. The Windows host port is published only as `127.0.0.1:8787`.
 
-This repository never stores or handles the real Custom GPT credential. The GPT must remain read-only because the imported OpenAPI document contains only search, read, lineage, and capabilities.
+## HTTPS schema origin
 
-## Acceptance checks
+`/openapi.json` never advertises a plain-HTTP public server URL.
 
-Before use, verify:
+Preferred fixed mode:
 
-- OpenAPI validates as 3.1 and has a real `components.schemas` object;
-- `servers[0].url` is the configured HTTPS origin despite forged forwarded headers;
-- only the four Action operations appear in `paths`;
-- `/actions/*` rejects malformed/missing/wrong bearer credentials;
-- request-size/type/range validation fails closed;
-- `/mcp`, `/ingest`, proposal, validation, commit, redaction, graph, filesystem, and admin paths return `404`;
-- path-like `event_id` values are rejected before filesystem access;
-- the container runs non-root and canonical data is physically read-only;
-- Action startup requires no Neo4j/Graphiti credential or connectivity;
-- focused, holdout, container, architecture, and mutation checks are green;
-- no real secret value exists in Git, CI, docs, issue comments, or test fixtures.
+```text
+FOSSIL_ACTION_PUBLIC_BASE_URL=https://<public-origin>
+```
+
+The fixed origin is authoritative and forged forwarded headers cannot override it.
+
+Trusted-proxy mode is also supported when a fixed origin is not used:
+
+```text
+FOSSIL_ACTION_TRUSTED_PROXY_CIDRS=<explicit proxy peer CIDR(s)>
+```
+
+Only requests from those networks may use one `X-Forwarded-Proto: https` and one valid `X-Forwarded-Host` to define the OpenAPI origin. Uvicorn runs with `proxy_headers=False`; wildcard proxy trust is not part of the design. If no trusted HTTPS origin exists, `/openapi.json` returns `503` instead of publishing internal HTTP.
+
+## Runtime variables
+
+```text
+FOSSIL_ACTION_BEARER_TOKEN      required, runtime-only, >=32 characters
+FOSSIL_ACTION_HOST              image uses 0.0.0.0; Windows publish remains loopback-only
+FOSSIL_ACTION_PORT              default 8787
+FOSSIL_ACTION_MAX_REQUEST_BYTES default 65536
+FOSSIL_ACTION_PUBLIC_BASE_URL   optional fixed HTTPS origin
+FOSSIL_ACTION_TRUSTED_PROXY_CIDRS optional explicit proxy source networks
+FOSSIL_REPOSITORY_ROOT          image /opt/fossil-core
+FOSSIL_DATA_ROOT                image /var/lib/fossil
+FOSSIL_PACK_MANIFEST            read-pack manifest
+```
+
+`config/chatgpt-action.env.example` contains placeholders only. The local integrator creates the populated file under `D:\...\secrets` after review; it is never committed.
+
+## Docker Desktop launch shape
+
+Documentation only — the PR does not execute this and contains no real credential:
+
+```powershell
+docker run --detach `
+  --name fossil-chatgpt-action `
+  --restart unless-stopped `
+  --env-file 'D:\FossilBrokerWorker\chatgpt-action\secrets\chatgpt-action.env' `
+  --publish 127.0.0.1:8787:8787 `
+  --mount 'type=bind,source=D:\FossilBrokerWorker\chatgpt-action\data,target=/var/lib/fossil,readonly' `
+  fossil-chatgpt-action:pr235
+```
+
+The external HTTPS reverse proxy/tunnel forwards only to Windows `127.0.0.1:8787`; it is the sole public exposure point.
+
+## Acceptance before private GPT connection
+
+Verify all focused, holdout, mutation, and container checks are green; effective UID is 10001; Docker `HostIp` is `127.0.0.1`; the canonical mount reports `RW=false` and rejects writes; empty search is `[]`; all prohibited routes are `404`; OpenAPI validates as 3.1 with non-empty `components.schemas`, explicit response properties, unique operation IDs, bearer security, exactly four Action paths, and an HTTPS server URL.
+
+Only then does the local integrator create/manage the real token, establish the HTTPS endpoint, and import the schema into a private Custom GPT. Those operations are outside this PR.
+
+## Rollback
+
+Stop/remove the Action container and external route, then restore the previous image/checkout. No canonical-data migration or rollback exists because the Action cannot write.

--- a/docs/operations/CHATGPT-ACTION.md
+++ b/docs/operations/CHATGPT-ACTION.md
@@ -2,140 +2,86 @@
 
 This PR packages a private, bearer-authenticated, read-only GPT Action edge. It does **not** deploy, create secrets, create tunnels, or configure a Custom GPT.
 
-Design/verification documents:
+Design and verification documents:
 
-- `CHATGPT-ACTION-PDD.md` — problem, scope, threat model, trust boundaries, exact Windows target;
+- `CHATGPT-ACTION-PDD.md` — product boundary, threat model, trust boundaries, Windows target;
 - `CHATGPT-ACTION-INVARIANTS.md` — normative machine-testable invariants;
-- `CHATGPT-ACTION-SDD.md` — architecture, API/OpenAPI contract, proxy rules, Docker Desktop runbook;
-- `CHATGPT-ACTION-HOLDOUT.md` — separately maintainable black-box holdout plan;
-- `CHATGPT-ACTION-VERIFICATION.md` — focused/container/mutation verification and delivery evidence.
+- `CHATGPT-ACTION-SDD.md` — architecture, API, origin handling, Docker Desktop contract, runbook;
+- `CHATGPT-ACTION-HOLDOUT.md` — independent black-box holdout specification;
+- `CHATGPT-ACTION-VERIFICATION.md` — commands, CI evidence template, limitations and rollback.
 
-## Exact read-only boundary
+## Public contract
 
-Public, unauthenticated:
+Unauthenticated discovery:
 
 - `GET /openapi.json`
 
-Bearer-protected:
+Bearer-protected operations:
 
 - `POST /actions/search`
 - `POST /actions/read`
-- `POST /actions/lineage`
 - `GET /actions/capabilities`
 
-Prohibited even when authenticated:
+`/actions/lineage` is intentionally **not** exposed by this standalone release. FOSSIL lineage remains a domain/MCP capability, but the standalone Action composition has no durable lineage provider; advertising a route that cannot succeed is prohibited.
 
-- MCP and `/mcp`;
-- ingest and `/ingest`;
-- proposal, validation, commit, redaction, write, admin, or management routes;
-- Neo4j/Graphiti query or mutation surfaces;
-- arbitrary graph mutation/query language;
-- arbitrary filesystem access, shell/process control, or runtime-configuration disclosure;
-- secret/token/credential disclosure.
+Also unavailable: `/mcp`, `/ingest`, propose, validate, commit, promote, redact, write/admin, arbitrary graph/Neo4j mutation, arbitrary filesystem access, and shell execution.
 
-## Target environment
+## Target host
 
-The build-ready target is:
-
-- Windows host;
-- Docker Desktop Linux engine with WSL 2 backend;
-- Ubuntu/Ubuntu-22.04 may be used for Python verification, but Docker integration inside those distros is not required;
-- no Podman/systemd/Quadlet/cloud-VM assumption;
-- all persistent material under:
+The intended local runtime is Windows + Docker Desktop's WSL 2 Linux engine. Do not require Podman or a Linux systemd service. Keep persistent material under:
 
 ```text
 D:\FossilBrokerWorker\chatgpt-action\
   fossil-core\
-  data\canonical\events\
-  secrets\chatgpt-action.env
+  data\
+    canonical\
+      events\
+  secrets\
+    chatgpt-action.env     # local only; never commit
 ```
 
-The current target `data\canonical\events` is empty. Authenticated search must therefore return `200 []`, never fabricated content.
+The Docker service is published only to `127.0.0.1:8787`, runs as UID/GID 10001, and mounts `D:\FossilBrokerWorker\chatgpt-action\data` at `/var/lib/fossil:ro`.
 
-## Build and verification
+## HTTPS/OpenAPI origin
 
-From WSL, Python-only verification can run against the checkout on `D:`:
+Preferred mode is a fixed origin-only `FOSSIL_ACTION_PUBLIC_BASE_URL=https://...`. Advanced mode leaves that unset and trusts forwarded HTTPS host/proto only from explicit `FOSSIL_ACTION_TRUSTED_PROXY_CIDRS` peers.
+
+A direct HTTPS request's `Host` header is not public-origin authority. If neither fixed origin nor trusted proxy origin is available, `/openapi.json` returns 503 rather than publishing an attacker-controlled server URL.
+
+## Redaction behavior
+
+Search traverses canonical event buckets only. `_redactions` tombstones are never normal search documents. If an event has a tombstone, search suppresses the event even when stale bytes remain and read returns generic 404 without exposing tombstone metadata.
+
+## Request-size behavior
+
+The Action enforces the request limit both from a declared `Content-Length` and while streaming chunks. Chunked, absent-length, or understated-length oversized bodies are rejected with 413 before adapter invocation.
+
+## Local verification before deployment
+
+From the reviewed checkout:
 
 ```bash
-cd /mnt/d/FossilBrokerWorker/chatgpt-action/fossil-core
-python3 -m venv .venv-linux
-. .venv-linux/bin/activate
 pip install -e '.[test,node]'
-pytest -q \
-  tests/test_chatgpt_action.py \
-  tests/test_chatgpt_action_server.py \
-  tests/test_chatgpt_action_architecture.py \
-  tests/holdout/test_chatgpt_action_holdout.py
+pytest -q tests/test_chatgpt_action.py tests/test_chatgpt_action_server.py tests/test_chatgpt_action_architecture.py tests/holdout/test_chatgpt_action_holdout.py
 python scripts/run_chatgpt_action_mutations.py
 ```
 
-Docker commands run from Windows PowerShell against Docker Desktop:
+Build the exact reviewed image with:
 
 ```powershell
-Set-Location 'D:\FossilBrokerWorker\chatgpt-action\fossil-core'
-docker build --file docker/chatgpt-action/Dockerfile --tag fossil-chatgpt-action:pr235 .
+docker build -f docker/chatgpt-action/Dockerfile -t fossil-chatgpt-action:local .
 ```
 
-The image runs as UID/GID 10001. Canonical data is mounted read-only at `/var/lib/fossil`. The Windows host port is published only as `127.0.0.1:8787`.
+The repository CI container workflow is the reference for non-root, loopback, read-only-mount, redaction, route-isolation, and trusted-proxy smoke checks.
 
-## HTTPS schema origin
+## Empty corpus
 
-`/openapi.json` never advertises a plain-HTTP public server URL.
+The current target canonical event directory may legitimately be empty. An authenticated search must return `200 []`; do not create fake knowledge just to make a smoke test return content.
 
-Preferred fixed mode:
+## Secret boundary
 
-```text
-FOSSIL_ACTION_PUBLIC_BASE_URL=https://<public-origin>
-```
-
-The fixed origin is authoritative and forged forwarded headers cannot override it.
-
-Trusted-proxy mode is also supported when a fixed origin is not used:
-
-```text
-FOSSIL_ACTION_TRUSTED_PROXY_CIDRS=<explicit proxy peer CIDR(s)>
-```
-
-Only requests from those networks may use one `X-Forwarded-Proto: https` and one valid `X-Forwarded-Host` to define the OpenAPI origin. Uvicorn runs with `proxy_headers=False`; wildcard proxy trust is not part of the design. If no trusted HTTPS origin exists, `/openapi.json` returns `503` instead of publishing internal HTTP.
-
-## Runtime variables
-
-```text
-FOSSIL_ACTION_BEARER_TOKEN      required, runtime-only, >=32 characters
-FOSSIL_ACTION_HOST              image uses 0.0.0.0; Windows publish remains loopback-only
-FOSSIL_ACTION_PORT              default 8787
-FOSSIL_ACTION_MAX_REQUEST_BYTES default 65536
-FOSSIL_ACTION_PUBLIC_BASE_URL   optional fixed HTTPS origin
-FOSSIL_ACTION_TRUSTED_PROXY_CIDRS optional explicit proxy source networks
-FOSSIL_REPOSITORY_ROOT          image /opt/fossil-core
-FOSSIL_DATA_ROOT                image /var/lib/fossil
-FOSSIL_PACK_MANIFEST            read-pack manifest
-```
-
-`config/chatgpt-action.env.example` contains placeholders only. The local integrator creates the populated file under `D:\...\secrets` after review; it is never committed.
-
-## Docker Desktop launch shape
-
-Documentation only — the PR does not execute this and contains no real credential:
-
-```powershell
-docker run --detach `
-  --name fossil-chatgpt-action `
-  --restart unless-stopped `
-  --env-file 'D:\FossilBrokerWorker\chatgpt-action\secrets\chatgpt-action.env' `
-  --publish 127.0.0.1:8787:8787 `
-  --mount 'type=bind,source=D:\FossilBrokerWorker\chatgpt-action\data,target=/var/lib/fossil,readonly' `
-  fossil-chatgpt-action:pr235
-```
-
-The external HTTPS reverse proxy/tunnel forwards only to Windows `127.0.0.1:8787`; it is the sole public exposure point.
-
-## Acceptance before private GPT connection
-
-Verify all focused, holdout, mutation, and container checks are green; effective UID is 10001; Docker `HostIp` is `127.0.0.1`; the canonical mount reports `RW=false` and rejects writes; empty search is `[]`; all prohibited routes are `404`; OpenAPI validates as 3.1 with non-empty `components.schemas`, explicit response properties, unique operation IDs, bearer security, exactly four Action paths, and an HTTPS server URL.
-
-Only then does the local integrator create/manage the real token, establish the HTTPS endpoint, and import the schema into a private Custom GPT. Those operations are outside this PR.
+Only the local integrator creates the real bearer token and any reverse-proxy/tunnel or Custom GPT credentials. Do not commit, log, paste into issues/PRs, or bake those values into the image.
 
 ## Rollback
 
-Stop/remove the Action container and external route, then restore the previous image/checkout. No canonical-data migration or rollback exists because the Action cannot write.
+Disable the external route if configured, stop/remove the Action container, and restore the previous reviewed image/SHA. Canonical data requires no rollback because this edge has no write capability.

--- a/docs/operations/CHATGPT-ACTION.md
+++ b/docs/operations/CHATGPT-ACTION.md
@@ -1,0 +1,85 @@
+# ChatGPT Custom GPT Action boundary
+
+This document describes the **read-only compatibility edge** for using a ChatGPT Custom GPT Action with FOSSIL.
+
+The Action edge is a protocol adapter only. It does not change FOSSIL truth authority, pack authorization, provenance, or the existing MCP contract.
+
+## Security boundary
+
+Use `create_chatgpt_action_app(...)` as a **distinct public HTTPS edge**. Do not publish the normal FOSSIL node network app merely to make ChatGPT reachable.
+
+The dedicated Action app exposes only:
+
+- `GET /openapi.json` — public schema used to configure the GPT Action;
+- `POST /actions/search` — `fossil.search` through `ThinMCPAdapter`;
+- `POST /actions/read` — `fossil.read` through `ThinMCPAdapter`;
+- `POST /actions/lineage` — `fossil.lineage` through `ThinMCPAdapter`;
+- `GET /actions/capabilities` — static metadata describing this bounded Action surface.
+
+It deliberately does **not** expose:
+
+- `/mcp`;
+- `/ingest`;
+- `fossil.propose`;
+- `fossil.validate`;
+- `fossil.commit`;
+- Neo4j/Graphiti APIs or arbitrary graph mutation.
+
+All `/actions/*` operations require a bearer token. `/openapi.json` is intentionally unauthenticated so ChatGPT can import the schema.
+
+## Runtime composition
+
+Construct the Action app from the same `FilesystemFossilNode` used by the private runtime, but give it a read-only corpus-search agent context:
+
+```python
+from fossil_core.agent import AgentContext
+from fossil_core.runtime.chatgpt_action import create_chatgpt_action_app
+
+context = AgentContext(
+    actor_id="chatgpt-action",
+    model_id="chatgpt",
+    harness_version="custom-gpt-action-v1",
+    skill_id="skill_corpus-search",
+    skill_version="1.0.0",
+)
+
+app = create_chatgpt_action_app(
+    node,
+    context=context,
+    bearer_token=action_token,
+)
+```
+
+`action_token` must come from the deployment secret store/environment at runtime. Never commit it, put it in an issue, or print it in logs.
+
+The public edge still uses the node's existing `CorpusService`, `PackAccess`, durable event store, and `ThinMCPAdapter`, so read authorization and pack boundaries remain canonical.
+
+## ChatGPT Custom GPT setup
+
+In the ChatGPT web GPT editor:
+
+1. Create or edit the private GPT used for FOSSIL.
+2. Open **Configure → Actions**.
+3. Import or paste the schema from `https://<ACTION_HOST>/openapi.json`.
+4. Configure Action authentication as an API key/bearer token and enter the same deployment token used by the Action edge.
+5. Keep the GPT private while validating the integration.
+6. Test `fossilSearch`, then `fossilRead`, then `fossilLineage` from the Action test UI.
+
+Do not paste the token into GPT instructions, the OpenAPI document, source control, GitHub issues, or chat messages.
+
+## Deployment rule
+
+The existing private FOSSIL Node can remain reachable over its intended private/Tailscale boundary. The ChatGPT Action edge needs externally reachable HTTPS for ChatGPT, but only the dedicated Action app should be exposed on that public route.
+
+A reverse proxy, tunnel, or later deployment unit may terminate TLS and route the public hostname to the dedicated Action ASGI app. That deployment choice is separate from this adapter and does not authorize public exposure of the MCP, ingestion, database, or admin surfaces.
+
+## Acceptance checks
+
+Before using a real secret or public hostname, verify mechanically that:
+
+- `/openapi.json` contains only the four Action paths;
+- `/actions/*` rejects missing/wrong bearer tokens;
+- `/mcp`, `/ingest`, and write-like Action paths return `404` on the dedicated app;
+- search/read/lineage results stay pack-authorized;
+- the existing MCP test suite remains unchanged and green;
+- no secret value appears in Git history, CI output, issues, or documentation.

--- a/docs/operations/CHATGPT-ACTION.md
+++ b/docs/operations/CHATGPT-ACTION.md
@@ -6,53 +6,80 @@ The Action edge is a protocol adapter only. It does not change FOSSIL truth auth
 
 ## Security boundary
 
-Use `create_chatgpt_action_app(...)` as a **distinct public HTTPS edge**. Do not publish the normal FOSSIL node network app merely to make ChatGPT reachable.
-
-The dedicated Action app exposes only:
+Deploy the dedicated Action service as the only public ChatGPT-facing surface. It exposes only:
 
 - `GET /openapi.json` — public schema used to configure the GPT Action;
 - `POST /actions/search` — `fossil.search` through `ThinMCPAdapter`;
 - `POST /actions/read` — `fossil.read` through `ThinMCPAdapter`;
 - `POST /actions/lineage` — `fossil.lineage` through `ThinMCPAdapter`;
-- `GET /actions/capabilities` — static metadata describing this bounded Action surface.
+- `GET /actions/capabilities` — metadata describing this bounded Action surface.
 
-It deliberately does **not** expose:
-
-- `/mcp`;
-- `/ingest`;
-- `fossil.propose`;
-- `fossil.validate`;
-- `fossil.commit`;
-- Neo4j/Graphiti APIs or arbitrary graph mutation.
+It deliberately does **not** expose `/mcp`, `/ingest`, `fossil.propose`, `fossil.validate`, `fossil.commit`, Neo4j/Graphiti APIs, or arbitrary graph mutation.
 
 All `/actions/*` operations require a bearer token. `/openapi.json` is intentionally unauthenticated so ChatGPT can import the schema.
 
-## Runtime composition
+## Standalone runtime
 
-Construct the Action app from the same `FilesystemFossilNode` used by the private runtime, but give it a read-only corpus-search agent context:
+The production entrypoint is:
 
-```python
-from fossil_core.agent import AgentContext
-from fossil_core.runtime.chatgpt_action import create_chatgpt_action_app
-
-context = AgentContext(
-    actor_id="chatgpt-action",
-    model_id="chatgpt",
-    harness_version="custom-gpt-action-v1",
-    skill_id="skill_corpus-search",
-    skill_version="1.0.0",
-)
-
-app = create_chatgpt_action_app(
-    node,
-    context=context,
-    bearer_token=action_token,
-)
+```text
+fossil-chatgpt-action
 ```
 
-`action_token` must come from the deployment secret store/environment at runtime. Never commit it, put it in an issue, or print it in logs.
+It boots directly from the canonical FOSSIL event store plus the pack and skill contracts. It does **not** construct Graphiti or connect to Neo4j. This keeps the public edge independent of the private MCP/projector/database runtime.
 
-The public edge still uses the node's existing `CorpusService`, `PackAccess`, durable event store, and `ThinMCPAdapter`, so read authorization and pack boundaries remain canonical.
+Runtime variables:
+
+```text
+FOSSIL_ACTION_BEARER_TOKEN   required; at least 32 characters
+FOSSIL_ACTION_HOST           default 127.0.0.1
+FOSSIL_ACTION_PORT           default 8787
+FOSSIL_REPOSITORY_ROOT       default current working directory
+FOSSIL_DATA_ROOT             default <repository>/data
+FOSSIL_PACK_MANIFEST         default examples/packs/common/manifest.json
+```
+
+The bearer secret must exist only in the host/deployment secret store or a host-local environment file. Never commit it, put it in an issue, or print it in logs.
+
+## Container build
+
+From the repository root:
+
+```bash
+podman build \
+  -f docker/chatgpt-action/Dockerfile \
+  -t localhost/fossil-chatgpt-action:local \
+  .
+```
+
+Create a host-local env file outside the repository from `config/chatgpt-action.env.example`, replace the placeholder token with a random secret, and restrict its permissions.
+
+Example local-only container launch:
+
+```bash
+podman run --rm \
+  --name fossil-chatgpt-action \
+  --env-file "$HOME/.config/fossil/chatgpt-action.env" \
+  -p 127.0.0.1:8787:8787 \
+  -v /ABSOLUTE/PATH/TO/FOSSIL-DATA:/var/lib/fossil:ro,Z \
+  localhost/fossil-chatgpt-action:local
+```
+
+The canonical data bind should be read-only for this service. The expected event-store path inside that mount is `/var/lib/fossil/canonical/events`.
+
+## Public HTTPS edge
+
+ChatGPT must be able to reach the Action API over HTTPS. Tailscale is **not required** for this public Action path.
+
+Keep the container bound to host loopback as shown above and terminate public HTTPS in a separately configured reverse proxy or outbound tunnel on the PC. Forward only the Action service; do not forward the private FOSSIL Node, MCP, ingestion, Neo4j, or admin surfaces.
+
+The HTTPS layer must preserve the public host/protocol headers so `/openapi.json` advertises the public HTTPS base URL. Before configuring ChatGPT, verify from outside the PC/network:
+
+```text
+https://<PUBLIC-ACTION-HOST>/openapi.json
+```
+
+and verify that `/mcp` and `/ingest` return `404` on that same host.
 
 ## ChatGPT Custom GPT setup
 
@@ -60,26 +87,35 @@ In the ChatGPT web GPT editor:
 
 1. Create or edit the private GPT used for FOSSIL.
 2. Open **Configure → Actions**.
-3. Import or paste the schema from `https://<ACTION_HOST>/openapi.json`.
-4. Configure Action authentication as an API key/bearer token and enter the same deployment token used by the Action edge.
+3. Import or paste the schema from `https://<PUBLIC-ACTION-HOST>/openapi.json`.
+4. Configure Action authentication as an API key/bearer token and enter the same runtime token used by the Action service.
 5. Keep the GPT private while validating the integration.
 6. Test `fossilSearch`, then `fossilRead`, then `fossilLineage` from the Action test UI.
 
 Do not paste the token into GPT instructions, the OpenAPI document, source control, GitHub issues, or chat messages.
 
-## Deployment rule
+## LOCAL_INFRA handoff
 
-The existing private FOSSIL Node can remain reachable over its intended private/Tailscale boundary. The ChatGPT Action edge needs externally reachable HTTPS for ChatGPT, but only the dedicated Action app should be exposed on that public route.
+A PC-local agent/Codex session should perform only the machine-specific steps below after this PR is reviewed/merged:
 
-A reverse proxy, tunnel, or later deployment unit may terminate TLS and route the public hostname to the dedicated Action ASGI app. That deployment choice is separate from this adapter and does not authorize public exposure of the MCP, ingestion, database, or admin surfaces.
+1. build the exact reviewed commit with `docker/chatgpt-action/Dockerfile`;
+2. identify the authoritative FOSSIL data root and mount it read-only at `/var/lib/fossil`;
+3. generate/store `FOSSIL_ACTION_BEARER_TOKEN` locally without printing it;
+4. start the container bound to `127.0.0.1:8787`;
+5. configure a public HTTPS reverse proxy or outbound tunnel to that loopback port;
+6. verify `/openapi.json`, bearer rejection, authorized search, and `404` for `/mcp`, `/ingest`, and write-like paths;
+7. configure the same bearer token in the private Custom GPT Action authentication UI;
+8. record only sanitized PASS/FAIL evidence, exact git SHA/image ID, and public hostname — never the secret.
 
 ## Acceptance checks
 
-Before using a real secret or public hostname, verify mechanically that:
+Before using the integration for real work, verify mechanically that:
 
 - `/openapi.json` contains only the four Action paths;
 - `/actions/*` rejects missing/wrong bearer tokens;
-- `/mcp`, `/ingest`, and write-like Action paths return `404` on the dedicated app;
-- search/read/lineage results stay pack-authorized;
-- the existing MCP test suite remains unchanged and green;
+- `/mcp`, `/ingest`, and write-like Action paths return `404`;
+- search/read results stay pack-authorized;
+- the Action service starts without Neo4j credentials or Graphiti connectivity;
+- the canonical data mount is read-only;
+- the existing MCP contract remains unchanged;
 - no secret value appears in Git history, CI output, issues, or documentation.

--- a/docs/operations/CHATGPT-ACTION.md
+++ b/docs/operations/CHATGPT-ACTION.md
@@ -1,45 +1,52 @@
 # ChatGPT Custom GPT Action boundary
 
-This document describes the **read-only compatibility edge** for using a ChatGPT Custom GPT Action with FOSSIL.
+This is the operator entrypoint for the **read-only compatibility edge** used by a private ChatGPT Custom GPT. Detailed design and verification live in:
 
-The Action edge is a protocol adapter only. It does not change FOSSIL truth authority, pack authorization, provenance, or the existing MCP contract.
+- `CHATGPT-ACTION-PDD.md` — user problem, threat model, trust boundaries, non-goals;
+- `CHATGPT-ACTION-INVARIANTS.md` — normative machine-testable invariants;
+- `CHATGPT-ACTION-SDD.md` — architecture, API, environment, container, proxy, WSL handoff;
+- `CHATGPT-ACTION-VERIFICATION.md` — focused/holdout/mutation verification and delivery evidence.
+
+The Action edge does not change FOSSIL truth authority, pack authorization, provenance, or the MCP contract.
 
 ## Security boundary
 
-Deploy the dedicated Action service as the only public ChatGPT-facing surface. It exposes only:
+The dedicated Action service exposes only:
 
-- `GET /openapi.json` — public schema used to configure the GPT Action;
-- `POST /actions/search` — `fossil.search` through `ThinMCPAdapter`;
-- `POST /actions/read` — `fossil.read` through `ThinMCPAdapter`;
-- `POST /actions/lineage` — `fossil.lineage` through `ThinMCPAdapter`;
-- `GET /actions/capabilities` — metadata describing this bounded Action surface.
+- `GET /openapi.json` — public OpenAPI discovery;
+- `POST /actions/search` — authenticated FOSSIL search;
+- `POST /actions/read` — authenticated durable-event read;
+- `POST /actions/lineage` — authenticated lineage read;
+- `GET /actions/capabilities` — authenticated read-only capability metadata.
 
-It deliberately does **not** expose `/mcp`, `/ingest`, `fossil.propose`, `fossil.validate`, `fossil.commit`, Neo4j/Graphiti APIs, or arbitrary graph mutation.
+It deliberately exposes **no** MCP, ingest, proposal, validation, commit, redaction, Graphiti/Neo4j API, graph mutation, arbitrary filesystem access, shell/admin operation, or credential surface.
 
-All `/actions/*` operations require a bearer token. `/openapi.json` is intentionally unauthenticated so ChatGPT can import the schema.
+All `/actions/*` operations require bearer authentication. `/openapi.json` is intentionally unauthenticated and contains no secret.
 
 ## Standalone runtime
 
-The production entrypoint is:
+The entrypoint is:
 
 ```text
 fossil-chatgpt-action
 ```
 
-It boots directly from the canonical FOSSIL event store plus the pack and skill contracts. It does **not** construct Graphiti or connect to Neo4j. This keeps the public edge independent of the private MCP/projector/database runtime.
+It boots directly from canonical FOSSIL events plus pack and skill contracts. It does not initialize Graphiti or Neo4j. The Action-specific event-store view has read methods only and is designed to boot against a physically read-only canonical mount.
 
 Runtime variables:
 
 ```text
-FOSSIL_ACTION_BEARER_TOKEN   required; at least 32 characters
-FOSSIL_ACTION_HOST           default 127.0.0.1
-FOSSIL_ACTION_PORT           default 8787
-FOSSIL_REPOSITORY_ROOT       default current working directory
-FOSSIL_DATA_ROOT             default <repository>/data
-FOSSIL_PACK_MANIFEST         default examples/packs/common/manifest.json
+FOSSIL_ACTION_BEARER_TOKEN      required; runtime-only; at least 32 characters
+FOSSIL_ACTION_HOST              default 127.0.0.1
+FOSSIL_ACTION_PORT              default 8787
+FOSSIL_ACTION_MAX_REQUEST_BYTES default 65536
+FOSSIL_ACTION_PUBLIC_BASE_URL   production HTTPS origin advertised in OpenAPI
+FOSSIL_REPOSITORY_ROOT          default current working directory
+FOSSIL_DATA_ROOT                default <repository>/data
+FOSSIL_PACK_MANIFEST            default examples/packs/common/manifest.json
 ```
 
-The bearer secret must exist only in the host/deployment secret store or a host-local environment file. Never commit it, put it in an issue, or print it in logs.
+This package does not create, receive, print, or deploy any real token or endpoint credential. The operator supplies those locally after code review.
 
 ## Container build
 
@@ -52,70 +59,69 @@ podman build \
   .
 ```
 
-Create a host-local env file outside the repository from `config/chatgpt-action.env.example`, replace the placeholder token with a random secret, and restrict its permissions.
+The container runs as UID/GID 10001. Production launch must mount canonical data read-only at `/var/lib/fossil`; the expected event path is `/var/lib/fossil/canonical/events`.
 
-Example local-only container launch:
-
-```bash
-podman run --rm \
-  --name fossil-chatgpt-action \
-  --env-file "$HOME/.config/fossil/chatgpt-action.env" \
-  -p 127.0.0.1:8787:8787 \
-  -v /ABSOLUTE/PATH/TO/FOSSIL-DATA:/var/lib/fossil:ro,Z \
-  localhost/fossil-chatgpt-action:local
-```
-
-The canonical data bind should be read-only for this service. The expected event-store path inside that mount is `/var/lib/fossil/canonical/events`.
+No real launch command with a credential is included here. Use `config/chatgpt-action.env.example` only as a field-name template and keep the populated file outside source control.
 
 ## Public HTTPS edge
 
-ChatGPT must be able to reach the Action API over HTTPS. Tailscale is **not required** for this public Action path.
+ChatGPT reaches the Action through operator-managed HTTPS. Tailscale is not required for this Action path. The reverse proxy/tunnel, DNS, TLS certificate, and provider credentials are all out of scope for this PR.
 
-Keep the container bound to host loopback as shown above and terminate public HTTPS in a separately configured reverse proxy or outbound tunnel on the PC. Forward only the Action service; do not forward the private FOSSIL Node, MCP, ingestion, Neo4j, or admin surfaces.
-
-The HTTPS layer must preserve the public host/protocol headers so `/openapi.json` advertises the public HTTPS base URL. Before configuring ChatGPT, verify from outside the PC/network:
+The Action process **does not trust `Forwarded` or `X-Forwarded-*` headers** to determine its public origin. Uvicorn proxy-header processing is disabled. Instead the local operator sets an explicit origin:
 
 ```text
-https://<PUBLIC-ACTION-HOST>/openapi.json
+FOSSIL_ACTION_PUBLIC_BASE_URL=https://<public-action-origin>
 ```
 
-and verify that `/mcp` and `/ingest` return `404` on that same host.
+That value must be an origin-only `https://` URL. `/openapi.json` then emits it exactly in `servers[0].url`, so the schema remains correct even when the internal hop is plain HTTP and even if a caller forges forwarded headers.
 
-## ChatGPT Custom GPT setup
+The external HTTPS edge must forward only the Action service. It must not publish the private FOSSIL Node, MCP, ingestion, Neo4j, or admin surfaces.
 
-In the ChatGPT web GPT editor:
+## Windows / WSL `D:` integrator handoff
 
-1. Create or edit the private GPT used for FOSSIL.
-2. Open **Configure → Actions**.
-3. Import or paste the schema from `https://<PUBLIC-ACTION-HOST>/openapi.json`.
-4. Configure Action authentication as an API key/bearer token and enter the same runtime token used by the Action service.
-5. Keep the GPT private while validating the integration.
-6. Test `fossilSearch`, then `fossilRead`, then `fossilLineage` from the Action test UI.
+A supported local layout is:
 
-Do not paste the token into GPT instructions, the OpenAPI document, source control, GitHub issues, or chat messages.
+```text
+D:\fossil\fossil-core   -> /mnt/d/fossil/fossil-core
+D:\fossil\data          -> /mnt/d/fossil/data
+```
 
-## LOCAL_INFRA handoff
+From WSL:
 
-A PC-local agent/Codex session should perform only the machine-specific steps below after this PR is reviewed/merged:
+```bash
+cd /mnt/d/fossil/fossil-core
+python -m venv .venv
+. .venv/bin/activate
+pip install -e '.[test,node]'
+pytest -q \
+  tests/test_chatgpt_action.py \
+  tests/test_chatgpt_action_server.py \
+  tests/test_chatgpt_action_architecture.py \
+  tests/holdout/test_chatgpt_action_holdout.py
+python scripts/run_chatgpt_action_mutations.py
+docker build -f docker/chatgpt-action/Dockerfile -t fossil-chatgpt-action:local .
+```
 
-1. build the exact reviewed commit with `docker/chatgpt-action/Dockerfile`;
-2. identify the authoritative FOSSIL data root and mount it read-only at `/var/lib/fossil`;
-3. generate/store `FOSSIL_ACTION_BEARER_TOKEN` locally without printing it;
-4. start the container bound to `127.0.0.1:8787`;
-5. configure a public HTTPS reverse proxy or outbound tunnel to that loopback port;
-6. verify `/openapi.json`, bearer rejection, authorized search, and `404` for `/mcp`, `/ingest`, and write-like paths;
-7. configure the same bearer token in the private Custom GPT Action authentication UI;
-8. record only sanitized PASS/FAIL evidence, exact git SHA/image ID, and public hostname — never the secret.
+The local integrator can then perform machine-specific configuration with locally generated secrets and an HTTPS endpoint. Those actions are intentionally not performed by this PR or its CI.
+
+## Private Custom GPT setup boundary
+
+After the local endpoint passes verification, the operator may import `https://<public-action-origin>/openapi.json` into a private Custom GPT and configure the same locally managed bearer credential in the GPT Action authentication UI.
+
+This repository never stores or handles the real Custom GPT credential. The GPT must remain read-only because the imported OpenAPI document contains only search, read, lineage, and capabilities.
 
 ## Acceptance checks
 
-Before using the integration for real work, verify mechanically that:
+Before use, verify:
 
-- `/openapi.json` contains only the four Action paths;
-- `/actions/*` rejects missing/wrong bearer tokens;
-- `/mcp`, `/ingest`, and write-like Action paths return `404`;
-- search/read results stay pack-authorized;
-- the Action service starts without Neo4j credentials or Graphiti connectivity;
-- the canonical data mount is read-only;
-- the existing MCP contract remains unchanged;
-- no secret value appears in Git history, CI output, issues, or documentation.
+- OpenAPI validates as 3.1 and has a real `components.schemas` object;
+- `servers[0].url` is the configured HTTPS origin despite forged forwarded headers;
+- only the four Action operations appear in `paths`;
+- `/actions/*` rejects malformed/missing/wrong bearer credentials;
+- request-size/type/range validation fails closed;
+- `/mcp`, `/ingest`, proposal, validation, commit, redaction, graph, filesystem, and admin paths return `404`;
+- path-like `event_id` values are rejected before filesystem access;
+- the container runs non-root and canonical data is physically read-only;
+- Action startup requires no Neo4j/Graphiti credential or connectivity;
+- focused, holdout, container, architecture, and mutation checks are green;
+- no real secret value exists in Git, CI, docs, issue comments, or test fixtures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
   "rfc3339-validator>=0.1.4,<1",
 ]
 
+[project.scripts]
+fossil-chatgpt-action = "fossil_core.runtime.chatgpt_action_server:main"
+
 [project.optional-dependencies]
 test = [
   "pytest>=8,<9",
@@ -23,7 +26,7 @@ mutation = ["mutmut @ git+https://github.com/boxed/mutmut.git@dc58270d5234752e22
 graphiti = ["graphiti-core==0.29.3", "httpx>=0.27,<1"]
 semantic = ["sentence-transformers==5.2.2"]
 s3 = ["boto3>=1.40,<2"]
-node = ["mcp==2.0.0"]
+node = ["mcp==2.0.0", "uvicorn>=0.35,<1"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ test = [
   "hypothesis>=6,<7",
   "mcp==2.0.0",
   "httpx>=0.28,<1",
+  "openapi-spec-validator>=0.7,<1",
 ]
 mutation = ["mutmut @ git+https://github.com/boxed/mutmut.git@dc58270d5234752e22247f814431750eafcf6e5f"]
 graphiti = ["graphiti-core==0.29.3", "httpx>=0.27,<1"]

--- a/scripts/run_chatgpt_action_mutations.py
+++ b/scripts/run_chatgpt_action_mutations.py
@@ -36,24 +36,38 @@ MUTANTS = (
         "Unknown and prohibited paths must remain 404.",
     ),
     Mutant(
+        "reintroduce_lineage_route",
+        ACTION,
+        (
+            (
+                '    "/actions/read": "fossil.read",',
+                '    "/actions/read": "fossil.read",\n    "/actions/lineage": "fossil.lineage",',
+            ),
+        ),
+        "The standalone Action must not expose lineage until a real lineage provider exists.",
+    ),
+    Mutant(
         "enable_commit_route",
         ACTION,
         (
             (
-                '    "/actions/lineage": "fossil.lineage",',
-                '    "/actions/lineage": "fossil.lineage",\n    "/actions/commit": "fossil.commit",',
+                '    "/actions/read": "fossil.read",',
+                '    "/actions/read": "fossil.read",\n    "/actions/commit": "fossil.commit",',
             ),
         ),
         "Authenticated callers must never gain a durable commit route.",
     ),
     Mutant(
-        "remove_body_size_guards",
+        "remove_declared_body_size_guard",
         ACTION,
-        (
-            ("if declared > self.max_request_body_size:", "if False:"),
-            ("if len(raw) > self.max_request_body_size:", "if False:"),
-        ),
-        "Oversized bodies must be rejected before adapter invocation.",
+        (("if declared > self.max_request_body_size:", "if False:"),),
+        "An explicitly oversized Content-Length must be rejected before adapter invocation.",
+    ),
+    Mutant(
+        "remove_streaming_body_size_guard",
+        ACTION,
+        (("if total > self.max_request_body_size:", "if False:"),),
+        "Chunked, absent, or understated Content-Length bodies must be bounded while streaming.",
     ),
     Mutant(
         "weaken_search_limit_validation",
@@ -85,6 +99,17 @@ MUTANTS = (
         "A correctly configured trusted proxy must produce the HTTPS schema origin.",
     ),
     Mutant(
+        "trust_direct_https_host",
+        ACTION,
+        (
+            (
+                "        return self._trusted_proxy_origin(request)",
+                "        if request.url.scheme == \"https\":\n            return str(request.base_url).rstrip(\"/\")\n        return self._trusted_proxy_origin(request)",
+            ),
+        ),
+        "Direct HTTPS Host is caller-controlled and must not define the public OpenAPI origin.",
+    ),
+    Mutant(
         "publish_http_schema_origin",
         ACTION,
         (("return self.public_base_url", 'return "http://internal.invalid:8787"'),),
@@ -106,6 +131,21 @@ MUTANTS = (
             ),
         ),
         "Successful response objects must retain declared properties.",
+    ),
+    Mutant(
+        "search_redacted_event_bytes",
+        SERVER,
+        (("if isinstance(event_id, str) and self.is_redacted(event_id):", "if False:"),),
+        "An event with a redaction tombstone must not be searchable even if bytes remain.",
+    ),
+    Mutant(
+        "reinclude_redaction_paths",
+        SERVER,
+        (
+            ("for bucket in sorted(self.root.iterdir()):", "for bucket in sorted(self.root.rglob(\"*\")):") ,
+            ("if isinstance(event_id, str) and self.is_redacted(event_id):", "if False:"),
+        ),
+        "_redactions tombstone paths must never be iterated as normal search events.",
     ),
     Mutant(
         "enable_uvicorn_global_proxy_headers",

--- a/scripts/run_chatgpt_action_mutations.py
+++ b/scripts/run_chatgpt_action_mutations.py
@@ -27,19 +27,24 @@ MUTANTS = (
         "bypass_bearer_check",
         ACTION,
         (("if not self._authorized(request):", "if False:"),),
-        "Unauthenticated Action requests must never succeed.",
+        "Missing/incorrect bearer authentication must fail closed.",
     ),
     Mutant(
         "widen_route_allowlist",
         ACTION,
         (("if path not in _ACTION_ROUTE_ALLOWLIST:", "if False:"),),
-        "Unknown/prohibited paths must remain 404 and never enter Action dispatch.",
+        "Unknown and prohibited paths must remain 404.",
     ),
     Mutant(
         "enable_commit_route",
         ACTION,
-        (("\"/actions/lineage\": \"fossil.lineage\",", "\"/actions/lineage\": \"fossil.lineage\",\n    \"/actions/commit\": \"fossil.commit\","),),
-        "Authenticated callers must not gain a durable write route.",
+        (
+            (
+                '    "/actions/lineage": "fossil.lineage",',
+                '    "/actions/lineage": "fossil.lineage",\n    "/actions/commit": "fossil.commit",',
+            ),
+        ),
+        "Authenticated callers must never gain a durable commit route.",
     ),
     Mutant(
         "remove_body_size_guards",
@@ -54,34 +59,56 @@ MUTANTS = (
         "weaken_search_limit_validation",
         ACTION,
         (("or limit > 100", "or limit > 1000"),),
-        "Ambiguous/out-of-range search limits must fail closed.",
+        "Out-of-range search limits must fail closed.",
     ),
     Mutant(
-        "trust_request_origin_for_openapi",
+        "allow_extra_capability_fields",
         ACTION,
-        (("server_url = self._schema_origin(request)", "server_url = str(request.base_url).rstrip(\"/\")"),),
-        "Configured/trusted HTTPS origin must not become caller-controlled.",
+        (("return set(payload).issubset(allowed)", "return True"),),
+        "Extra fields must not smuggle graph/write/filesystem capabilities.",
     ),
     Mutant(
-        "trust_all_proxy_sources",
+        "trust_forwarded_headers_from_any_peer",
         ACTION,
-        (("if not self.trusted_proxy_networks or request.client is None:", "if request.client is None:"),),
-        "Forwarded HTTPS headers must be accepted only from explicitly trusted proxy networks.",
+        (
+            (
+                "if not any(peer in network for network in self.trusted_proxy_networks):\n            return None",
+                "if False:\n            return None",
+            ),
+        ),
+        "Forwarded origin metadata must be trusted only from configured proxy CIDRs.",
+    ),
+    Mutant(
+        "remove_trusted_proxy_origin_support",
+        ACTION,
+        (("return self._trusted_proxy_origin(request)", "return None"),),
+        "A correctly configured trusted proxy must produce the HTTPS schema origin.",
+    ),
+    Mutant(
+        "publish_http_schema_origin",
+        ACTION,
+        (("return self.public_base_url", 'return "http://internal.invalid:8787"'),),
+        "The generated public server URL must never regress to HTTP.",
     ),
     Mutant(
         "remove_components_schemas",
         ACTION,
         (("\"schemas\": schemas,", "\"x-disabled-schemas\": schemas,"),),
-        "Custom GPT import requires a valid components.schemas object.",
+        "Custom GPT/OpenAPI compatibility requires components.schemas.",
     ),
     Mutant(
-        "erase_search_response_property",
+        "erase_search_response_properties",
         ACTION,
-        (("\"event_id\": {\"type\": \"string\"},", "\"event_id_removed\": {\"type\": \"string\"},"),),
-        "Response objects must retain explicit event identifiers/properties.",
+        (
+            (
+                '"SearchResult": {\n            "type": "object",\n            "additionalProperties": True,\n            "required": ["event_id", "event_type", "pack_id", "recorded_at"],\n            "properties": {',
+                '"SearchResult": {\n            "type": "object",\n            "additionalProperties": True,\n            "required": ["event_id", "event_type", "pack_id", "recorded_at"],\n            "properties": {},\n            "x-original-properties": {',
+            ),
+        ),
+        "Successful response objects must retain declared properties.",
     ),
     Mutant(
-        "enable_proxy_headers",
+        "enable_uvicorn_global_proxy_headers",
         SERVER,
         (("proxy_headers=False,", "proxy_headers=True,"),),
         "Uvicorn must not globally trust caller-controlled forwarded headers.",
@@ -89,8 +116,13 @@ MUTANTS = (
     Mutant(
         "add_write_method_to_read_store",
         SERVER,
-        (("    def iter_events(self) -> Iterator[dict[str, Any]]:", "    def commit(self, event: dict[str, Any]) -> dict[str, Any]:\n        return event\n\n    def iter_events(self) -> Iterator[dict[str, Any]]:"),),
-        "The standalone event-store view must expose no mutation API.",
+        (
+            (
+                "    def iter_events(self) -> Iterator[dict[str, Any]]:",
+                "    def commit(self, event: dict[str, Any]) -> dict[str, Any]:\n        return event\n\n    def iter_events(self) -> Iterator[dict[str, Any]]:",
+            ),
+        ),
+        "The Action event-store view must expose no mutation API.",
     ),
     Mutant(
         "run_container_as_root",
@@ -102,7 +134,13 @@ MUTANTS = (
         "make_canonical_mount_writable",
         WORKFLOW,
         ((":/var/lib/fossil:ro", ":/var/lib/fossil:rw"),),
-        "The deployment/container contract must preserve a read-only canonical mount.",
+        "The container/deployment contract must preserve a read-only canonical mount.",
+    ),
+    Mutant(
+        "remove_loopback_host_binding",
+        WORKFLOW,
+        (("-p 127.0.0.1:8787:8787", "-p 8787:8787"),),
+        "Docker Desktop must publish the Action port only on Windows loopback.",
     ),
 )
 

--- a/scripts/run_chatgpt_action_mutations.py
+++ b/scripts/run_chatgpt_action_mutations.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTION = ROOT / "src" / "fossil_core" / "runtime" / "chatgpt_action.py"
+SERVER = ROOT / "src" / "fossil_core" / "runtime" / "chatgpt_action_server.py"
+DOCKERFILE = ROOT / "docker" / "chatgpt-action" / "Dockerfile"
+WORKFLOW = ROOT / ".github" / "workflows" / "chatgpt-action-container.yml"
+
+
+@dataclass(frozen=True)
+class Mutant:
+    name: str
+    path: Path
+    replacements: tuple[tuple[str, str], ...]
+    rationale: str
+
+
+MUTANTS = (
+    Mutant(
+        "bypass_bearer_check",
+        ACTION,
+        (("if not self._authorized(request):", "if False:"),),
+        "Unauthenticated Action requests must never succeed.",
+    ),
+    Mutant(
+        "widen_route_allowlist",
+        ACTION,
+        (("if path not in {*_ACTION_PATHS, \"/actions/capabilities\"}:", "if False:"),),
+        "Unknown/prohibited paths must remain 404 and never enter Action dispatch.",
+    ),
+    Mutant(
+        "enable_commit_route",
+        ACTION,
+        (("\"/actions/lineage\": \"fossil.lineage\",", "\"/actions/lineage\": \"fossil.lineage\",\n    \"/actions/commit\": \"fossil.commit\","),),
+        "Authenticated callers must not gain a durable write route.",
+    ),
+    Mutant(
+        "remove_body_size_guards",
+        ACTION,
+        (
+            ("if int(content_length) > self.max_request_body_size:", "if False:"),
+            ("if len(raw) > self.max_request_body_size:", "if False:"),
+        ),
+        "Oversized bodies must be rejected before adapter invocation.",
+    ),
+    Mutant(
+        "weaken_search_limit_validation",
+        ACTION,
+        (("if isinstance(limit, bool) or not isinstance(limit, int) or limit < 1 or limit > 100:", "if False:"),),
+        "Ambiguous/out-of-range search limits must fail closed.",
+    ),
+    Mutant(
+        "trust_request_origin_for_openapi",
+        ACTION,
+        (("server_url = self.public_base_url or str(request.base_url)", "server_url = str(request.base_url)"),),
+        "Forged proxy/host headers must not rewrite the configured public HTTPS origin.",
+    ),
+    Mutant(
+        "remove_components_schemas",
+        ACTION,
+        (("\"schemas\": {", "\"x-disabled-schemas\": {"),),
+        "Custom GPT import requires a valid components.schemas object.",
+    ),
+    Mutant(
+        "erase_response_properties",
+        ACTION,
+        (("\"properties\": record_properties,", "\"properties\": {},"),),
+        "Response objects must retain explicit properties.",
+    ),
+    Mutant(
+        "enable_proxy_headers",
+        SERVER,
+        (("proxy_headers=False,", "proxy_headers=True,"),),
+        "The application entrypoint must not trust caller-controlled forwarded headers.",
+    ),
+    Mutant(
+        "add_write_method_to_read_store",
+        SERVER,
+        (("    def iter_events(self) -> Iterator[dict[str, Any]]:", "    def commit(self, event: dict[str, Any]) -> dict[str, Any]:\n        return event\n\n    def iter_events(self) -> Iterator[dict[str, Any]]:"),),
+        "The standalone event-store view must expose no mutation API.",
+    ),
+    Mutant(
+        "run_container_as_root",
+        DOCKERFILE,
+        (("USER fossil", "USER root"),),
+        "The production image must execute as non-root.",
+    ),
+    Mutant(
+        "make_canonical_mount_writable",
+        WORKFLOW,
+        ((":/var/lib/fossil:ro", ":/var/lib/fossil:rw"),),
+        "The deployment/container contract must preserve a read-only canonical mount.",
+    ),
+)
+
+
+TEST_COMMAND = [
+    sys.executable,
+    "-m",
+    "pytest",
+    "-q",
+    "tests/holdout/test_chatgpt_action_holdout.py",
+    "tests/test_chatgpt_action_architecture.py",
+]
+
+
+def apply_mutant(mutant: Mutant) -> str:
+    original = mutant.path.read_text(encoding="utf-8")
+    mutated = original
+    for old, new in mutant.replacements:
+        if old not in mutated:
+            raise RuntimeError(f"mutant {mutant.name}: anchor not found: {old!r}")
+        mutated = mutated.replace(old, new, 1)
+    mutant.path.write_text(mutated, encoding="utf-8")
+    return original
+
+
+def main() -> int:
+    survivors: list[str] = []
+    killed: list[str] = []
+    env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+
+    for mutant in MUTANTS:
+        original = apply_mutant(mutant)
+        try:
+            completed = subprocess.run(
+                TEST_COMMAND,
+                cwd=ROOT,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=False,
+            )
+        finally:
+            mutant.path.write_text(original, encoding="utf-8")
+
+        if completed.returncode == 0:
+            survivors.append(mutant.name)
+            status = "SURVIVED"
+        else:
+            killed.append(mutant.name)
+            status = "KILLED"
+        print(f"{status}: {mutant.name} — {mutant.rationale}")
+        if completed.returncode == 0:
+            print(completed.stdout)
+
+    print(f"mutation summary: killed={len(killed)} survived={len(survivors)} total={len(MUTANTS)}")
+    if survivors:
+        print("surviving mutants: " + ", ".join(survivors))
+        return 1
+    print("surviving mutants: none")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_chatgpt_action_mutations.py
+++ b/scripts/run_chatgpt_action_mutations.py
@@ -58,8 +58,8 @@ MUTANTS = (
     Mutant(
         "weaken_search_limit_validation",
         ACTION,
-        (("or limit > 100", "or limit > 1000"),),
-        "Out-of-range search limits must fail closed.",
+        (("isinstance(limit, bool)", "False"),),
+        "Boolean/ambiguous search limits must fail closed.",
     ),
     Mutant(
         "allow_extra_capability_fields",
@@ -133,8 +133,11 @@ MUTANTS = (
     Mutant(
         "make_canonical_mount_writable",
         WORKFLOW,
-        ((":/var/lib/fossil:ro", ":/var/lib/fossil:rw"),),
-        "The container/deployment contract must preserve a read-only canonical mount.",
+        (
+            (":/var/lib/fossil:ro", ":/var/lib/fossil:rw"),
+            (":/var/lib/fossil:ro", ":/var/lib/fossil:rw"),
+        ),
+        "All container/deployment fixtures must preserve a read-only canonical mount.",
     ),
     Mutant(
         "remove_loopback_host_binding",

--- a/scripts/run_chatgpt_action_mutations.py
+++ b/scripts/run_chatgpt_action_mutations.py
@@ -32,7 +32,7 @@ MUTANTS = (
     Mutant(
         "widen_route_allowlist",
         ACTION,
-        (("if path not in {*_ACTION_PATHS, \"/actions/capabilities\"}:", "if False:"),),
+        (("if path not in _ACTION_ROUTE_ALLOWLIST:", "if False:"),),
         "Unknown/prohibited paths must remain 404 and never enter Action dispatch.",
     ),
     Mutant(
@@ -45,7 +45,7 @@ MUTANTS = (
         "remove_body_size_guards",
         ACTION,
         (
-            ("if int(content_length) > self.max_request_body_size:", "if False:"),
+            ("if declared > self.max_request_body_size:", "if False:"),
             ("if len(raw) > self.max_request_body_size:", "if False:"),
         ),
         "Oversized bodies must be rejected before adapter invocation.",
@@ -53,32 +53,38 @@ MUTANTS = (
     Mutant(
         "weaken_search_limit_validation",
         ACTION,
-        (("if isinstance(limit, bool) or not isinstance(limit, int) or limit < 1 or limit > 100:", "if False:"),),
+        (("or limit > 100", "or limit > 1000"),),
         "Ambiguous/out-of-range search limits must fail closed.",
     ),
     Mutant(
         "trust_request_origin_for_openapi",
         ACTION,
-        (("server_url = self.public_base_url or str(request.base_url)", "server_url = str(request.base_url)"),),
-        "Forged proxy/host headers must not rewrite the configured public HTTPS origin.",
+        (("server_url = self._schema_origin(request)", "server_url = str(request.base_url).rstrip(\"/\")"),),
+        "Configured/trusted HTTPS origin must not become caller-controlled.",
+    ),
+    Mutant(
+        "trust_all_proxy_sources",
+        ACTION,
+        (("if not self.trusted_proxy_networks or request.client is None:", "if request.client is None:"),),
+        "Forwarded HTTPS headers must be accepted only from explicitly trusted proxy networks.",
     ),
     Mutant(
         "remove_components_schemas",
         ACTION,
-        (("\"schemas\": {", "\"x-disabled-schemas\": {"),),
+        (("\"schemas\": schemas,", "\"x-disabled-schemas\": schemas,"),),
         "Custom GPT import requires a valid components.schemas object.",
     ),
     Mutant(
-        "erase_response_properties",
+        "erase_search_response_property",
         ACTION,
-        (("\"properties\": record_properties,", "\"properties\": {},"),),
-        "Response objects must retain explicit properties.",
+        (("\"event_id\": {\"type\": \"string\"},", "\"event_id_removed\": {\"type\": \"string\"},"),),
+        "Response objects must retain explicit event identifiers/properties.",
     ),
     Mutant(
         "enable_proxy_headers",
         SERVER,
         (("proxy_headers=False,", "proxy_headers=True,"),),
-        "The application entrypoint must not trust caller-controlled forwarded headers.",
+        "Uvicorn must not globally trust caller-controlled forwarded headers.",
     ),
     Mutant(
         "add_write_method_to_read_store",
@@ -125,10 +131,17 @@ def apply_mutant(mutant: Mutant) -> str:
 def main() -> int:
     survivors: list[str] = []
     killed: list[str] = []
+    harness_errors: list[str] = []
     env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
 
     for mutant in MUTANTS:
-        original = apply_mutant(mutant)
+        try:
+            original = apply_mutant(mutant)
+        except RuntimeError as exc:
+            harness_errors.append(mutant.name)
+            print(f"HARNESS_ERROR: {exc}")
+            continue
+
         try:
             completed = subprocess.run(
                 TEST_COMMAND,
@@ -145,16 +158,22 @@ def main() -> int:
         if completed.returncode == 0:
             survivors.append(mutant.name)
             status = "SURVIVED"
+            print(completed.stdout)
         else:
             killed.append(mutant.name)
             status = "KILLED"
         print(f"{status}: {mutant.name} — {mutant.rationale}")
-        if completed.returncode == 0:
-            print(completed.stdout)
 
-    print(f"mutation summary: killed={len(killed)} survived={len(survivors)} total={len(MUTANTS)}")
+    print(
+        "mutation summary: "
+        f"killed={len(killed)} survived={len(survivors)} "
+        f"harness_errors={len(harness_errors)} total={len(MUTANTS)}"
+    )
+    if harness_errors:
+        print("harness errors: " + ", ".join(harness_errors))
     if survivors:
         print("surviving mutants: " + ", ".join(survivors))
+    if harness_errors or survivors:
         return 1
     print("surviving mutants: none")
     return 0

--- a/src/fossil_core/runtime/chatgpt_action.py
+++ b/src/fossil_core/runtime/chatgpt_action.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+import hmac
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from fossil_core.adapters.mcp import ThinMCPAdapter
+from fossil_core.agent import AgentContext, AgentProvenanceError
+from fossil_core.domain.pack import PackBoundaryError
+from fossil_core.ports.capability import CapabilityError
+
+from .network import create_node_network_app
+from .node import FilesystemFossilNode
+
+
+_ACTION_PATHS = {
+    "/actions/search": "fossil.search",
+    "/actions/read": "fossil.read",
+    "/actions/lineage": "fossil.lineage",
+}
+
+
+def _error(code: str, detail: str, status_code: int) -> JSONResponse:
+    return JSONResponse(
+        {"error": {"code": code, "detail": detail}}, status_code=status_code
+    )
+
+
+def _map_action_error(exc: Exception) -> JSONResponse:
+    if isinstance(exc, PackBoundaryError):
+        return _error("unauthorized_pack", str(exc), 403)
+    if isinstance(exc, (CapabilityError, AgentProvenanceError)):
+        return _error("capability_denied", str(exc), 403)
+    if isinstance(exc, FileNotFoundError):
+        return _error("not_found", str(exc), 404)
+    if isinstance(exc, KeyError):
+        detail = str(exc.args[0]) if exc.args else "resource not found"
+        return _error("not_found", detail, 404)
+    if isinstance(exc, (TypeError, ValueError)):
+        return _error("invalid_request", str(exc), 400)
+    if isinstance(exc, OSError):
+        return _error("canonical_store_unavailable", str(exc), 503)
+    return _error("internal_error", "FOSSIL Action execution failed", 500)
+
+
+def _object_schema(*, required: list[str], properties: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": required,
+        "properties": properties,
+    }
+
+
+def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str, Any]:
+    """Return the read-only OpenAPI contract intended for a ChatGPT GPT Action."""
+
+    error_schema = {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+            "error": {
+                "type": "object",
+                "required": ["code", "detail"],
+                "properties": {
+                    "code": {"type": "string"},
+                    "detail": {"type": "string"},
+                },
+            }
+        },
+    }
+    common_responses = {
+        "400": {"description": "Invalid request", "content": {"application/json": {"schema": error_schema}}},
+        "401": {"description": "Missing or invalid bearer token", "content": {"application/json": {"schema": error_schema}}},
+        "403": {"description": "Pack or capability denied", "content": {"application/json": {"schema": error_schema}}},
+        "404": {"description": "Resource not found", "content": {"application/json": {"schema": error_schema}}},
+        "503": {"description": "Canonical store unavailable", "content": {"application/json": {"schema": error_schema}}},
+    }
+
+    schema: dict[str, Any] = {
+        "openapi": "3.1.0",
+        "info": {
+            "title": "FOSSIL read-only ChatGPT Action API",
+            "version": "1.0.0",
+            "description": (
+                "Read-only compatibility surface over the canonical FOSSIL corpus. "
+                "It exposes search, durable-event read, lineage, and adapter capability metadata; "
+                "durable proposal/validation/commit are intentionally not exposed."
+            ),
+        },
+        "components": {
+            "securitySchemes": {
+                "BearerAuth": {
+                    "type": "http",
+                    "scheme": "bearer",
+                    "bearerFormat": "opaque",
+                }
+            }
+        },
+        "security": [{"BearerAuth": []}],
+        "paths": {
+            "/actions/search": {
+                "post": {
+                    "operationId": "fossilSearch",
+                    "summary": "Search readable FOSSIL knowledge",
+                    "description": "Search only the packs mounted as readable for the configured node context.",
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": _object_schema(
+                                    required=["query"],
+                                    properties={
+                                        "query": {"type": "string", "minLength": 1},
+                                        "limit": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 100,
+                                            "default": 20,
+                                        },
+                                    },
+                                )
+                            }
+                        },
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Authorized search results",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "array",
+                                        "items": {"type": "object", "additionalProperties": True},
+                                    }
+                                }
+                            },
+                        },
+                        **common_responses,
+                    },
+                }
+            },
+            "/actions/read": {
+                "post": {
+                    "operationId": "fossilRead",
+                    "summary": "Read one durable FOSSIL event",
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": _object_schema(
+                                    required=["event_id"],
+                                    properties={"event_id": {"type": "string", "minLength": 1}},
+                                )
+                            }
+                        },
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Authorized durable event",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "object", "additionalProperties": True}
+                                }
+                            },
+                        },
+                        **common_responses,
+                    },
+                }
+            },
+            "/actions/lineage": {
+                "post": {
+                    "operationId": "fossilLineage",
+                    "summary": "Read conversation intellectual lineage",
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": _object_schema(
+                                    required=["conversation_id"],
+                                    properties={
+                                        "conversation_id": {"type": "string", "minLength": 1},
+                                        "node_id": {"type": "string", "minLength": 1},
+                                    },
+                                )
+                            }
+                        },
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Authorized lineage view",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "object", "additionalProperties": True}
+                                }
+                            },
+                        },
+                        **common_responses,
+                    },
+                }
+            },
+            "/actions/capabilities": {
+                "get": {
+                    "operationId": "fossilActionCapabilities",
+                    "summary": "Describe the bounded ChatGPT Action surface",
+                    "responses": {
+                        "200": {
+                            "description": "Read-only Action capabilities",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "object", "additionalProperties": True}
+                                }
+                            },
+                        },
+                        "401": common_responses["401"],
+                    },
+                }
+            },
+        },
+    }
+    if server_url:
+        schema["servers"] = [{"url": server_url.rstrip("/")}]
+    return schema
+
+
+class ChatGPTActionMiddleware(BaseHTTPMiddleware):
+    """Intercept a small authenticated REST surface before the node's MCP mount."""
+
+    def __init__(
+        self,
+        app: Any,
+        *,
+        adapter: ThinMCPAdapter,
+        bearer_token: str,
+        max_request_body_size: int = 64 * 1024,
+    ) -> None:
+        super().__init__(app)
+        if not bearer_token or bearer_token != bearer_token.strip():
+            raise ValueError("ChatGPT Action bearer token must be a non-empty trimmed string")
+        if max_request_body_size < 1:
+            raise ValueError("ChatGPT Action request body limit must be positive")
+        self.adapter = adapter
+        self.bearer_token = bearer_token
+        self.max_request_body_size = max_request_body_size
+
+    def _authorized(self, request: Request) -> bool:
+        value = request.headers.get("authorization", "")
+        scheme, separator, supplied = value.partition(" ")
+        if not separator or scheme.lower() != "bearer" or not supplied:
+            return False
+        return hmac.compare_digest(supplied, self.bearer_token)
+
+    async def _read_json(self, request: Request) -> Mapping[str, Any] | JSONResponse:
+        content_length = request.headers.get("content-length")
+        if content_length is not None:
+            try:
+                if int(content_length) > self.max_request_body_size:
+                    return _error(
+                        "request_too_large",
+                        f"request exceeds {self.max_request_body_size} byte Action limit",
+                        413,
+                    )
+            except ValueError:
+                return _error("invalid_request", "invalid Content-Length header", 400)
+
+        raw = await request.body()
+        if len(raw) > self.max_request_body_size:
+            return _error(
+                "request_too_large",
+                f"request exceeds {self.max_request_body_size} byte Action limit",
+                413,
+            )
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return _error("invalid_json", "request body must be valid UTF-8 JSON", 400)
+        if not isinstance(payload, Mapping):
+            return _error("invalid_request", "request body must be a JSON object", 400)
+        return payload
+
+    async def dispatch(self, request: Request, call_next: Any) -> Response:
+        path = request.url.path
+        if path == "/openapi.json" and request.method == "GET":
+            return JSONResponse(
+                chatgpt_action_openapi_schema(server_url=str(request.base_url))
+            )
+
+        if path not in {*_ACTION_PATHS, "/actions/capabilities"}:
+            return await call_next(request)
+
+        if not self._authorized(request):
+            response = _error("unauthorized", "valid bearer token required", 401)
+            response.headers["WWW-Authenticate"] = "Bearer"
+            return response
+
+        if path == "/actions/capabilities" and request.method == "GET":
+            service = getattr(self.adapter, "service", None)
+            return JSONResponse(
+                {
+                    "service_version": getattr(service, "service_version", "unknown"),
+                    "action_capabilities": ["search", "read", "lineage"],
+                    "durable_writes_exposed": False,
+                    "arbitrary_graph_mutation": False,
+                }
+            )
+
+        tool_name = _ACTION_PATHS.get(path)
+        if tool_name is None or request.method != "POST":
+            return _error("method_not_allowed", "unsupported Action method", 405)
+
+        parsed = await self._read_json(request)
+        if isinstance(parsed, JSONResponse):
+            return parsed
+
+        arguments = dict(parsed)
+        if tool_name == "fossil.search":
+            query = arguments.get("query")
+            if not isinstance(query, str) or not query.strip():
+                return _error("invalid_request", "query must be a non-empty string", 400)
+            arguments["query"] = query
+            if "limit" in arguments:
+                try:
+                    arguments["limit"] = int(arguments["limit"])
+                except (TypeError, ValueError):
+                    return _error("invalid_request", "limit must be an integer", 400)
+        elif tool_name == "fossil.read":
+            event_id = arguments.get("event_id")
+            if not isinstance(event_id, str) or not event_id:
+                return _error("invalid_request", "event_id must be a non-empty string", 400)
+            arguments = {"event_id": event_id}
+        elif tool_name == "fossil.lineage":
+            conversation_id = arguments.get("conversation_id")
+            if not isinstance(conversation_id, str) or not conversation_id:
+                return _error(
+                    "invalid_request", "conversation_id must be a non-empty string", 400
+                )
+            clean_arguments: dict[str, Any] = {"conversation_id": conversation_id}
+            if arguments.get("node_id") is not None:
+                node_id = arguments["node_id"]
+                if not isinstance(node_id, str) or not node_id:
+                    return _error("invalid_request", "node_id must be a non-empty string", 400)
+                clean_arguments["node_id"] = node_id
+            arguments = clean_arguments
+
+        try:
+            result = self.adapter.invoke(tool_name, arguments)
+        except Exception as exc:
+            return _map_action_error(exc)
+        return JSONResponse(result)
+
+
+def add_chatgpt_action_api(
+    app: Starlette,
+    *,
+    adapter: ThinMCPAdapter,
+    bearer_token: str,
+    max_request_body_size: int = 64 * 1024,
+) -> Starlette:
+    """Attach the read-only GPT Action compatibility surface to a Starlette node app."""
+
+    app.add_middleware(
+        ChatGPTActionMiddleware,
+        adapter=adapter,
+        bearer_token=bearer_token,
+        max_request_body_size=max_request_body_size,
+    )
+    app.state.chatgpt_action_enabled = True
+    return app
+
+
+def create_chatgpt_action_network_app(
+    node: FilesystemFossilNode,
+    *,
+    context: AgentContext,
+    bearer_token: str,
+    max_action_request_body_size: int = 64 * 1024,
+    **network_kwargs: Any,
+) -> Starlette:
+    """Compose the existing FOSSIL node network app plus read-only GPT Actions.
+
+    The same ``ThinMCPAdapter``/``CorpusService`` boundary is used by MCP and the
+    Action surface. The Action API deliberately exposes no proposal, validation,
+    commit, ingestion, or arbitrary graph mutation operation.
+    """
+
+    app = create_node_network_app(node, context=context, **network_kwargs)
+    adapter = ThinMCPAdapter(
+        service=node.corpus_service,
+        access=node.pack_access,
+        context=context,
+    )
+    return add_chatgpt_action_api(
+        app,
+        adapter=adapter,
+        bearer_token=bearer_token,
+        max_request_body_size=max_action_request_body_size,
+    )
+
+
+__all__ = [
+    "ChatGPTActionMiddleware",
+    "add_chatgpt_action_api",
+    "chatgpt_action_openapi_schema",
+    "create_chatgpt_action_network_app",
+]

--- a/src/fossil_core/runtime/chatgpt_action.py
+++ b/src/fossil_core/runtime/chatgpt_action.py
@@ -24,7 +24,6 @@ from .node import FilesystemFossilNode
 _ACTION_PATHS = {
     "/actions/search": "fossil.search",
     "/actions/read": "fossil.read",
-    "/actions/lineage": "fossil.lineage",
 }
 _ACTION_ROUTE_ALLOWLIST = frozenset(
     {"/openapi.json", *_ACTION_PATHS, "/actions/capabilities"}
@@ -94,7 +93,9 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
         "405": _json_response(_ref("ErrorEnvelope"), "HTTP method not allowed"),
         "413": _json_response(_ref("ErrorEnvelope"), "Request body too large"),
         "500": _json_response(_ref("ErrorEnvelope"), "Internal server error"),
-        "503": _json_response(_ref("ErrorEnvelope"), "Canonical store or HTTPS origin unavailable"),
+        "503": _json_response(
+            _ref("ErrorEnvelope"), "Canonical store or HTTPS origin unavailable"
+        ),
     }
 
     schemas: dict[str, Any] = {
@@ -143,13 +144,8 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
         ),
         "ReadRequest": _object_schema(
             required=["event_id"],
-            properties={"event_id": _identifier_schema("Opaque durable event identifier")},
-        ),
-        "LineageRequest": _object_schema(
-            required=["conversation_id"],
             properties={
-                "conversation_id": _identifier_schema("Opaque conversation identifier"),
-                "node_id": _identifier_schema("Optional opaque lineage-node identifier"),
+                "event_id": _identifier_schema("Opaque durable event identifier")
             },
         ),
         "SearchResult": {
@@ -198,7 +194,7 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                     "type": "array",
                     "items": {"type": "string"},
                 },
-                "correlation_id": {"type": "string"},
+                "correlation_id": {"type": ["string", "null"]},
                 "idempotency_key": {"type": "string"},
                 "payload": {
                     "type": "object",
@@ -209,75 +205,6 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                     "type": "object",
                     "additionalProperties": True,
                     "description": "Canonical event provenance when present.",
-                },
-            },
-        },
-        "LineageNode": {
-            "type": "object",
-            "additionalProperties": True,
-            "required": ["node_id", "kind"],
-            "properties": {
-                "node_id": {"type": "string"},
-                "kind": {"type": "string"},
-                "label": {"type": "string"},
-                "text": {"type": "string"},
-                "evidence_status": {"type": "string"},
-                "position_state": {"type": "string"},
-                "source_message_refs": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                },
-                "source_span_refs": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                },
-            },
-        },
-        "Citation": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": [
-                "span_id",
-                "artifact_id",
-                "evidence_status",
-                "byte_start",
-                "byte_end",
-                "text",
-            ],
-            "properties": {
-                "span_id": {"type": "string"},
-                "artifact_id": {"type": "string"},
-                "evidence_status": {"type": "string"},
-                "byte_start": {"type": "integer", "minimum": 0},
-                "byte_end": {"type": "integer", "minimum": 1},
-                "text": {"type": "string"},
-            },
-        },
-        "LineageResponse": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": [
-                "conversation_id",
-                "pack_id",
-                "current_conclusions",
-                "historical_nodes",
-            ],
-            "properties": {
-                "conversation_id": {"type": "string"},
-                "pack_id": {"type": "string"},
-                "current_conclusions": {
-                    "type": "array",
-                    "items": _ref("LineageNode"),
-                },
-                "historical_nodes": {
-                    "type": "array",
-                    "items": _ref("LineageNode"),
-                },
-                "node": _ref("LineageNode"),
-                "citations": {"type": "array", "items": _ref("Citation")},
-                "opposing_positions": {
-                    "type": "array",
-                    "items": _ref("LineageNode"),
                 },
             },
         },
@@ -297,7 +224,7 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                 "action_capabilities": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "const": ["search", "read", "lineage"],
+                    "const": ["search", "read"],
                 },
                 "durable_writes_exposed": {"type": "boolean", "const": False},
                 "ingestion_exposed": {"type": "boolean", "const": False},
@@ -314,9 +241,12 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
             "version": "1.0.0",
             "description": (
                 "Private read-only compatibility surface over canonical FOSSIL data. "
-                "Only search, durable-event read, lineage, and capability metadata are "
-                "Action operations. MCP, ingestion, proposal, validation, commit, graph "
-                "mutation, arbitrary filesystem access, and secret disclosure are prohibited."
+                "Only search, durable-event read, and capability metadata are Action "
+                "operations. Lineage remains a FOSSIL domain/MCP capability but is not "
+                "advertised by the standalone Action until a durable read-only lineage "
+                "provider is configured. MCP, ingestion, proposal, validation, commit, "
+                "graph mutation, arbitrary filesystem access, and secret disclosure are "
+                "prohibited."
             ),
         },
         "components": {
@@ -368,24 +298,6 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                     },
                 }
             },
-            "/actions/lineage": {
-                "post": {
-                    "operationId": "fossilLineage",
-                    "summary": "Read conversation intellectual lineage",
-                    "requestBody": {
-                        "required": True,
-                        "content": {
-                            "application/json": {"schema": _ref("LineageRequest")}
-                        },
-                    },
-                    "responses": {
-                        "200": _json_response(
-                            _ref("LineageResponse"), "Authorized lineage view"
-                        ),
-                        **common_responses,
-                    },
-                }
-            },
             "/actions/capabilities": {
                 "get": {
                     "operationId": "fossilActionCapabilities",
@@ -407,7 +319,7 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
     return schema
 
 
-def _safe_identifier(value: Any, field: str) -> str | None:
+def _safe_identifier(value: Any) -> str | None:
     if not isinstance(value, str) or not _OPAQUE_ID.fullmatch(value):
         return None
     return value
@@ -432,7 +344,9 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
     ) -> None:
         super().__init__(app)
         if not bearer_token or bearer_token != bearer_token.strip():
-            raise ValueError("ChatGPT Action bearer token must be a non-empty trimmed string")
+            raise ValueError(
+                "ChatGPT Action bearer token must be a non-empty trimmed string"
+            )
         if max_request_body_size < 1:
             raise ValueError("ChatGPT Action request body limit must be positive")
         if public_base_url is not None and not public_base_url.startswith("https://"):
@@ -471,8 +385,12 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
         if not any(peer in network for network in self.trusted_proxy_networks):
             return None
 
-        proto = request.headers.get("x-forwarded-proto", "")
-        host = request.headers.get("x-forwarded-host", "")
+        proto_values = request.headers.getlist("x-forwarded-proto")
+        host_values = request.headers.getlist("x-forwarded-host")
+        if len(proto_values) != 1 or len(host_values) != 1:
+            return None
+        proto = proto_values[0]
+        host = host_values[0]
         if (
             proto.lower() != "https"
             or not host
@@ -503,8 +421,9 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
     def _schema_origin(self, request: Request) -> str | None:
         if self.public_base_url:
             return self.public_base_url
-        if request.url.scheme == "https":
-            return str(request.base_url).rstrip("/")
+        # A caller-controlled direct HTTPS Host is not an authority signal. Without
+        # a fixed public origin, only forwarded HTTPS metadata from an explicitly
+        # trusted proxy peer may define the server URL advertised to a Custom GPT.
         return self._trusted_proxy_origin(request)
 
     async def _read_json(self, request: Request) -> Mapping[str, Any] | JSONResponse:
@@ -523,15 +442,20 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
                     413,
                 )
 
-        raw = await request.body()
-        if len(raw) > self.max_request_body_size:
-            return _error(
-                "request_too_large",
-                f"request exceeds {self.max_request_body_size} byte Action limit",
-                413,
-            )
+        raw = bytearray()
+        total = 0
+        async for chunk in request.stream():
+            total += len(chunk)
+            if total > self.max_request_body_size:
+                return _error(
+                    "request_too_large",
+                    f"request exceeds {self.max_request_body_size} byte Action limit",
+                    413,
+                )
+            raw.extend(chunk)
+
         try:
-            payload = json.loads(raw.decode("utf-8"))
+            payload = json.loads(bytes(raw).decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError):
             return _error("invalid_json", "request body must be valid UTF-8 JSON", 400)
         if not isinstance(payload, Mapping):
@@ -545,7 +469,9 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
 
         if path == "/openapi.json":
             if request.method != "GET":
-                return _error("method_not_allowed", "OpenAPI discovery requires GET", 405)
+                return _error(
+                    "method_not_allowed", "OpenAPI discovery requires GET", 405
+                )
             server_url = self._schema_origin(request)
             if server_url is None:
                 return _error(
@@ -562,12 +488,14 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
 
         if path == "/actions/capabilities":
             if request.method != "GET":
-                return _error("method_not_allowed", "capabilities requires GET", 405)
+                return _error(
+                    "method_not_allowed", "capabilities requires GET", 405
+                )
             service = getattr(self.adapter, "service", None)
             return JSONResponse(
                 {
                     "service_version": getattr(service, "service_version", "unknown"),
-                    "action_capabilities": ["search", "read", "lineage"],
+                    "action_capabilities": ["search", "read"],
                     "durable_writes_exposed": False,
                     "ingestion_exposed": False,
                     "mcp_exposed": False,
@@ -577,7 +505,9 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
 
         tool_name = _ACTION_PATHS[path]
         if request.method != "POST":
-            return _error("method_not_allowed", "Action operation requires POST", 405)
+            return _error(
+                "method_not_allowed", "Action operation requires POST", 405
+            )
 
         parsed = await self._read_json(request)
         if isinstance(parsed, JSONResponse):
@@ -592,7 +522,9 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
                 or not query.strip()
                 or len(query) > _MAX_QUERY_CHARS
             ):
-                return _error("invalid_request", "query must be a bounded non-empty string", 400)
+                return _error(
+                    "invalid_request", "query must be a bounded non-empty string", 400
+                )
             arguments: dict[str, Any] = {"query": query}
             if "limit" in parsed:
                 limit = parsed["limit"]
@@ -608,31 +540,15 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
                         400,
                     )
                 arguments["limit"] = limit
-        elif tool_name == "fossil.read":
+        else:
             if not _has_only_keys(parsed, {"event_id"}):
                 return _error("invalid_request", "unexpected request field", 400)
-            event_id = _safe_identifier(parsed.get("event_id"), "event_id")
+            event_id = _safe_identifier(parsed.get("event_id"))
             if event_id is None:
-                return _error("invalid_request", "event_id must be an opaque identifier", 400)
-            arguments = {"event_id": event_id}
-        else:
-            if not _has_only_keys(parsed, {"conversation_id", "node_id"}):
-                return _error("invalid_request", "unexpected request field", 400)
-            conversation_id = _safe_identifier(parsed.get("conversation_id"), "conversation_id")
-            if conversation_id is None:
                 return _error(
-                    "invalid_request",
-                    "conversation_id must be an opaque identifier",
-                    400,
+                    "invalid_request", "event_id must be an opaque identifier", 400
                 )
-            arguments = {"conversation_id": conversation_id}
-            if parsed.get("node_id") is not None:
-                node_id = _safe_identifier(parsed["node_id"], "node_id")
-                if node_id is None:
-                    return _error(
-                        "invalid_request", "node_id must be an opaque identifier", 400
-                    )
-                arguments["node_id"] = node_id
+            arguments = {"event_id": event_id}
 
         try:
             result = self.adapter.invoke(tool_name, arguments)

--- a/src/fossil_core/runtime/chatgpt_action.py
+++ b/src/fossil_core/runtime/chatgpt_action.py
@@ -23,6 +23,7 @@ _ACTION_PATHS = {
     "/actions/read": "fossil.read",
     "/actions/lineage": "fossil.lineage",
 }
+_ACTION_ROUTE_ALLOWLIST = frozenset({"/openapi.json", *_ACTION_PATHS, "/actions/capabilities"})
 
 
 def _error(code: str, detail: str, status_code: int) -> JSONResponse:
@@ -44,7 +45,7 @@ def _map_action_error(exc: Exception) -> JSONResponse:
     if isinstance(exc, (TypeError, ValueError)):
         return _error("invalid_request", str(exc), 400)
     if isinstance(exc, OSError):
-        return _error("canonical_store_unavailable", str(exc), 503)
+        return _error("canonical_store_unavailable", "canonical store unavailable", 503)
     return _error("internal_error", "FOSSIL Action execution failed", 500)
 
 
@@ -57,48 +58,35 @@ def _object_schema(*, required: list[str], properties: dict[str, Any]) -> dict[s
     }
 
 
+def _json_response(schema: dict[str, Any], description: str) -> dict[str, Any]:
+    return {
+        "description": description,
+        "content": {"application/json": {"schema": schema}},
+    }
+
+
 def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str, Any]:
     """Return the bounded read-only OpenAPI contract for a ChatGPT GPT Action."""
 
-    error_schema = {
-        "type": "object",
-        "required": ["error"],
-        "properties": {
-            "error": {
-                "type": "object",
-                "required": ["code", "detail"],
-                "properties": {
-                    "code": {"type": "string"},
-                    "detail": {"type": "string"},
-                },
-            }
-        },
-    }
+    error_ref = {"$ref": "#/components/schemas/ErrorEnvelope"}
     common_responses = {
-        "400": {
-            "description": "Invalid request",
-            "content": {"application/json": {"schema": error_schema}},
-        },
-        "401": {
-            "description": "Missing or invalid bearer token",
-            "content": {"application/json": {"schema": error_schema}},
-        },
-        "403": {
-            "description": "Pack or capability denied",
-            "content": {"application/json": {"schema": error_schema}},
-        },
-        "404": {
-            "description": "Resource not found",
-            "content": {"application/json": {"schema": error_schema}},
-        },
-        "413": {
-            "description": "Request body too large",
-            "content": {"application/json": {"schema": error_schema}},
-        },
-        "503": {
-            "description": "Canonical store unavailable",
-            "content": {"application/json": {"schema": error_schema}},
-        },
+        "400": _json_response(error_ref, "Invalid request"),
+        "401": _json_response(error_ref, "Missing or invalid bearer token"),
+        "403": _json_response(error_ref, "Pack or capability denied"),
+        "404": _json_response(error_ref, "Resource not found"),
+        "413": _json_response(error_ref, "Request body too large"),
+        "503": _json_response(error_ref, "Canonical store unavailable"),
+    }
+
+    record_properties = {
+        "event_id": {"type": "string"},
+        "pack_id": {"type": "string"},
+        "event_type": {"type": "string"},
+        "occurred_at": {"type": "string"},
+        "recorded_at": {"type": "string"},
+        "subject_refs": {"type": "array", "items": {"type": "string"}},
+        "evidence_refs": {"type": "array", "items": {"type": "string"}},
+        "payload": {"type": "object", "additionalProperties": True},
     }
 
     schema: dict[str, Any] = {
@@ -108,19 +96,76 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
             "version": "1.0.0",
             "description": (
                 "Read-only compatibility surface over the canonical FOSSIL corpus. "
-                "It exposes search, durable-event read, lineage, and Action capability "
-                "metadata. Durable proposal, validation, commit, ingestion, MCP, and "
-                "arbitrary graph mutation are intentionally not exposed."
+                "Only OpenAPI discovery, search, durable-event read, lineage, and "
+                "capability metadata are exposed. MCP, ingestion, proposal, validation, "
+                "commit, graph mutation, and arbitrary filesystem access are prohibited."
             ),
         },
         "components": {
+            "schemas": {
+                "ErrorDetail": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["code", "detail"],
+                    "properties": {
+                        "code": {"type": "string"},
+                        "detail": {"type": "string"},
+                    },
+                },
+                "ErrorEnvelope": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["error"],
+                    "properties": {
+                        "error": {"$ref": "#/components/schemas/ErrorDetail"}
+                    },
+                },
+                "FossilRecord": {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "properties": record_properties,
+                },
+                "LineageResponse": {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "required": ["conversation_id"],
+                    "properties": {
+                        "conversation_id": {"type": "string"},
+                        "current_conclusions": {"type": "array", "items": {"type": "object"}},
+                        "historical_nodes": {"type": "array", "items": {"type": "object"}},
+                        "node": {"type": ["object", "null"]},
+                        "citations": {"type": "array", "items": {"type": "object"}},
+                        "opposing_positions": {"type": "array", "items": {"type": "object"}},
+                    },
+                },
+                "CapabilitiesResponse": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": [
+                        "service_version",
+                        "action_capabilities",
+                        "durable_writes_exposed",
+                        "ingestion_exposed",
+                        "mcp_exposed",
+                        "arbitrary_graph_mutation",
+                    ],
+                    "properties": {
+                        "service_version": {"type": "string"},
+                        "action_capabilities": {"type": "array", "items": {"type": "string"}},
+                        "durable_writes_exposed": {"type": "boolean", "const": False},
+                        "ingestion_exposed": {"type": "boolean", "const": False},
+                        "mcp_exposed": {"type": "boolean", "const": False},
+                        "arbitrary_graph_mutation": {"type": "boolean", "const": False},
+                    },
+                },
+            },
             "securitySchemes": {
                 "BearerAuth": {
                     "type": "http",
                     "scheme": "bearer",
                     "bearerFormat": "opaque",
                 }
-            }
+            },
         },
         "security": [{"BearerAuth": []}],
         "paths": {
@@ -128,44 +173,21 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                 "post": {
                     "operationId": "fossilSearch",
                     "summary": "Search readable FOSSIL knowledge",
-                    "description": (
-                        "Search only packs mounted as readable for the configured "
-                        "FOSSIL Action context."
-                    ),
                     "requestBody": {
                         "required": True,
-                        "content": {
-                            "application/json": {
-                                "schema": _object_schema(
-                                    required=["query"],
-                                    properties={
-                                        "query": {"type": "string", "minLength": 1},
-                                        "limit": {
-                                            "type": "integer",
-                                            "minimum": 1,
-                                            "maximum": 100,
-                                            "default": 20,
-                                        },
-                                    },
-                                )
-                            }
-                        },
+                        "content": {"application/json": {"schema": _object_schema(
+                            required=["query"],
+                            properties={
+                                "query": {"type": "string", "minLength": 1},
+                                "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20},
+                            },
+                        )}},
                     },
                     "responses": {
-                        "200": {
-                            "description": "Authorized search results",
-                            "content": {
-                                "application/json": {
-                                    "schema": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "additionalProperties": True,
-                                        },
-                                    }
-                                }
-                            },
-                        },
+                        "200": _json_response(
+                            {"type": "array", "items": {"$ref": "#/components/schemas/FossilRecord"}},
+                            "Authorized search results",
+                        ),
                         **common_responses,
                     },
                 }
@@ -176,29 +198,13 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                     "summary": "Read one durable FOSSIL event",
                     "requestBody": {
                         "required": True,
-                        "content": {
-                            "application/json": {
-                                "schema": _object_schema(
-                                    required=["event_id"],
-                                    properties={
-                                        "event_id": {"type": "string", "minLength": 1}
-                                    },
-                                )
-                            }
-                        },
+                        "content": {"application/json": {"schema": _object_schema(
+                            required=["event_id"],
+                            properties={"event_id": {"type": "string", "minLength": 1}},
+                        )}},
                     },
                     "responses": {
-                        "200": {
-                            "description": "Authorized durable event",
-                            "content": {
-                                "application/json": {
-                                    "schema": {
-                                        "type": "object",
-                                        "additionalProperties": True,
-                                    }
-                                }
-                            },
-                        },
+                        "200": _json_response({"$ref": "#/components/schemas/FossilRecord"}, "Authorized durable event"),
                         **common_responses,
                     },
                 }
@@ -209,33 +215,16 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                     "summary": "Read conversation intellectual lineage",
                     "requestBody": {
                         "required": True,
-                        "content": {
-                            "application/json": {
-                                "schema": _object_schema(
-                                    required=["conversation_id"],
-                                    properties={
-                                        "conversation_id": {
-                                            "type": "string",
-                                            "minLength": 1,
-                                        },
-                                        "node_id": {"type": "string", "minLength": 1},
-                                    },
-                                )
-                            }
-                        },
+                        "content": {"application/json": {"schema": _object_schema(
+                            required=["conversation_id"],
+                            properties={
+                                "conversation_id": {"type": "string", "minLength": 1},
+                                "node_id": {"type": "string", "minLength": 1},
+                            },
+                        )}},
                     },
                     "responses": {
-                        "200": {
-                            "description": "Authorized lineage view",
-                            "content": {
-                                "application/json": {
-                                    "schema": {
-                                        "type": "object",
-                                        "additionalProperties": True,
-                                    }
-                                }
-                            },
-                        },
+                        "200": _json_response({"$ref": "#/components/schemas/LineageResponse"}, "Authorized lineage view"),
                         **common_responses,
                     },
                 }
@@ -245,17 +234,7 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                     "operationId": "fossilActionCapabilities",
                     "summary": "Describe the bounded ChatGPT Action surface",
                     "responses": {
-                        "200": {
-                            "description": "Read-only Action capabilities",
-                            "content": {
-                                "application/json": {
-                                    "schema": {
-                                        "type": "object",
-                                        "additionalProperties": True,
-                                    }
-                                }
-                            },
-                        },
+                        "200": _json_response({"$ref": "#/components/schemas/CapabilitiesResponse"}, "Read-only Action capabilities"),
                         "401": common_responses["401"],
                     },
                 }
@@ -277,15 +256,19 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
         adapter: ThinMCPAdapter,
         bearer_token: str,
         max_request_body_size: int = 64 * 1024,
+        public_base_url: str | None = None,
     ) -> None:
         super().__init__(app)
         if not bearer_token or bearer_token != bearer_token.strip():
             raise ValueError("ChatGPT Action bearer token must be a non-empty trimmed string")
         if max_request_body_size < 1:
             raise ValueError("ChatGPT Action request body limit must be positive")
+        if public_base_url is not None and not public_base_url.startswith("https://"):
+            raise ValueError("public ChatGPT Action base URL must use https://")
         self.adapter = adapter
         self.bearer_token = bearer_token
         self.max_request_body_size = max_request_body_size
+        self.public_base_url = public_base_url.rstrip("/") if public_base_url else None
 
     def _authorized(self, request: Request) -> bool:
         value = request.headers.get("authorization", "")
@@ -299,21 +282,12 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
         if content_length is not None:
             try:
                 if int(content_length) > self.max_request_body_size:
-                    return _error(
-                        "request_too_large",
-                        f"request exceeds {self.max_request_body_size} byte Action limit",
-                        413,
-                    )
+                    return _error("request_too_large", f"request exceeds {self.max_request_body_size} byte Action limit", 413)
             except ValueError:
                 return _error("invalid_request", "invalid Content-Length header", 400)
-
         raw = await request.body()
         if len(raw) > self.max_request_body_size:
-            return _error(
-                "request_too_large",
-                f"request exceeds {self.max_request_body_size} byte Action limit",
-                413,
-            )
+            return _error("request_too_large", f"request exceeds {self.max_request_body_size} byte Action limit", 413)
         try:
             payload = json.loads(raw.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError):
@@ -324,10 +298,11 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: Any) -> Response:
         path = request.url.path
-        if path == "/openapi.json" and request.method == "GET":
-            return JSONResponse(
-                chatgpt_action_openapi_schema(server_url=str(request.base_url))
-            )
+        if path == "/openapi.json":
+            if request.method != "GET":
+                return _error("method_not_allowed", "OpenAPI discovery requires GET", 405)
+            server_url = self.public_base_url or str(request.base_url)
+            return JSONResponse(chatgpt_action_openapi_schema(server_url=server_url))
 
         if path not in {*_ACTION_PATHS, "/actions/capabilities"}:
             return await call_next(request)
@@ -337,22 +312,22 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
             response.headers["WWW-Authenticate"] = "Bearer"
             return response
 
-        if path == "/actions/capabilities" and request.method == "GET":
+        if path == "/actions/capabilities":
+            if request.method != "GET":
+                return _error("method_not_allowed", "capabilities requires GET", 405)
             service = getattr(self.adapter, "service", None)
-            return JSONResponse(
-                {
-                    "service_version": getattr(service, "service_version", "unknown"),
-                    "action_capabilities": ["search", "read", "lineage"],
-                    "durable_writes_exposed": False,
-                    "ingestion_exposed": False,
-                    "mcp_exposed": False,
-                    "arbitrary_graph_mutation": False,
-                }
-            )
+            return JSONResponse({
+                "service_version": getattr(service, "service_version", "unknown"),
+                "action_capabilities": ["search", "read", "lineage"],
+                "durable_writes_exposed": False,
+                "ingestion_exposed": False,
+                "mcp_exposed": False,
+                "arbitrary_graph_mutation": False,
+            })
 
         tool_name = _ACTION_PATHS.get(path)
         if tool_name is None or request.method != "POST":
-            return _error("method_not_allowed", "unsupported Action method", 405)
+            return _error("method_not_allowed", "Action operation requires POST", 405)
 
         parsed = await self._read_json(request)
         if isinstance(parsed, JSONResponse):
@@ -364,10 +339,10 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
                 return _error("invalid_request", "query must be a non-empty string", 400)
             arguments: dict[str, Any] = {"query": query}
             if "limit" in parsed:
-                try:
-                    arguments["limit"] = int(parsed["limit"])
-                except (TypeError, ValueError):
-                    return _error("invalid_request", "limit must be an integer", 400)
+                limit = parsed["limit"]
+                if isinstance(limit, bool) or not isinstance(limit, int) or limit < 1 or limit > 100:
+                    return _error("invalid_request", "limit must be an integer from 1 through 100", 400)
+                arguments["limit"] = limit
         elif tool_name == "fossil.read":
             event_id = parsed.get("event_id")
             if not isinstance(event_id, str) or not event_id:
@@ -376,16 +351,12 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
         else:
             conversation_id = parsed.get("conversation_id")
             if not isinstance(conversation_id, str) or not conversation_id:
-                return _error(
-                    "invalid_request", "conversation_id must be a non-empty string", 400
-                )
+                return _error("invalid_request", "conversation_id must be a non-empty string", 400)
             arguments = {"conversation_id": conversation_id}
             if parsed.get("node_id") is not None:
                 node_id = parsed["node_id"]
                 if not isinstance(node_id, str) or not node_id:
-                    return _error(
-                        "invalid_request", "node_id must be a non-empty string", 400
-                    )
+                    return _error("invalid_request", "node_id must be a non-empty string", 400)
                 arguments["node_id"] = node_id
 
         try:
@@ -401,14 +372,14 @@ def add_chatgpt_action_api(
     adapter: ThinMCPAdapter,
     bearer_token: str,
     max_request_body_size: int = 64 * 1024,
+    public_base_url: str | None = None,
 ) -> Starlette:
-    """Attach the Action compatibility surface to a Starlette app."""
-
     app.add_middleware(
         ChatGPTActionMiddleware,
         adapter=adapter,
         bearer_token=bearer_token,
         max_request_body_size=max_request_body_size,
+        public_base_url=public_base_url,
     )
     app.state.chatgpt_action_enabled = True
     return app
@@ -420,26 +391,15 @@ def create_chatgpt_action_app(
     context: AgentContext,
     bearer_token: str,
     max_request_body_size: int = 64 * 1024,
+    public_base_url: str | None = None,
 ) -> Starlette:
-    """Create the public-facing read-only GPT Action ASGI app.
-
-    This app deliberately does not mount the node's MCP, ingestion, health, or
-    readiness routes. Deploy it as a distinct public HTTPS edge while the normal
-    FOSSIL node remains private. Both surfaces share the same canonical
-    ``CorpusService`` and pack authorization semantics.
-    """
-
-    adapter = ThinMCPAdapter(
-        service=node.corpus_service,
-        access=node.pack_access,
-        context=context,
-    )
-    app = Starlette()
+    adapter = ThinMCPAdapter(service=node.corpus_service, access=node.pack_access, context=context)
     return add_chatgpt_action_api(
-        app,
+        Starlette(),
         adapter=adapter,
         bearer_token=bearer_token,
         max_request_body_size=max_request_body_size,
+        public_base_url=public_base_url,
     )
 
 

--- a/src/fossil_core/runtime/chatgpt_action.py
+++ b/src/fossil_core/runtime/chatgpt_action.py
@@ -15,7 +15,6 @@ from fossil_core.agent import AgentContext, AgentProvenanceError
 from fossil_core.domain.pack import PackBoundaryError
 from fossil_core.ports.capability import CapabilityError
 
-from .network import create_node_network_app
 from .node import FilesystemFossilNode
 
 
@@ -59,7 +58,7 @@ def _object_schema(*, required: list[str], properties: dict[str, Any]) -> dict[s
 
 
 def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str, Any]:
-    """Return the read-only OpenAPI contract intended for a ChatGPT GPT Action."""
+    """Return the bounded read-only OpenAPI contract for a ChatGPT GPT Action."""
 
     error_schema = {
         "type": "object",
@@ -76,11 +75,30 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
         },
     }
     common_responses = {
-        "400": {"description": "Invalid request", "content": {"application/json": {"schema": error_schema}}},
-        "401": {"description": "Missing or invalid bearer token", "content": {"application/json": {"schema": error_schema}}},
-        "403": {"description": "Pack or capability denied", "content": {"application/json": {"schema": error_schema}}},
-        "404": {"description": "Resource not found", "content": {"application/json": {"schema": error_schema}}},
-        "503": {"description": "Canonical store unavailable", "content": {"application/json": {"schema": error_schema}}},
+        "400": {
+            "description": "Invalid request",
+            "content": {"application/json": {"schema": error_schema}},
+        },
+        "401": {
+            "description": "Missing or invalid bearer token",
+            "content": {"application/json": {"schema": error_schema}},
+        },
+        "403": {
+            "description": "Pack or capability denied",
+            "content": {"application/json": {"schema": error_schema}},
+        },
+        "404": {
+            "description": "Resource not found",
+            "content": {"application/json": {"schema": error_schema}},
+        },
+        "413": {
+            "description": "Request body too large",
+            "content": {"application/json": {"schema": error_schema}},
+        },
+        "503": {
+            "description": "Canonical store unavailable",
+            "content": {"application/json": {"schema": error_schema}},
+        },
     }
 
     schema: dict[str, Any] = {
@@ -90,8 +108,9 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
             "version": "1.0.0",
             "description": (
                 "Read-only compatibility surface over the canonical FOSSIL corpus. "
-                "It exposes search, durable-event read, lineage, and adapter capability metadata; "
-                "durable proposal/validation/commit are intentionally not exposed."
+                "It exposes search, durable-event read, lineage, and Action capability "
+                "metadata. Durable proposal, validation, commit, ingestion, MCP, and "
+                "arbitrary graph mutation are intentionally not exposed."
             ),
         },
         "components": {
@@ -109,7 +128,10 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                 "post": {
                     "operationId": "fossilSearch",
                     "summary": "Search readable FOSSIL knowledge",
-                    "description": "Search only the packs mounted as readable for the configured node context.",
+                    "description": (
+                        "Search only packs mounted as readable for the configured "
+                        "FOSSIL Action context."
+                    ),
                     "requestBody": {
                         "required": True,
                         "content": {
@@ -136,7 +158,10 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                                 "application/json": {
                                     "schema": {
                                         "type": "array",
-                                        "items": {"type": "object", "additionalProperties": True},
+                                        "items": {
+                                            "type": "object",
+                                            "additionalProperties": True,
+                                        },
                                     }
                                 }
                             },
@@ -155,7 +180,9 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                             "application/json": {
                                 "schema": _object_schema(
                                     required=["event_id"],
-                                    properties={"event_id": {"type": "string", "minLength": 1}},
+                                    properties={
+                                        "event_id": {"type": "string", "minLength": 1}
+                                    },
                                 )
                             }
                         },
@@ -165,7 +192,10 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                             "description": "Authorized durable event",
                             "content": {
                                 "application/json": {
-                                    "schema": {"type": "object", "additionalProperties": True}
+                                    "schema": {
+                                        "type": "object",
+                                        "additionalProperties": True,
+                                    }
                                 }
                             },
                         },
@@ -184,7 +214,10 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                                 "schema": _object_schema(
                                     required=["conversation_id"],
                                     properties={
-                                        "conversation_id": {"type": "string", "minLength": 1},
+                                        "conversation_id": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                        },
                                         "node_id": {"type": "string", "minLength": 1},
                                     },
                                 )
@@ -196,7 +229,10 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                             "description": "Authorized lineage view",
                             "content": {
                                 "application/json": {
-                                    "schema": {"type": "object", "additionalProperties": True}
+                                    "schema": {
+                                        "type": "object",
+                                        "additionalProperties": True,
+                                    }
                                 }
                             },
                         },
@@ -213,7 +249,10 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                             "description": "Read-only Action capabilities",
                             "content": {
                                 "application/json": {
-                                    "schema": {"type": "object", "additionalProperties": True}
+                                    "schema": {
+                                        "type": "object",
+                                        "additionalProperties": True,
+                                    }
                                 }
                             },
                         },
@@ -229,7 +268,7 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
 
 
 class ChatGPTActionMiddleware(BaseHTTPMiddleware):
-    """Intercept a small authenticated REST surface before the node's MCP mount."""
+    """Serve only the bounded authenticated REST compatibility surface."""
 
     def __init__(
         self,
@@ -305,6 +344,8 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
                     "service_version": getattr(service, "service_version", "unknown"),
                     "action_capabilities": ["search", "read", "lineage"],
                     "durable_writes_exposed": False,
+                    "ingestion_exposed": False,
+                    "mcp_exposed": False,
                     "arbitrary_graph_mutation": False,
                 }
             )
@@ -317,35 +358,35 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
         if isinstance(parsed, JSONResponse):
             return parsed
 
-        arguments = dict(parsed)
         if tool_name == "fossil.search":
-            query = arguments.get("query")
+            query = parsed.get("query")
             if not isinstance(query, str) or not query.strip():
                 return _error("invalid_request", "query must be a non-empty string", 400)
-            arguments["query"] = query
-            if "limit" in arguments:
+            arguments: dict[str, Any] = {"query": query}
+            if "limit" in parsed:
                 try:
-                    arguments["limit"] = int(arguments["limit"])
+                    arguments["limit"] = int(parsed["limit"])
                 except (TypeError, ValueError):
                     return _error("invalid_request", "limit must be an integer", 400)
         elif tool_name == "fossil.read":
-            event_id = arguments.get("event_id")
+            event_id = parsed.get("event_id")
             if not isinstance(event_id, str) or not event_id:
                 return _error("invalid_request", "event_id must be a non-empty string", 400)
             arguments = {"event_id": event_id}
-        elif tool_name == "fossil.lineage":
-            conversation_id = arguments.get("conversation_id")
+        else:
+            conversation_id = parsed.get("conversation_id")
             if not isinstance(conversation_id, str) or not conversation_id:
                 return _error(
                     "invalid_request", "conversation_id must be a non-empty string", 400
                 )
-            clean_arguments: dict[str, Any] = {"conversation_id": conversation_id}
-            if arguments.get("node_id") is not None:
-                node_id = arguments["node_id"]
+            arguments = {"conversation_id": conversation_id}
+            if parsed.get("node_id") is not None:
+                node_id = parsed["node_id"]
                 if not isinstance(node_id, str) or not node_id:
-                    return _error("invalid_request", "node_id must be a non-empty string", 400)
-                clean_arguments["node_id"] = node_id
-            arguments = clean_arguments
+                    return _error(
+                        "invalid_request", "node_id must be a non-empty string", 400
+                    )
+                arguments["node_id"] = node_id
 
         try:
             result = self.adapter.invoke(tool_name, arguments)
@@ -361,7 +402,7 @@ def add_chatgpt_action_api(
     bearer_token: str,
     max_request_body_size: int = 64 * 1024,
 ) -> Starlette:
-    """Attach the read-only GPT Action compatibility surface to a Starlette node app."""
+    """Attach the Action compatibility surface to a Starlette app."""
 
     app.add_middleware(
         ChatGPTActionMiddleware,
@@ -373,32 +414,32 @@ def add_chatgpt_action_api(
     return app
 
 
-def create_chatgpt_action_network_app(
+def create_chatgpt_action_app(
     node: FilesystemFossilNode,
     *,
     context: AgentContext,
     bearer_token: str,
-    max_action_request_body_size: int = 64 * 1024,
-    **network_kwargs: Any,
+    max_request_body_size: int = 64 * 1024,
 ) -> Starlette:
-    """Compose the existing FOSSIL node network app plus read-only GPT Actions.
+    """Create the public-facing read-only GPT Action ASGI app.
 
-    The same ``ThinMCPAdapter``/``CorpusService`` boundary is used by MCP and the
-    Action surface. The Action API deliberately exposes no proposal, validation,
-    commit, ingestion, or arbitrary graph mutation operation.
+    This app deliberately does not mount the node's MCP, ingestion, health, or
+    readiness routes. Deploy it as a distinct public HTTPS edge while the normal
+    FOSSIL node remains private. Both surfaces share the same canonical
+    ``CorpusService`` and pack authorization semantics.
     """
 
-    app = create_node_network_app(node, context=context, **network_kwargs)
     adapter = ThinMCPAdapter(
         service=node.corpus_service,
         access=node.pack_access,
         context=context,
     )
+    app = Starlette()
     return add_chatgpt_action_api(
         app,
         adapter=adapter,
         bearer_token=bearer_token,
-        max_request_body_size=max_action_request_body_size,
+        max_request_body_size=max_request_body_size,
     )
 
 
@@ -406,5 +447,5 @@ __all__ = [
     "ChatGPTActionMiddleware",
     "add_chatgpt_action_api",
     "chatgpt_action_openapi_schema",
-    "create_chatgpt_action_network_app",
+    "create_chatgpt_action_app",
 ]

--- a/src/fossil_core/runtime/chatgpt_action.py
+++ b/src/fossil_core/runtime/chatgpt_action.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import hmac
+import ipaddress
 import json
+import re
 from collections.abc import Mapping
 from typing import Any
+from urllib.parse import urlsplit
 
 from starlette.applications import Starlette
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -23,7 +26,11 @@ _ACTION_PATHS = {
     "/actions/read": "fossil.read",
     "/actions/lineage": "fossil.lineage",
 }
-_ACTION_ROUTE_ALLOWLIST = frozenset({"/openapi.json", *_ACTION_PATHS, "/actions/capabilities"})
+_ACTION_ROUTE_ALLOWLIST = frozenset(
+    {"/openapi.json", *_ACTION_PATHS, "/actions/capabilities"}
+)
+_OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,255}$")
+_MAX_QUERY_CHARS = 8192
 
 
 def _error(code: str, detail: str, status_code: int) -> JSONResponse:
@@ -34,16 +41,13 @@ def _error(code: str, detail: str, status_code: int) -> JSONResponse:
 
 def _map_action_error(exc: Exception) -> JSONResponse:
     if isinstance(exc, PackBoundaryError):
-        return _error("unauthorized_pack", str(exc), 403)
+        return _error("unauthorized_pack", "requested knowledge is not readable", 403)
     if isinstance(exc, (CapabilityError, AgentProvenanceError)):
-        return _error("capability_denied", str(exc), 403)
-    if isinstance(exc, FileNotFoundError):
-        return _error("not_found", str(exc), 404)
-    if isinstance(exc, KeyError):
-        detail = str(exc.args[0]) if exc.args else "resource not found"
-        return _error("not_found", detail, 404)
+        return _error("capability_denied", "requested capability is not permitted", 403)
+    if isinstance(exc, (FileNotFoundError, KeyError)):
+        return _error("not_found", "requested resource was not found", 404)
     if isinstance(exc, (TypeError, ValueError)):
-        return _error("invalid_request", str(exc), 400)
+        return _error("invalid_request", "request was rejected", 400)
     if isinstance(exc, OSError):
         return _error("canonical_store_unavailable", "canonical store unavailable", 503)
     return _error("internal_error", "FOSSIL Action execution failed", 500)
@@ -65,28 +69,242 @@ def _json_response(schema: dict[str, Any], description: str) -> dict[str, Any]:
     }
 
 
-def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str, Any]:
-    """Return the bounded read-only OpenAPI contract for a ChatGPT GPT Action."""
+def _ref(name: str) -> dict[str, str]:
+    return {"$ref": f"#/components/schemas/{name}"}
 
-    error_ref = {"$ref": "#/components/schemas/ErrorEnvelope"}
-    common_responses = {
-        "400": _json_response(error_ref, "Invalid request"),
-        "401": _json_response(error_ref, "Missing or invalid bearer token"),
-        "403": _json_response(error_ref, "Pack or capability denied"),
-        "404": _json_response(error_ref, "Resource not found"),
-        "413": _json_response(error_ref, "Request body too large"),
-        "503": _json_response(error_ref, "Canonical store unavailable"),
+
+def _identifier_schema(description: str) -> dict[str, Any]:
+    return {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 256,
+        "pattern": _OPAQUE_ID.pattern,
+        "description": description,
     }
 
-    record_properties = {
-        "event_id": {"type": "string"},
-        "pack_id": {"type": "string"},
-        "event_type": {"type": "string"},
-        "occurred_at": {"type": "string"},
-        "recorded_at": {"type": "string"},
-        "subject_refs": {"type": "array", "items": {"type": "string"}},
-        "evidence_refs": {"type": "array", "items": {"type": "string"}},
-        "payload": {"type": "object", "additionalProperties": True},
+
+def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str, Any]:
+    """Return the bounded OpenAPI 3.1 contract for a private GPT Action."""
+
+    common_responses = {
+        "400": _json_response(_ref("ErrorEnvelope"), "Invalid request"),
+        "401": _json_response(_ref("ErrorEnvelope"), "Missing or invalid bearer token"),
+        "403": _json_response(_ref("ErrorEnvelope"), "Pack or capability denied"),
+        "404": _json_response(_ref("ErrorEnvelope"), "Resource not found"),
+        "405": _json_response(_ref("ErrorEnvelope"), "HTTP method not allowed"),
+        "413": _json_response(_ref("ErrorEnvelope"), "Request body too large"),
+        "500": _json_response(_ref("ErrorEnvelope"), "Internal server error"),
+        "503": _json_response(_ref("ErrorEnvelope"), "Canonical store or HTTPS origin unavailable"),
+    }
+
+    schemas: dict[str, Any] = {
+        "ErrorDetail": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["code", "detail"],
+            "properties": {
+                "code": {"type": "string"},
+                "detail": {"type": "string"},
+            },
+        },
+        "ErrorEnvelope": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["error"],
+            "properties": {"error": _ref("ErrorDetail")},
+        },
+        "Actor": {
+            "type": "object",
+            "additionalProperties": True,
+            "properties": {
+                "actor_type": {"type": "string"},
+                "actor_id": {"type": "string"},
+                "model_id": {"type": "string"},
+                "harness_version": {"type": "string"},
+                "skill_id": {"type": "string"},
+                "skill_version": {"type": "string"},
+            },
+        },
+        "SearchRequest": _object_schema(
+            required=["query"],
+            properties={
+                "query": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": _MAX_QUERY_CHARS,
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 20,
+                },
+            },
+        ),
+        "ReadRequest": _object_schema(
+            required=["event_id"],
+            properties={"event_id": _identifier_schema("Opaque durable event identifier")},
+        ),
+        "LineageRequest": _object_schema(
+            required=["conversation_id"],
+            properties={
+                "conversation_id": _identifier_schema("Opaque conversation identifier"),
+                "node_id": _identifier_schema("Optional opaque lineage-node identifier"),
+            },
+        ),
+        "SearchResult": {
+            "type": "object",
+            "additionalProperties": True,
+            "required": ["event_id", "event_type", "pack_id", "recorded_at"],
+            "properties": {
+                "event_id": {"type": "string"},
+                "event_type": {"type": "string"},
+                "pack_id": {"type": "string"},
+                "recorded_at": {"type": "string"},
+                "subject_refs": {"type": "array", "items": {"type": "string"}},
+                "evidence_refs": {"type": "array", "items": {"type": "string"}},
+                "source_snapshot_refs": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "score": {"type": "number"},
+            },
+        },
+        "FossilEvent": {
+            "type": "object",
+            "additionalProperties": True,
+            "required": [
+                "event_id",
+                "event_type",
+                "pack_id",
+                "occurred_at",
+                "recorded_at",
+            ],
+            "properties": {
+                "schema_version": {"type": "string"},
+                "event_id": {"type": "string"},
+                "event_type": {"type": "string"},
+                "occurred_at": {"type": "string"},
+                "recorded_at": {"type": "string"},
+                "pack_id": {"type": "string"},
+                "actor": _ref("Actor"),
+                "subject_refs": {"type": "array", "items": {"type": "string"}},
+                "evidence_refs": {"type": "array", "items": {"type": "string"}},
+                "source_snapshot_refs": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "caused_by_event_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "correlation_id": {"type": "string"},
+                "idempotency_key": {"type": "string"},
+                "payload": {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "description": "Event-type-specific canonical payload.",
+                },
+                "provenance": {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "description": "Canonical event provenance when present.",
+                },
+            },
+        },
+        "LineageNode": {
+            "type": "object",
+            "additionalProperties": True,
+            "required": ["node_id", "kind"],
+            "properties": {
+                "node_id": {"type": "string"},
+                "kind": {"type": "string"},
+                "label": {"type": "string"},
+                "text": {"type": "string"},
+                "evidence_status": {"type": "string"},
+                "position_state": {"type": "string"},
+                "source_message_refs": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "source_span_refs": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+            },
+        },
+        "Citation": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": [
+                "span_id",
+                "artifact_id",
+                "evidence_status",
+                "byte_start",
+                "byte_end",
+                "text",
+            ],
+            "properties": {
+                "span_id": {"type": "string"},
+                "artifact_id": {"type": "string"},
+                "evidence_status": {"type": "string"},
+                "byte_start": {"type": "integer", "minimum": 0},
+                "byte_end": {"type": "integer", "minimum": 1},
+                "text": {"type": "string"},
+            },
+        },
+        "LineageResponse": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": [
+                "conversation_id",
+                "pack_id",
+                "current_conclusions",
+                "historical_nodes",
+            ],
+            "properties": {
+                "conversation_id": {"type": "string"},
+                "pack_id": {"type": "string"},
+                "current_conclusions": {
+                    "type": "array",
+                    "items": _ref("LineageNode"),
+                },
+                "historical_nodes": {
+                    "type": "array",
+                    "items": _ref("LineageNode"),
+                },
+                "node": _ref("LineageNode"),
+                "citations": {"type": "array", "items": _ref("Citation")},
+                "opposing_positions": {
+                    "type": "array",
+                    "items": _ref("LineageNode"),
+                },
+            },
+        },
+        "CapabilitiesResponse": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": [
+                "service_version",
+                "action_capabilities",
+                "durable_writes_exposed",
+                "ingestion_exposed",
+                "mcp_exposed",
+                "arbitrary_graph_mutation",
+            ],
+            "properties": {
+                "service_version": {"type": "string"},
+                "action_capabilities": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "const": ["search", "read", "lineage"],
+                },
+                "durable_writes_exposed": {"type": "boolean", "const": False},
+                "ingestion_exposed": {"type": "boolean", "const": False},
+                "mcp_exposed": {"type": "boolean", "const": False},
+                "arbitrary_graph_mutation": {"type": "boolean", "const": False},
+            },
+        },
     }
 
     schema: dict[str, Any] = {
@@ -95,70 +313,14 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
             "title": "FOSSIL read-only ChatGPT Action API",
             "version": "1.0.0",
             "description": (
-                "Read-only compatibility surface over the canonical FOSSIL corpus. "
-                "Only OpenAPI discovery, search, durable-event read, lineage, and "
-                "capability metadata are exposed. MCP, ingestion, proposal, validation, "
-                "commit, graph mutation, and arbitrary filesystem access are prohibited."
+                "Private read-only compatibility surface over canonical FOSSIL data. "
+                "Only search, durable-event read, lineage, and capability metadata are "
+                "Action operations. MCP, ingestion, proposal, validation, commit, graph "
+                "mutation, arbitrary filesystem access, and secret disclosure are prohibited."
             ),
         },
         "components": {
-            "schemas": {
-                "ErrorDetail": {
-                    "type": "object",
-                    "additionalProperties": False,
-                    "required": ["code", "detail"],
-                    "properties": {
-                        "code": {"type": "string"},
-                        "detail": {"type": "string"},
-                    },
-                },
-                "ErrorEnvelope": {
-                    "type": "object",
-                    "additionalProperties": False,
-                    "required": ["error"],
-                    "properties": {
-                        "error": {"$ref": "#/components/schemas/ErrorDetail"}
-                    },
-                },
-                "FossilRecord": {
-                    "type": "object",
-                    "additionalProperties": True,
-                    "properties": record_properties,
-                },
-                "LineageResponse": {
-                    "type": "object",
-                    "additionalProperties": True,
-                    "required": ["conversation_id"],
-                    "properties": {
-                        "conversation_id": {"type": "string"},
-                        "current_conclusions": {"type": "array", "items": {"type": "object"}},
-                        "historical_nodes": {"type": "array", "items": {"type": "object"}},
-                        "node": {"type": ["object", "null"]},
-                        "citations": {"type": "array", "items": {"type": "object"}},
-                        "opposing_positions": {"type": "array", "items": {"type": "object"}},
-                    },
-                },
-                "CapabilitiesResponse": {
-                    "type": "object",
-                    "additionalProperties": False,
-                    "required": [
-                        "service_version",
-                        "action_capabilities",
-                        "durable_writes_exposed",
-                        "ingestion_exposed",
-                        "mcp_exposed",
-                        "arbitrary_graph_mutation",
-                    ],
-                    "properties": {
-                        "service_version": {"type": "string"},
-                        "action_capabilities": {"type": "array", "items": {"type": "string"}},
-                        "durable_writes_exposed": {"type": "boolean", "const": False},
-                        "ingestion_exposed": {"type": "boolean", "const": False},
-                        "mcp_exposed": {"type": "boolean", "const": False},
-                        "arbitrary_graph_mutation": {"type": "boolean", "const": False},
-                    },
-                },
-            },
+            "schemas": schemas,
             "securitySchemes": {
                 "BearerAuth": {
                     "type": "http",
@@ -175,17 +337,13 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                     "summary": "Search readable FOSSIL knowledge",
                     "requestBody": {
                         "required": True,
-                        "content": {"application/json": {"schema": _object_schema(
-                            required=["query"],
-                            properties={
-                                "query": {"type": "string", "minLength": 1},
-                                "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20},
-                            },
-                        )}},
+                        "content": {
+                            "application/json": {"schema": _ref("SearchRequest")}
+                        },
                     },
                     "responses": {
                         "200": _json_response(
-                            {"type": "array", "items": {"$ref": "#/components/schemas/FossilRecord"}},
+                            {"type": "array", "items": _ref("SearchResult")},
                             "Authorized search results",
                         ),
                         **common_responses,
@@ -198,13 +356,14 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                     "summary": "Read one durable FOSSIL event",
                     "requestBody": {
                         "required": True,
-                        "content": {"application/json": {"schema": _object_schema(
-                            required=["event_id"],
-                            properties={"event_id": {"type": "string", "minLength": 1}},
-                        )}},
+                        "content": {
+                            "application/json": {"schema": _ref("ReadRequest")}
+                        },
                     },
                     "responses": {
-                        "200": _json_response({"$ref": "#/components/schemas/FossilRecord"}, "Authorized durable event"),
+                        "200": _json_response(
+                            _ref("FossilEvent"), "Authorized durable event"
+                        ),
                         **common_responses,
                     },
                 }
@@ -215,16 +374,14 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
                     "summary": "Read conversation intellectual lineage",
                     "requestBody": {
                         "required": True,
-                        "content": {"application/json": {"schema": _object_schema(
-                            required=["conversation_id"],
-                            properties={
-                                "conversation_id": {"type": "string", "minLength": 1},
-                                "node_id": {"type": "string", "minLength": 1},
-                            },
-                        )}},
+                        "content": {
+                            "application/json": {"schema": _ref("LineageRequest")}
+                        },
                     },
                     "responses": {
-                        "200": _json_response({"$ref": "#/components/schemas/LineageResponse"}, "Authorized lineage view"),
+                        "200": _json_response(
+                            _ref("LineageResponse"), "Authorized lineage view"
+                        ),
                         **common_responses,
                     },
                 }
@@ -232,10 +389,14 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
             "/actions/capabilities": {
                 "get": {
                     "operationId": "fossilActionCapabilities",
-                    "summary": "Describe the bounded ChatGPT Action surface",
+                    "summary": "Describe the bounded read-only Action surface",
                     "responses": {
-                        "200": _json_response({"$ref": "#/components/schemas/CapabilitiesResponse"}, "Read-only Action capabilities"),
+                        "200": _json_response(
+                            _ref("CapabilitiesResponse"),
+                            "Read-only Action capabilities",
+                        ),
                         "401": common_responses["401"],
+                        "405": common_responses["405"],
                     },
                 }
             },
@@ -244,6 +405,16 @@ def chatgpt_action_openapi_schema(*, server_url: str | None = None) -> dict[str,
     if server_url:
         schema["servers"] = [{"url": server_url.rstrip("/")}]
     return schema
+
+
+def _safe_identifier(value: Any, field: str) -> str | None:
+    if not isinstance(value, str) or not _OPAQUE_ID.fullmatch(value):
+        return None
+    return value
+
+
+def _has_only_keys(payload: Mapping[str, Any], allowed: set[str]) -> bool:
+    return set(payload).issubset(allowed)
 
 
 class ChatGPTActionMiddleware(BaseHTTPMiddleware):
@@ -257,6 +428,7 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
         bearer_token: str,
         max_request_body_size: int = 64 * 1024,
         public_base_url: str | None = None,
+        trusted_proxy_cidrs: tuple[str, ...] = (),
     ) -> None:
         super().__init__(app)
         if not bearer_token or bearer_token != bearer_token.strip():
@@ -269,25 +441,95 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
         self.bearer_token = bearer_token
         self.max_request_body_size = max_request_body_size
         self.public_base_url = public_base_url.rstrip("/") if public_base_url else None
+        self.trusted_proxy_networks = tuple(
+            ipaddress.ip_network(cidr, strict=False) for cidr in trusted_proxy_cidrs
+        )
 
     def _authorized(self, request: Request) -> bool:
-        value = request.headers.get("authorization", "")
+        values = request.headers.getlist("authorization")
+        if len(values) != 1:
+            return False
+        value = values[0]
         scheme, separator, supplied = value.partition(" ")
-        if not separator or scheme.lower() != "bearer" or not supplied:
+        if (
+            separator != " "
+            or scheme.lower() != "bearer"
+            or not supplied
+            or supplied != supplied.strip()
+            or any(character.isspace() for character in supplied)
+        ):
             return False
         return hmac.compare_digest(supplied, self.bearer_token)
+
+    def _trusted_proxy_origin(self, request: Request) -> str | None:
+        if not self.trusted_proxy_networks or request.client is None:
+            return None
+        try:
+            peer = ipaddress.ip_address(request.client.host)
+        except ValueError:
+            return None
+        if not any(peer in network for network in self.trusted_proxy_networks):
+            return None
+
+        proto = request.headers.get("x-forwarded-proto", "")
+        host = request.headers.get("x-forwarded-host", "")
+        if (
+            proto.lower() != "https"
+            or not host
+            or "," in proto
+            or "," in host
+            or len(host) > 255
+            or any(character.isspace() for character in host)
+            or any(character in host for character in "/\\@?#")
+        ):
+            return None
+        try:
+            parsed = urlsplit(f"https://{host}")
+            _ = parsed.port
+        except ValueError:
+            return None
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path
+            or parsed.query
+            or parsed.fragment
+        ):
+            return None
+        return f"https://{host}"
+
+    def _schema_origin(self, request: Request) -> str | None:
+        if self.public_base_url:
+            return self.public_base_url
+        if request.url.scheme == "https":
+            return str(request.base_url).rstrip("/")
+        return self._trusted_proxy_origin(request)
 
     async def _read_json(self, request: Request) -> Mapping[str, Any] | JSONResponse:
         content_length = request.headers.get("content-length")
         if content_length is not None:
             try:
-                if int(content_length) > self.max_request_body_size:
-                    return _error("request_too_large", f"request exceeds {self.max_request_body_size} byte Action limit", 413)
+                declared = int(content_length)
             except ValueError:
                 return _error("invalid_request", "invalid Content-Length header", 400)
+            if declared < 0:
+                return _error("invalid_request", "invalid Content-Length header", 400)
+            if declared > self.max_request_body_size:
+                return _error(
+                    "request_too_large",
+                    f"request exceeds {self.max_request_body_size} byte Action limit",
+                    413,
+                )
+
         raw = await request.body()
         if len(raw) > self.max_request_body_size:
-            return _error("request_too_large", f"request exceeds {self.max_request_body_size} byte Action limit", 413)
+            return _error(
+                "request_too_large",
+                f"request exceeds {self.max_request_body_size} byte Action limit",
+                413,
+            )
         try:
             payload = json.loads(raw.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError):
@@ -298,14 +540,20 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: Any) -> Response:
         path = request.url.path
+        if path not in _ACTION_ROUTE_ALLOWLIST:
+            return _error("not_found", "route not found", 404)
+
         if path == "/openapi.json":
             if request.method != "GET":
                 return _error("method_not_allowed", "OpenAPI discovery requires GET", 405)
-            server_url = self.public_base_url or str(request.base_url)
+            server_url = self._schema_origin(request)
+            if server_url is None:
+                return _error(
+                    "https_origin_required",
+                    "OpenAPI discovery requires a trusted public HTTPS origin",
+                    503,
+                )
             return JSONResponse(chatgpt_action_openapi_schema(server_url=server_url))
-
-        if path not in {*_ACTION_PATHS, "/actions/capabilities"}:
-            return await call_next(request)
 
         if not self._authorized(request):
             response = _error("unauthorized", "valid bearer token required", 401)
@@ -316,17 +564,19 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
             if request.method != "GET":
                 return _error("method_not_allowed", "capabilities requires GET", 405)
             service = getattr(self.adapter, "service", None)
-            return JSONResponse({
-                "service_version": getattr(service, "service_version", "unknown"),
-                "action_capabilities": ["search", "read", "lineage"],
-                "durable_writes_exposed": False,
-                "ingestion_exposed": False,
-                "mcp_exposed": False,
-                "arbitrary_graph_mutation": False,
-            })
+            return JSONResponse(
+                {
+                    "service_version": getattr(service, "service_version", "unknown"),
+                    "action_capabilities": ["search", "read", "lineage"],
+                    "durable_writes_exposed": False,
+                    "ingestion_exposed": False,
+                    "mcp_exposed": False,
+                    "arbitrary_graph_mutation": False,
+                }
+            )
 
-        tool_name = _ACTION_PATHS.get(path)
-        if tool_name is None or request.method != "POST":
+        tool_name = _ACTION_PATHS[path]
+        if request.method != "POST":
             return _error("method_not_allowed", "Action operation requires POST", 405)
 
         parsed = await self._read_json(request)
@@ -334,29 +584,54 @@ class ChatGPTActionMiddleware(BaseHTTPMiddleware):
             return parsed
 
         if tool_name == "fossil.search":
+            if not _has_only_keys(parsed, {"query", "limit"}):
+                return _error("invalid_request", "unexpected request field", 400)
             query = parsed.get("query")
-            if not isinstance(query, str) or not query.strip():
-                return _error("invalid_request", "query must be a non-empty string", 400)
+            if (
+                not isinstance(query, str)
+                or not query.strip()
+                or len(query) > _MAX_QUERY_CHARS
+            ):
+                return _error("invalid_request", "query must be a bounded non-empty string", 400)
             arguments: dict[str, Any] = {"query": query}
             if "limit" in parsed:
                 limit = parsed["limit"]
-                if isinstance(limit, bool) or not isinstance(limit, int) or limit < 1 or limit > 100:
-                    return _error("invalid_request", "limit must be an integer from 1 through 100", 400)
+                if (
+                    isinstance(limit, bool)
+                    or not isinstance(limit, int)
+                    or limit < 1
+                    or limit > 100
+                ):
+                    return _error(
+                        "invalid_request",
+                        "limit must be an integer from 1 through 100",
+                        400,
+                    )
                 arguments["limit"] = limit
         elif tool_name == "fossil.read":
-            event_id = parsed.get("event_id")
-            if not isinstance(event_id, str) or not event_id:
-                return _error("invalid_request", "event_id must be a non-empty string", 400)
+            if not _has_only_keys(parsed, {"event_id"}):
+                return _error("invalid_request", "unexpected request field", 400)
+            event_id = _safe_identifier(parsed.get("event_id"), "event_id")
+            if event_id is None:
+                return _error("invalid_request", "event_id must be an opaque identifier", 400)
             arguments = {"event_id": event_id}
         else:
-            conversation_id = parsed.get("conversation_id")
-            if not isinstance(conversation_id, str) or not conversation_id:
-                return _error("invalid_request", "conversation_id must be a non-empty string", 400)
+            if not _has_only_keys(parsed, {"conversation_id", "node_id"}):
+                return _error("invalid_request", "unexpected request field", 400)
+            conversation_id = _safe_identifier(parsed.get("conversation_id"), "conversation_id")
+            if conversation_id is None:
+                return _error(
+                    "invalid_request",
+                    "conversation_id must be an opaque identifier",
+                    400,
+                )
             arguments = {"conversation_id": conversation_id}
             if parsed.get("node_id") is not None:
-                node_id = parsed["node_id"]
-                if not isinstance(node_id, str) or not node_id:
-                    return _error("invalid_request", "node_id must be a non-empty string", 400)
+                node_id = _safe_identifier(parsed["node_id"], "node_id")
+                if node_id is None:
+                    return _error(
+                        "invalid_request", "node_id must be an opaque identifier", 400
+                    )
                 arguments["node_id"] = node_id
 
         try:
@@ -373,6 +648,7 @@ def add_chatgpt_action_api(
     bearer_token: str,
     max_request_body_size: int = 64 * 1024,
     public_base_url: str | None = None,
+    trusted_proxy_cidrs: tuple[str, ...] = (),
 ) -> Starlette:
     app.add_middleware(
         ChatGPTActionMiddleware,
@@ -380,6 +656,7 @@ def add_chatgpt_action_api(
         bearer_token=bearer_token,
         max_request_body_size=max_request_body_size,
         public_base_url=public_base_url,
+        trusted_proxy_cidrs=trusted_proxy_cidrs,
     )
     app.state.chatgpt_action_enabled = True
     return app
@@ -392,14 +669,22 @@ def create_chatgpt_action_app(
     bearer_token: str,
     max_request_body_size: int = 64 * 1024,
     public_base_url: str | None = None,
+    trusted_proxy_cidrs: tuple[str, ...] = (),
 ) -> Starlette:
-    adapter = ThinMCPAdapter(service=node.corpus_service, access=node.pack_access, context=context)
+    """Create the public-facing read-only GPT Action ASGI app."""
+
+    adapter = ThinMCPAdapter(
+        service=node.corpus_service,
+        access=node.pack_access,
+        context=context,
+    )
     return add_chatgpt_action_api(
         Starlette(),
         adapter=adapter,
         bearer_token=bearer_token,
         max_request_body_size=max_request_body_size,
         public_base_url=public_base_url,
+        trusted_proxy_cidrs=trusted_proxy_cidrs,
     )
 
 

--- a/src/fossil_core/runtime/chatgpt_action_server.py
+++ b/src/fossil_core/runtime/chatgpt_action_server.py
@@ -5,13 +5,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping
 
+from starlette.applications import Starlette
+
 from fossil_core.adapters.filesystem.event_store import DurableEventStore
 from fossil_core.adapters.mcp import ThinMCPAdapter
 from fossil_core.agent import AgentContext, CorpusService, SkillRegistry
 from fossil_core.application.ingest.pack_validation import KnowledgePackValidator
 from fossil_core.domain.pack import PackAccess
 
-from .chatgpt_action import create_chatgpt_action_app
+from .chatgpt_action import add_chatgpt_action_api
 
 
 @dataclass(frozen=True)
@@ -106,9 +108,12 @@ def build_chatgpt_action_adapter(
     return ThinMCPAdapter(service=service, access=access, context=context)
 
 
-def create_chatgpt_action_app_from_settings(settings: ChatGPTActionServerSettings):
+def create_chatgpt_action_app_from_settings(
+    settings: ChatGPTActionServerSettings,
+) -> Starlette:
     adapter = build_chatgpt_action_adapter(settings)
-    return create_chatgpt_action_app(
+    return add_chatgpt_action_api(
+        Starlette(),
         adapter=adapter,
         bearer_token=settings.bearer_token,
     )
@@ -116,7 +121,7 @@ def create_chatgpt_action_app_from_settings(settings: ChatGPTActionServerSetting
 
 def create_chatgpt_action_app_from_environment(
     environment: Mapping[str, str] | None = None,
-):
+) -> Starlette:
     return create_chatgpt_action_app_from_settings(
         ChatGPTActionServerSettings.from_environment(environment)
     )

--- a/src/fossil_core/runtime/chatgpt_action_server.py
+++ b/src/fossil_core/runtime/chatgpt_action_server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator, Mapping
@@ -18,6 +19,9 @@ from fossil_core.event_store import EventRedactedError
 from .chatgpt_action import add_chatgpt_action_api
 
 
+_EVENT_ID = re.compile(r"^evt_[A-Za-z0-9_-]{16,128}$")
+
+
 class _ReadOnlyEventStore:
     """Filesystem view that implements only the event reads used by this edge."""
 
@@ -27,11 +31,19 @@ class _ReadOnlyEventStore:
             raise FileNotFoundError(f"canonical event store does not exist: {self.root}")
         self.redactions = self.root / "_redactions"
 
+    @staticmethod
+    def _validate_event_id(event_id: str) -> str:
+        if not _EVENT_ID.fullmatch(event_id):
+            raise ValueError("event_id is not a valid FOSSIL event identifier")
+        return event_id
+
     def _event_path(self, event_id: str) -> Path:
+        event_id = self._validate_event_id(event_id)
         suffix = event_id.removeprefix("evt_")
         return self.root / suffix[:2] / f"{event_id}.json"
 
     def _redaction_path(self, event_id: str) -> Path:
+        event_id = self._validate_event_id(event_id)
         suffix = event_id.removeprefix("evt_")
         return self.redactions / suffix[:2] / f"{event_id}.json"
 

--- a/src/fossil_core/runtime/chatgpt_action_server.py
+++ b/src/fossil_core/runtime/chatgpt_action_server.py
@@ -1,19 +1,50 @@
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Mapping
+from typing import Any, Iterator, Mapping
 
 from starlette.applications import Starlette
 
-from fossil_core.adapters.filesystem.event_store import DurableEventStore
 from fossil_core.adapters.mcp import ThinMCPAdapter
 from fossil_core.agent import AgentContext, CorpusService, SkillRegistry
 from fossil_core.application.ingest.pack_validation import KnowledgePackValidator
 from fossil_core.domain.pack import PackAccess
+from fossil_core.event_store import EventRedactedError
 
 from .chatgpt_action import add_chatgpt_action_api
+
+
+class _ReadOnlyEventStore:
+    """Filesystem view that implements only the event reads used by this edge."""
+
+    def __init__(self, root: Path):
+        self.root = Path(root)
+        if not self.root.is_dir():
+            raise FileNotFoundError(f"canonical event store does not exist: {self.root}")
+        self.redactions = self.root / "_redactions"
+
+    def _event_path(self, event_id: str) -> Path:
+        suffix = event_id.removeprefix("evt_")
+        return self.root / suffix[:2] / f"{event_id}.json"
+
+    def _redaction_path(self, event_id: str) -> Path:
+        suffix = event_id.removeprefix("evt_")
+        return self.redactions / suffix[:2] / f"{event_id}.json"
+
+    def is_redacted(self, event_id: str) -> bool:
+        return self._redaction_path(event_id).exists()
+
+    def get(self, event_id: str) -> dict[str, Any]:
+        if self.is_redacted(event_id):
+            raise EventRedactedError(f"event {event_id} has been redacted")
+        return json.loads(self._event_path(event_id).read_text(encoding="utf-8"))
+
+    def iter_events(self) -> Iterator[dict[str, Any]]:
+        for path in sorted(self.root.glob("*/*.json")):
+            yield json.loads(path.read_text(encoding="utf-8"))
 
 
 @dataclass(frozen=True)
@@ -89,10 +120,7 @@ def build_chatgpt_action_adapter(
     manifest = pack_validator.load_and_validate(manifest_path)
     access = PackAccess.from_manifest(manifest)
 
-    event_store = DurableEventStore(
-        settings.data_root / "canonical" / "events",
-        _schema(repository_root, "events", "v1.schema.json"),
-    )
+    event_store = _ReadOnlyEventStore(settings.data_root / "canonical" / "events")
     skills = SkillRegistry(
         repository_root / "skills",
         _schema(repository_root, "agent-skill", "v1.schema.json"),

--- a/src/fossil_core/runtime/chatgpt_action_server.py
+++ b/src/fossil_core/runtime/chatgpt_action_server.py
@@ -5,6 +5,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator, Mapping
+from urllib.parse import urlparse
 
 from starlette.applications import Starlette
 
@@ -57,6 +58,8 @@ class ChatGPTActionServerSettings:
     bearer_token: str
     host: str = "127.0.0.1"
     port: int = 8787
+    max_request_body_size: int = 64 * 1024
+    public_base_url: str | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "repository_root", Path(self.repository_root))
@@ -70,33 +73,43 @@ class ChatGPTActionServerSettings:
             raise ValueError("FOSSIL_ACTION_HOST must be a non-empty trimmed host")
         if self.port < 1 or self.port > 65535:
             raise ValueError("FOSSIL_ACTION_PORT must be between 1 and 65535")
+        if self.max_request_body_size < 1 or self.max_request_body_size > 1024 * 1024:
+            raise ValueError("FOSSIL_ACTION_MAX_REQUEST_BYTES must be between 1 and 1048576")
+        if self.public_base_url is not None:
+            parsed = urlparse(self.public_base_url)
+            if parsed.scheme != "https" or not parsed.netloc or parsed.path not in {"", "/"}:
+                raise ValueError(
+                    "FOSSIL_ACTION_PUBLIC_BASE_URL must be an origin-only https:// URL"
+                )
+            object.__setattr__(self, "public_base_url", self.public_base_url.rstrip("/"))
 
     @classmethod
     def from_environment(
         cls, environment: Mapping[str, str] | None = None
     ) -> "ChatGPTActionServerSettings":
         env = os.environ if environment is None else environment
-        token = env.get("FOSSIL_ACTION_BEARER_TOKEN", "")
         repository_root = Path(env.get("FOSSIL_REPOSITORY_ROOT", Path.cwd()))
-        data_root = Path(env.get("FOSSIL_DATA_ROOT", repository_root / "data"))
-        pack_manifest = Path(
-            env.get(
-                "FOSSIL_PACK_MANIFEST",
-                "examples/packs/common/manifest.json",
-            )
-        )
         raw_port = env.get("FOSSIL_ACTION_PORT", "8787")
+        raw_max = env.get("FOSSIL_ACTION_MAX_REQUEST_BYTES", str(64 * 1024))
         try:
             port = int(raw_port)
         except ValueError as exc:
             raise ValueError("FOSSIL_ACTION_PORT must be an integer") from exc
+        try:
+            max_request_body_size = int(raw_max)
+        except ValueError as exc:
+            raise ValueError("FOSSIL_ACTION_MAX_REQUEST_BYTES must be an integer") from exc
         return cls(
             repository_root=repository_root,
-            data_root=data_root,
-            pack_manifest_path=pack_manifest,
-            bearer_token=token,
+            data_root=Path(env.get("FOSSIL_DATA_ROOT", repository_root / "data")),
+            pack_manifest_path=Path(
+                env.get("FOSSIL_PACK_MANIFEST", "examples/packs/common/manifest.json")
+            ),
+            bearer_token=env.get("FOSSIL_ACTION_BEARER_TOKEN", ""),
             host=env.get("FOSSIL_ACTION_HOST", "127.0.0.1"),
             port=port,
+            max_request_body_size=max_request_body_size,
+            public_base_url=env.get("FOSSIL_ACTION_PUBLIC_BASE_URL") or None,
         )
 
 
@@ -144,6 +157,8 @@ def create_chatgpt_action_app_from_settings(
         Starlette(),
         adapter=adapter,
         bearer_token=settings.bearer_token,
+        max_request_body_size=settings.max_request_body_size,
+        public_base_url=settings.public_base_url,
     )
 
 
@@ -173,6 +188,7 @@ def main() -> None:
         port=settings.port,
         access_log=False,
         server_header=False,
+        proxy_headers=False,
     )
 
 

--- a/src/fossil_core/runtime/chatgpt_action_server.py
+++ b/src/fossil_core/runtime/chatgpt_action_server.py
@@ -57,8 +57,13 @@ class _ReadOnlyEventStore:
         return json.loads(self._event_path(event_id).read_text(encoding="utf-8"))
 
     def iter_events(self) -> Iterator[dict[str, Any]]:
-        for path in sorted(self.root.glob("*/*.json")):
-            yield json.loads(path.read_text(encoding="utf-8"))
+        """Iterate canonical event objects only; redaction tombstones are metadata."""
+
+        for bucket in sorted(self.root.iterdir()):
+            if not bucket.is_dir() or bucket.name == "_redactions":
+                continue
+            for path in sorted(bucket.glob("*.json")):
+                yield json.loads(path.read_text(encoding="utf-8"))
 
 
 @dataclass(frozen=True)
@@ -159,7 +164,7 @@ def _schema(repository_root: Path, *parts: str) -> Path:
 def build_chatgpt_action_adapter(
     settings: ChatGPTActionServerSettings,
 ) -> ThinMCPAdapter:
-    """Build only the canonical read boundary; do not construct Graphiti/Neo4j."""
+    """Build canonical search/read only; do not construct Graphiti/Neo4j/lineage."""
 
     repository_root = settings.repository_root
     manifest_path = settings.pack_manifest_path

--- a/src/fossil_core/runtime/chatgpt_action_server.py
+++ b/src/fossil_core/runtime/chatgpt_action_server.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+from fossil_core.adapters.filesystem.event_store import DurableEventStore
+from fossil_core.adapters.mcp import ThinMCPAdapter
+from fossil_core.agent import AgentContext, CorpusService, SkillRegistry
+from fossil_core.application.ingest.pack_validation import KnowledgePackValidator
+from fossil_core.domain.pack import PackAccess
+
+from .chatgpt_action import create_chatgpt_action_app
+
+
+@dataclass(frozen=True)
+class ChatGPTActionServerSettings:
+    """Runtime-only configuration for the public read-only Action edge."""
+
+    repository_root: Path
+    data_root: Path
+    pack_manifest_path: Path
+    bearer_token: str
+    host: str = "127.0.0.1"
+    port: int = 8787
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "repository_root", Path(self.repository_root))
+        object.__setattr__(self, "data_root", Path(self.data_root))
+        object.__setattr__(self, "pack_manifest_path", Path(self.pack_manifest_path))
+        if not self.bearer_token or self.bearer_token != self.bearer_token.strip():
+            raise ValueError("FOSSIL_ACTION_BEARER_TOKEN must be a non-empty trimmed secret")
+        if len(self.bearer_token) < 32:
+            raise ValueError("FOSSIL_ACTION_BEARER_TOKEN must contain at least 32 characters")
+        if not self.host or self.host != self.host.strip():
+            raise ValueError("FOSSIL_ACTION_HOST must be a non-empty trimmed host")
+        if self.port < 1 or self.port > 65535:
+            raise ValueError("FOSSIL_ACTION_PORT must be between 1 and 65535")
+
+    @classmethod
+    def from_environment(
+        cls, environment: Mapping[str, str] | None = None
+    ) -> "ChatGPTActionServerSettings":
+        env = os.environ if environment is None else environment
+        token = env.get("FOSSIL_ACTION_BEARER_TOKEN", "")
+        repository_root = Path(env.get("FOSSIL_REPOSITORY_ROOT", Path.cwd()))
+        data_root = Path(env.get("FOSSIL_DATA_ROOT", repository_root / "data"))
+        pack_manifest = Path(
+            env.get(
+                "FOSSIL_PACK_MANIFEST",
+                "examples/packs/common/manifest.json",
+            )
+        )
+        raw_port = env.get("FOSSIL_ACTION_PORT", "8787")
+        try:
+            port = int(raw_port)
+        except ValueError as exc:
+            raise ValueError("FOSSIL_ACTION_PORT must be an integer") from exc
+        return cls(
+            repository_root=repository_root,
+            data_root=data_root,
+            pack_manifest_path=pack_manifest,
+            bearer_token=token,
+            host=env.get("FOSSIL_ACTION_HOST", "127.0.0.1"),
+            port=port,
+        )
+
+
+def _schema(repository_root: Path, *parts: str) -> Path:
+    return repository_root / "schemas" / Path(*parts)
+
+
+def build_chatgpt_action_adapter(
+    settings: ChatGPTActionServerSettings,
+) -> ThinMCPAdapter:
+    """Build only the canonical read boundary; do not construct Graphiti/Neo4j."""
+
+    repository_root = settings.repository_root
+    manifest_path = settings.pack_manifest_path
+    if not manifest_path.is_absolute():
+        manifest_path = repository_root / manifest_path
+
+    pack_validator = KnowledgePackValidator(
+        _schema(repository_root, "knowledge-pack", "v1.schema.json")
+    )
+    manifest = pack_validator.load_and_validate(manifest_path)
+    access = PackAccess.from_manifest(manifest)
+
+    event_store = DurableEventStore(
+        settings.data_root / "canonical" / "events",
+        _schema(repository_root, "events", "v1.schema.json"),
+    )
+    skills = SkillRegistry(
+        repository_root / "skills",
+        _schema(repository_root, "agent-skill", "v1.schema.json"),
+    )
+    service = CorpusService(event_store=event_store, skills=skills)
+    context = AgentContext(
+        actor_id="chatgpt-action-readonly",
+        model_id="chatgpt",
+        harness_version="custom-gpt-action-v1",
+        skill_id="skill_corpus-search",
+        skill_version="1.0.0",
+    )
+    return ThinMCPAdapter(service=service, access=access, context=context)
+
+
+def create_chatgpt_action_app_from_settings(settings: ChatGPTActionServerSettings):
+    adapter = build_chatgpt_action_adapter(settings)
+    return create_chatgpt_action_app(
+        adapter=adapter,
+        bearer_token=settings.bearer_token,
+    )
+
+
+def create_chatgpt_action_app_from_environment(
+    environment: Mapping[str, str] | None = None,
+):
+    return create_chatgpt_action_app_from_settings(
+        ChatGPTActionServerSettings.from_environment(environment)
+    )
+
+
+def main() -> None:
+    """Run the Action edge; TLS is intentionally terminated upstream."""
+
+    try:
+        import uvicorn
+    except ImportError as exc:  # pragma: no cover - packaging guard
+        raise RuntimeError(
+            "uvicorn is required; install fossil-core with the 'node' extra"
+        ) from exc
+
+    settings = ChatGPTActionServerSettings.from_environment()
+    app = create_chatgpt_action_app_from_settings(settings)
+    uvicorn.run(
+        app,
+        host=settings.host,
+        port=settings.port,
+        access_log=False,
+        server_header=False,
+    )
+
+
+__all__ = [
+    "ChatGPTActionServerSettings",
+    "build_chatgpt_action_adapter",
+    "create_chatgpt_action_app_from_environment",
+    "create_chatgpt_action_app_from_settings",
+    "main",
+]

--- a/src/fossil_core/runtime/chatgpt_action_server.py
+++ b/src/fossil_core/runtime/chatgpt_action_server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 import re
@@ -72,6 +73,7 @@ class ChatGPTActionServerSettings:
     port: int = 8787
     max_request_body_size: int = 64 * 1024
     public_base_url: str | None = None
+    trusted_proxy_cidrs: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "repository_root", Path(self.repository_root))
@@ -86,14 +88,34 @@ class ChatGPTActionServerSettings:
         if self.port < 1 or self.port > 65535:
             raise ValueError("FOSSIL_ACTION_PORT must be between 1 and 65535")
         if self.max_request_body_size < 1 or self.max_request_body_size > 1024 * 1024:
-            raise ValueError("FOSSIL_ACTION_MAX_REQUEST_BYTES must be between 1 and 1048576")
+            raise ValueError(
+                "FOSSIL_ACTION_MAX_REQUEST_BYTES must be between 1 and 1048576"
+            )
         if self.public_base_url is not None:
             parsed = urlparse(self.public_base_url)
-            if parsed.scheme != "https" or not parsed.netloc or parsed.path not in {"", "/"}:
+            if (
+                parsed.scheme != "https"
+                or not parsed.netloc
+                or parsed.path not in {"", "/"}
+                or parsed.params
+                or parsed.query
+                or parsed.fragment
+                or parsed.username is not None
+                or parsed.password is not None
+            ):
                 raise ValueError(
                     "FOSSIL_ACTION_PUBLIC_BASE_URL must be an origin-only https:// URL"
                 )
-            object.__setattr__(self, "public_base_url", self.public_base_url.rstrip("/"))
+            object.__setattr__(
+                self, "public_base_url", self.public_base_url.rstrip("/")
+            )
+        for cidr in self.trusted_proxy_cidrs:
+            try:
+                ipaddress.ip_network(cidr, strict=False)
+            except ValueError as exc:
+                raise ValueError(
+                    f"invalid FOSSIL_ACTION_TRUSTED_PROXY_CIDRS entry: {cidr!r}"
+                ) from exc
 
     @classmethod
     def from_environment(
@@ -103,6 +125,7 @@ class ChatGPTActionServerSettings:
         repository_root = Path(env.get("FOSSIL_REPOSITORY_ROOT", Path.cwd()))
         raw_port = env.get("FOSSIL_ACTION_PORT", "8787")
         raw_max = env.get("FOSSIL_ACTION_MAX_REQUEST_BYTES", str(64 * 1024))
+        raw_proxy_cidrs = env.get("FOSSIL_ACTION_TRUSTED_PROXY_CIDRS", "")
         try:
             port = int(raw_port)
         except ValueError as exc:
@@ -111,6 +134,9 @@ class ChatGPTActionServerSettings:
             max_request_body_size = int(raw_max)
         except ValueError as exc:
             raise ValueError("FOSSIL_ACTION_MAX_REQUEST_BYTES must be an integer") from exc
+        proxy_cidrs = tuple(
+            item.strip() for item in raw_proxy_cidrs.split(",") if item.strip()
+        )
         return cls(
             repository_root=repository_root,
             data_root=Path(env.get("FOSSIL_DATA_ROOT", repository_root / "data")),
@@ -122,6 +148,7 @@ class ChatGPTActionServerSettings:
             port=port,
             max_request_body_size=max_request_body_size,
             public_base_url=env.get("FOSSIL_ACTION_PUBLIC_BASE_URL") or None,
+            trusted_proxy_cidrs=proxy_cidrs,
         )
 
 
@@ -171,6 +198,7 @@ def create_chatgpt_action_app_from_settings(
         bearer_token=settings.bearer_token,
         max_request_body_size=settings.max_request_body_size,
         public_base_url=settings.public_base_url,
+        trusted_proxy_cidrs=settings.trusted_proxy_cidrs,
     )
 
 
@@ -183,7 +211,7 @@ def create_chatgpt_action_app_from_environment(
 
 
 def main() -> None:
-    """Run the Action edge; TLS is intentionally terminated upstream."""
+    """Run the Action edge; TLS and proxy routing are intentionally external."""
 
     try:
         import uvicorn
@@ -200,6 +228,8 @@ def main() -> None:
         port=settings.port,
         access_log=False,
         server_header=False,
+        # Forwarded headers are interpreted only by ChatGPTActionMiddleware after
+        # explicit source-CIDR validation. Do not let Uvicorn trust them globally.
         proxy_headers=False,
     )
 

--- a/src/fossil_core/runtime/chatgpt_action_server.py
+++ b/src/fossil_core/runtime/chatgpt_action_server.py
@@ -57,13 +57,17 @@ class _ReadOnlyEventStore:
         return json.loads(self._event_path(event_id).read_text(encoding="utf-8"))
 
     def iter_events(self) -> Iterator[dict[str, Any]]:
-        """Iterate canonical event objects only; redaction tombstones are metadata."""
+        """Iterate unredacted canonical events only; tombstones are metadata."""
 
         for bucket in sorted(self.root.iterdir()):
             if not bucket.is_dir() or bucket.name == "_redactions":
                 continue
             for path in sorted(bucket.glob("*.json")):
-                yield json.loads(path.read_text(encoding="utf-8"))
+                event = json.loads(path.read_text(encoding="utf-8"))
+                event_id = event.get("event_id")
+                if isinstance(event_id, str) and self.is_redacted(event_id):
+                    continue
+                yield event
 
 
 @dataclass(frozen=True)

--- a/tests/holdout/test_chatgpt_action_holdout.py
+++ b/tests/holdout/test_chatgpt_action_holdout.py
@@ -288,6 +288,27 @@ def test_holdout_oversized_and_malformed_payloads_fail_before_service(tmp_path: 
     assert non_object.status_code == 400
 
 
+def test_holdout_search_limit_type_and_boundary_are_strict(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
+    with TestClient(app, base_url="http://internal:8787") as client:
+        for invalid_limit in (True, False, "10", 0, -1, 101, 1000, 1.5):
+            response = client.post(
+                "/actions/search",
+                headers=auth(),
+                json={"query": "x", "limit": invalid_limit},
+            )
+            assert response.status_code == 400, repr(invalid_limit)
+
+        for valid_limit in (1, 100):
+            response = client.post(
+                "/actions/search",
+                headers=auth(),
+                json={"query": "x", "limit": valid_limit},
+            )
+            assert response.status_code == 200, valid_limit
+            assert response.json() == []
+
+
 def test_holdout_unknown_and_mutation_like_paths_are_not_routable(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
     prohibited = [

--- a/tests/holdout/test_chatgpt_action_holdout.py
+++ b/tests/holdout/test_chatgpt_action_holdout.py
@@ -23,7 +23,13 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def make_settings(tmp_path: Path, *, max_bytes: int = 65536) -> ChatGPTActionServerSettings:
+def make_settings(
+    tmp_path: Path,
+    *,
+    max_bytes: int = 65536,
+    public_base_url: str | None = PUBLIC_ORIGIN,
+    trusted_proxy_cidrs: tuple[str, ...] = (),
+) -> ChatGPTActionServerSettings:
     data_root = tmp_path / "fossil-data"
     events = data_root / "canonical" / "events"
     events.mkdir(parents=True, exist_ok=True)
@@ -33,7 +39,8 @@ def make_settings(tmp_path: Path, *, max_bytes: int = 65536) -> ChatGPTActionSer
         pack_manifest_path=Path("examples/packs/common/manifest.json"),
         bearer_token=TOKEN,
         max_request_body_size=max_bytes,
-        public_base_url=PUBLIC_ORIGIN,
+        public_base_url=public_base_url,
+        trusted_proxy_cidrs=trusted_proxy_cidrs,
     )
 
 
@@ -76,7 +83,7 @@ def test_holdout_duplicate_authorization_header_fails_closed(tmp_path: Path) -> 
     assert response.status_code == 401
 
 
-def test_holdout_forged_forwarded_headers_cannot_rewrite_schema(tmp_path: Path) -> None:
+def test_holdout_forged_forwarded_headers_cannot_rewrite_fixed_schema_origin(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
     forged = {
         "forwarded": "proto=http;host=attacker.invalid",
@@ -88,6 +95,52 @@ def test_holdout_forged_forwarded_headers_cannot_rewrite_schema(tmp_path: Path) 
     with TestClient(app, base_url="http://internal.invalid:8787") as client:
         schema = client.get("/openapi.json", headers=forged).json()
     assert schema["servers"] == [{"url": PUBLIC_ORIGIN}]
+
+
+def test_holdout_untrusted_forwarded_headers_fail_closed_without_fixed_origin(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(
+        make_settings(tmp_path, public_base_url=None, trusted_proxy_cidrs=("10.0.0.0/8",))
+    )
+    with TestClient(
+        app,
+        base_url="http://internal.invalid:8787",
+        client=("127.0.0.1", 50000),
+    ) as client:
+        response = client.get(
+            "/openapi.json",
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "attacker.invalid",
+            },
+        )
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "https_origin_required"
+
+
+def test_holdout_trusted_proxy_can_represent_https_origin(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(
+        make_settings(
+            tmp_path,
+            public_base_url=None,
+            trusted_proxy_cidrs=("127.0.0.1/32",),
+        )
+    )
+    with TestClient(
+        app,
+        base_url="http://internal.invalid:8787",
+        client=("127.0.0.1", 50000),
+    ) as client:
+        response = client.get(
+            "/openapi.json",
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "fossil-proxy.example.invalid",
+            },
+        )
+    assert response.status_code == 200
+    assert response.json()["servers"] == [
+        {"url": "https://fossil-proxy.example.invalid"}
+    ]
 
 
 def test_holdout_openapi_is_valid_and_custom_gpt_bounded(tmp_path: Path) -> None:
@@ -102,7 +155,11 @@ def test_holdout_openapi_is_valid_and_custom_gpt_bounded(tmp_path: Path) -> None
     assert set(schema["components"]["schemas"]) >= {
         "ErrorDetail",
         "ErrorEnvelope",
-        "FossilRecord",
+        "SearchRequest",
+        "ReadRequest",
+        "LineageRequest",
+        "SearchResult",
+        "FossilEvent",
         "LineageResponse",
         "CapabilitiesResponse",
     }
@@ -120,8 +177,10 @@ def test_holdout_openapi_is_valid_and_custom_gpt_bounded(tmp_path: Path) -> None
     assert len(operation_ids) == len(set(operation_ids)) == 4
     assert schema["components"]["securitySchemes"]["BearerAuth"]["scheme"] == "bearer"
 
-    props = schema["components"]["schemas"]["FossilRecord"]["properties"]
-    assert {"event_id", "pack_id", "event_type", "recorded_at", "payload"} <= set(props)
+    search_props = schema["components"]["schemas"]["SearchResult"]["properties"]
+    assert {"event_id", "pack_id", "event_type", "recorded_at"} <= set(search_props)
+    event_props = schema["components"]["schemas"]["FossilEvent"]["properties"]
+    assert {"event_id", "pack_id", "event_type", "recorded_at", "payload"} <= set(event_props)
     capability_props = schema["components"]["schemas"]["CapabilitiesResponse"]["properties"]
     assert capability_props["durable_writes_exposed"]["const"] is False
     assert capability_props["mcp_exposed"]["const"] is False
@@ -135,7 +194,6 @@ def test_holdout_openapi_is_valid_and_custom_gpt_bounded(tmp_path: Path) -> None
         '"/actions/commit"',
         '"/actions/redact"',
         "neo4j",
-        "graph mutation endpoint",
         TOKEN.lower(),
     ):
         assert forbidden not in serialized
@@ -237,6 +295,21 @@ def test_holdout_validation_rejects_ambiguous_limits_and_non_object_json(tmp_pat
             content=b'["x"]',
         )
     assert non_object.status_code == 400
+
+
+def test_holdout_unexpected_fields_do_not_create_hidden_capabilities(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
+    payloads = [
+        {"query": "x", "path": "/etc/passwd"},
+        {"query": "x", "cypher": "MATCH (n) DETACH DELETE n"},
+        {"event_id": "evt_abcdefghijklmnop", "commit": True},
+        {"conversation_id": "conv_abcdefghijklmnop", "mcp": {"tool": "fossil.commit"}},
+    ]
+    with TestClient(app) as client:
+        assert client.post("/actions/search", headers=auth(), json=payloads[0]).status_code == 400
+        assert client.post("/actions/search", headers=auth(), json=payloads[1]).status_code == 400
+        assert client.post("/actions/read", headers=auth(), json=payloads[2]).status_code == 400
+        assert client.post("/actions/lineage", headers=auth(), json=payloads[3]).status_code == 400
 
 
 def test_holdout_secret_never_appears_in_public_or_error_responses(tmp_path: Path) -> None:

--- a/tests/holdout/test_chatgpt_action_holdout.py
+++ b/tests/holdout/test_chatgpt_action_holdout.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from openapi_spec_validator import validate_spec
+from starlette.testclient import TestClient
+
+from fossil_core.runtime.chatgpt_action_server import (
+    ChatGPTActionServerSettings,
+    build_chatgpt_action_adapter,
+    create_chatgpt_action_app_from_settings,
+)
+
+
+TOKEN = "holdout-token-0123456789abcdef-0123456789"
+PUBLIC_ORIGIN = "https://fossil-action.holdout.invalid"
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def make_settings(tmp_path: Path, *, max_bytes: int = 65536) -> ChatGPTActionServerSettings:
+    data_root = tmp_path / "fossil-data"
+    events = data_root / "canonical" / "events"
+    events.mkdir(parents=True, exist_ok=True)
+    return ChatGPTActionServerSettings(
+        repository_root=repo_root(),
+        data_root=data_root,
+        pack_manifest_path=Path("examples/packs/common/manifest.json"),
+        bearer_token=TOKEN,
+        max_request_body_size=max_bytes,
+        public_base_url=PUBLIC_ORIGIN,
+    )
+
+
+def auth() -> dict[str, str]:
+    return {"authorization": f"Bearer {TOKEN}"}
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {},
+        {"authorization": ""},
+        {"authorization": "Basic abc"},
+        {"authorization": "Bearer"},
+        {"authorization": "Bearer wrong"},
+        {"authorization": f"Bearer {TOKEN} "},
+        {"authorization": f"Bearer {TOKEN.upper()}"},
+    ],
+)
+def test_holdout_malformed_auth_fails_closed(tmp_path: Path, headers: dict[str, str]) -> None:
+    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
+    with TestClient(app) as client:
+        response = client.post("/actions/search", headers=headers, json={"query": "x"})
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+
+
+def test_holdout_duplicate_authorization_header_fails_closed(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
+    with TestClient(app) as client:
+        response = client.post(
+            "/actions/search",
+            headers=[
+                ("authorization", f"Bearer {TOKEN}"),
+                ("authorization", "Bearer attacker"),
+                ("content-type", "application/json"),
+            ],
+            content=b'{"query":"x"}',
+        )
+    assert response.status_code == 401
+
+
+def test_holdout_forged_forwarded_headers_cannot_rewrite_schema(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
+    forged = {
+        "forwarded": "proto=http;host=attacker.invalid",
+        "x-forwarded-proto": "http",
+        "x-forwarded-host": "attacker.invalid",
+        "x-forwarded-port": "80",
+        "host": "internal.invalid:8787",
+    }
+    with TestClient(app, base_url="http://internal.invalid:8787") as client:
+        schema = client.get("/openapi.json", headers=forged).json()
+    assert schema["servers"] == [{"url": PUBLIC_ORIGIN}]
+
+
+def test_holdout_openapi_is_valid_and_custom_gpt_bounded(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
+    with TestClient(app) as client:
+        response = client.get("/openapi.json")
+    assert response.status_code == 200
+    schema = response.json()
+    validate_spec(schema)
+    assert schema["openapi"].startswith("3.1.")
+    assert isinstance(schema["components"]["schemas"], dict)
+    assert set(schema["components"]["schemas"]) >= {
+        "ErrorDetail",
+        "ErrorEnvelope",
+        "FossilRecord",
+        "LineageResponse",
+        "CapabilitiesResponse",
+    }
+    assert set(schema["paths"]) == {
+        "/actions/search",
+        "/actions/read",
+        "/actions/lineage",
+        "/actions/capabilities",
+    }
+    operation_ids = [
+        operation["operationId"]
+        for path in schema["paths"].values()
+        for operation in path.values()
+    ]
+    assert len(operation_ids) == len(set(operation_ids)) == 4
+    assert schema["components"]["securitySchemes"]["BearerAuth"]["scheme"] == "bearer"
+
+    props = schema["components"]["schemas"]["FossilRecord"]["properties"]
+    assert {"event_id", "pack_id", "event_type", "recorded_at", "payload"} <= set(props)
+    capability_props = schema["components"]["schemas"]["CapabilitiesResponse"]["properties"]
+    assert capability_props["durable_writes_exposed"]["const"] is False
+    assert capability_props["mcp_exposed"]["const"] is False
+
+    serialized = json.dumps(schema).lower()
+    for forbidden in (
+        '"/mcp"',
+        '"/ingest"',
+        '"/actions/propose"',
+        '"/actions/validate"',
+        '"/actions/commit"',
+        '"/actions/redact"',
+        "neo4j",
+        "graph mutation endpoint",
+        TOKEN.lower(),
+    ):
+        assert forbidden not in serialized
+
+
+def test_holdout_oversized_payloads_fail_before_service(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path, max_bytes=64))
+    with TestClient(app) as client:
+        actual = client.post(
+            "/actions/search",
+            headers=auth(),
+            content=json.dumps({"query": "x" * 100}).encode(),
+        )
+        declared = client.post(
+            "/actions/search",
+            headers={**auth(), "content-type": "application/json", "content-length": "9999"},
+            content=b'{"query":"x"}',
+        )
+    assert actual.status_code == 413
+    assert declared.status_code == 413
+
+
+def test_holdout_unknown_and_prohibited_paths_are_not_routable(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
+    prohibited = [
+        "/mcp",
+        "/ingest",
+        "/actions/propose",
+        "/actions/validate",
+        "/actions/commit",
+        "/actions/redact",
+        "/neo4j",
+        "/graph",
+        "/filesystem",
+        "/admin",
+        "/unknown",
+    ]
+    with TestClient(app) as client:
+        for path in prohibited:
+            assert client.get(path, headers=auth()).status_code == 404, path
+            assert client.post(path, headers=auth(), json={}).status_code == 404, path
+
+
+def test_holdout_unsupported_methods_return_405(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
+    with TestClient(app) as client:
+        assert client.post("/openapi.json").status_code == 405
+        assert client.get("/actions/search", headers=auth()).status_code == 405
+        assert client.get("/actions/read", headers=auth()).status_code == 405
+        assert client.get("/actions/lineage", headers=auth()).status_code == 405
+        assert client.post("/actions/capabilities", headers=auth(), json={}).status_code == 405
+
+
+def test_holdout_path_traversal_event_ids_are_rejected(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
+    malicious = [
+        "../../../../etc/passwd",
+        "evt_../../../../etc/passwd",
+        "evt_................",
+        "evt_abcdefghijklmnop/../../secret",
+        "C:\\Windows\\System32\\drivers\\etc\\hosts",
+    ]
+    with TestClient(app) as client:
+        for event_id in malicious:
+            response = client.post(
+                "/actions/read", headers=auth(), json={"event_id": event_id}
+            )
+            assert response.status_code == 400, event_id
+
+
+def test_holdout_read_only_store_has_no_mutation_surface_and_boots_without_write(tmp_path: Path) -> None:
+    configured = make_settings(tmp_path)
+    events = configured.data_root / "canonical" / "events"
+    os.chmod(events, 0o555)
+    try:
+        adapter = build_chatgpt_action_adapter(configured)
+        for forbidden in ("commit", "prepare", "validate", "redact", "put", "delete"):
+            assert not hasattr(adapter.service.event_store, forbidden)
+        app = create_chatgpt_action_app_from_settings(configured)
+        with TestClient(app) as client:
+            response = client.post("/actions/search", headers=auth(), json={"query": "empty"})
+        assert response.status_code == 200
+        assert response.json() == []
+    finally:
+        os.chmod(events, 0o755)
+
+
+def test_holdout_validation_rejects_ambiguous_limits_and_non_object_json(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
+    with TestClient(app) as client:
+        for limit in (True, False, 0, -1, 101, "5", 1.5):
+            response = client.post(
+                "/actions/search", headers=auth(), json={"query": "x", "limit": limit}
+            )
+            assert response.status_code == 400, repr(limit)
+        non_object = client.post(
+            "/actions/search",
+            headers={**auth(), "content-type": "application/json"},
+            content=b'["x"]',
+        )
+    assert non_object.status_code == 400
+
+
+def test_holdout_secret_never_appears_in_public_or_error_responses(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
+    with TestClient(app) as client:
+        responses = [
+            client.get("/openapi.json"),
+            client.get("/actions/capabilities", headers=auth()),
+            client.post("/actions/search", json={"query": "x"}),
+            client.post("/actions/search", headers=auth(), content=b"not-json"),
+        ]
+    for response in responses:
+        assert TOKEN not in response.text

--- a/tests/holdout/test_chatgpt_action_holdout.py
+++ b/tests/holdout/test_chatgpt_action_holdout.py
@@ -15,10 +15,10 @@ from fossil_core.runtime.chatgpt_action_server import (
 
 TOKEN = "holdout-token-0123456789abcdef-0123456789"
 PUBLIC_ORIGIN = "https://fossil-action.holdout.invalid"
+COMMON = "pack_269099f7b2ba43b7a99b9427d64092de"
 ACTION_PATHS = {
     "/actions/search",
     "/actions/read",
-    "/actions/lineage",
     "/actions/capabilities",
 }
 
@@ -49,6 +49,58 @@ def make_settings(
 
 def auth() -> dict[str, str]:
     return {"authorization": f"Bearer {TOKEN}"}
+
+
+def put_event(data_root: Path, event_id: str, marker: str) -> None:
+    suffix = event_id.removeprefix("evt_")
+    path = data_root / "canonical" / "events" / suffix[:2] / f"{event_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "dkg.event.v1",
+                "event_id": event_id,
+                "event_type": "claim.proposed",
+                "occurred_at": "2026-08-20T12:00:00Z",
+                "recorded_at": "2026-08-20T12:00:00Z",
+                "pack_id": COMMON,
+                "actor": {"actor_type": "human", "actor_id": "holdout"},
+                "subject_refs": ["clm_holdout"],
+                "caused_by_event_ids": [],
+                "correlation_id": None,
+                "idempotency_key": f"holdout-{event_id}",
+                "evidence_refs": [],
+                "source_snapshot_refs": [],
+                "payload": {"claim_text": marker},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def put_redaction(data_root: Path, event_id: str, marker: str) -> None:
+    suffix = event_id.removeprefix("evt_")
+    path = (
+        data_root
+        / "canonical"
+        / "events"
+        / "_redactions"
+        / suffix[:2]
+        / f"{event_id}.json"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "event_id": event_id,
+                "pack_id": COMMON,
+                "reason": marker,
+                "authority": "holdout",
+                "redacted_at": "2026-08-20T12:30:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
 
 
 @pytest.mark.parametrize(
@@ -106,23 +158,42 @@ def test_holdout_scheme_case_is_allowed_but_token_case_is_exact(tmp_path: Path) 
     assert denied.status_code == 401
 
 
-def test_holdout_fixed_origin_resists_forged_forwarded_headers(tmp_path: Path) -> None:
+def test_holdout_fixed_origin_resists_forged_forwarded_and_host_headers(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
     forged = {
         "forwarded": "proto=http;host=attacker.invalid",
         "x-forwarded-proto": "https",
         "x-forwarded-host": "attacker.invalid",
         "x-forwarded-port": "443",
-        "host": "internal.invalid:8787",
+        "host": "attacker.invalid",
     }
     with TestClient(
         app,
-        base_url="http://internal.invalid:8787",
+        base_url="https://attacker.invalid",
         client=("203.0.113.80", 55000),
     ) as client:
         response = client.get("/openapi.json", headers=forged)
     assert response.status_code == 200
     assert response.json()["servers"] == [{"url": PUBLIC_ORIGIN}]
+
+
+def test_holdout_direct_https_host_fails_closed_without_origin_authority(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(
+        make_settings(tmp_path, public_base_url=None)
+    )
+    with TestClient(
+        app,
+        base_url="https://attacker.invalid",
+        client=("203.0.113.80", 55000),
+    ) as client:
+        response = client.get(
+            "/openapi.json",
+            headers={"host": "forged-public-host.invalid"},
+        )
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "https_origin_required"
+    assert "forged-public-host.invalid" not in response.text
+    assert "attacker.invalid" not in response.text
 
 
 def test_holdout_untrusted_forwarded_headers_fail_closed_without_fixed_origin(
@@ -198,7 +269,7 @@ def test_holdout_trusted_proxy_requires_unambiguous_https_headers(tmp_path: Path
             assert '"url":"http://' not in response.text.replace(" ", "")
 
 
-def test_holdout_openapi_is_valid_and_custom_gpt_bounded(tmp_path: Path) -> None:
+def test_holdout_openapi_is_valid_custom_gpt_bounded_and_truthful(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
     with TestClient(app, base_url="http://internal:8787") as client:
         response = client.get("/openapi.json")
@@ -215,20 +286,16 @@ def test_holdout_openapi_is_valid_and_custom_gpt_bounded(tmp_path: Path) -> None
         "ErrorEnvelope",
         "SearchRequest",
         "ReadRequest",
-        "LineageRequest",
         "SearchResult",
         "FossilEvent",
-        "LineageNode",
-        "Citation",
-        "LineageResponse",
         "CapabilitiesResponse",
     }
+    assert not set(schema["components"]["schemas"]).intersection(
+        {"LineageRequest", "LineageResponse", "LineageNode", "Citation"}
+    )
     for name in (
         "SearchResult",
         "FossilEvent",
-        "LineageNode",
-        "Citation",
-        "LineageResponse",
         "CapabilitiesResponse",
     ):
         assert schema["components"]["schemas"][name].get("properties")
@@ -238,11 +305,11 @@ def test_holdout_openapi_is_valid_and_custom_gpt_bounded(tmp_path: Path) -> None
         for path in schema["paths"].values()
         for operation in path.values()
     ]
-    assert len(operation_ids) == len(set(operation_ids)) == 4
+    assert len(operation_ids) == len(set(operation_ids)) == 3
     assert schema["components"]["securitySchemes"]["BearerAuth"]["scheme"] == "bearer"
     assert schema["components"]["schemas"]["CapabilitiesResponse"]["properties"][
-        "durable_writes_exposed"
-    ]["const"] is False
+        "action_capabilities"
+    ]["const"] == ["search", "read"]
 
     serialized = json.dumps(schema).lower()
     assert '"url": "http://' not in serialized
@@ -250,6 +317,7 @@ def test_holdout_openapi_is_valid_and_custom_gpt_bounded(tmp_path: Path) -> None
     for forbidden in (
         '"/mcp"',
         '"/ingest"',
+        '"/actions/lineage"',
         '"/actions/propose"',
         '"/actions/validate"',
         '"/actions/commit"',
@@ -259,8 +327,15 @@ def test_holdout_openapi_is_valid_and_custom_gpt_bounded(tmp_path: Path) -> None
         assert forbidden not in serialized
 
 
-def test_holdout_oversized_and_malformed_payloads_fail_before_service(tmp_path: Path) -> None:
+def test_holdout_oversized_malformed_and_streamed_payloads_fail_closed(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path, max_bytes=64))
+
+    def large_chunks():
+        yield b'{"query":"'
+        yield b"x" * 40
+        yield b"y" * 40
+        yield b'"}'
+
     with TestClient(app, base_url="http://internal:8787") as client:
         actual = client.post(
             "/actions/search",
@@ -276,6 +351,24 @@ def test_holdout_oversized_and_malformed_payloads_fail_before_service(tmp_path: 
             },
             content=b'{"query":"x"}',
         )
+        chunked = client.post(
+            "/actions/search",
+            headers={
+                **auth(),
+                "content-type": "application/json",
+                "transfer-encoding": "chunked",
+            },
+            content=large_chunks(),
+        )
+        understated = client.post(
+            "/actions/search",
+            headers={
+                **auth(),
+                "content-type": "application/json",
+                "content-length": "10",
+            },
+            content=large_chunks(),
+        )
         malformed = client.post(
             "/actions/search", headers=auth(), content=b"{not-json"
         )
@@ -284,36 +377,18 @@ def test_holdout_oversized_and_malformed_payloads_fail_before_service(tmp_path: 
         )
     assert actual.status_code == 413
     assert declared.status_code == 413
+    assert chunked.status_code == 413
+    assert understated.status_code == 413
     assert malformed.status_code == 400
     assert non_object.status_code == 400
 
 
-def test_holdout_search_limit_type_and_boundary_are_strict(tmp_path: Path) -> None:
-    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
-    with TestClient(app, base_url="http://internal:8787") as client:
-        for invalid_limit in (True, False, "10", 0, -1, 101, 1000, 1.5):
-            response = client.post(
-                "/actions/search",
-                headers=auth(),
-                json={"query": "x", "limit": invalid_limit},
-            )
-            assert response.status_code == 400, repr(invalid_limit)
-
-        for valid_limit in (1, 100):
-            response = client.post(
-                "/actions/search",
-                headers=auth(),
-                json={"query": "x", "limit": valid_limit},
-            )
-            assert response.status_code == 200, valid_limit
-            assert response.json() == []
-
-
-def test_holdout_unknown_and_mutation_like_paths_are_not_routable(tmp_path: Path) -> None:
+def test_holdout_unknown_lineage_and_mutation_like_paths_are_not_routable(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
     prohibited = [
         "/mcp",
         "/ingest",
+        "/actions/lineage",
         "/actions/propose",
         "/actions/validate",
         "/actions/commit",
@@ -337,11 +412,10 @@ def test_holdout_unsupported_methods_return_405(tmp_path: Path) -> None:
         assert client.post("/openapi.json").status_code == 405
         assert client.get("/actions/search", headers=auth()).status_code == 405
         assert client.get("/actions/read", headers=auth()).status_code == 405
-        assert client.get("/actions/lineage", headers=auth()).status_code == 405
         assert client.post("/actions/capabilities", headers=auth()).status_code == 405
 
 
-def test_holdout_path_and_capability_smuggling_are_rejected(tmp_path: Path) -> None:
+def test_holdout_path_capability_and_search_limit_smuggling_are_rejected(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
     with TestClient(app, base_url="http://internal:8787") as client:
         for event_id in (
@@ -366,11 +440,53 @@ def test_holdout_path_and_capability_smuggling_are_rejected(tmp_path: Path) -> N
             headers=auth(),
             json={"event_id": "evt_abcdefghijklmnop", "commit": True},
         ).status_code == 400
+
         assert client.post(
-            "/actions/lineage",
-            headers=auth(),
-            json={"conversation_id": "conv_abcdefghijklmnop", "mcp": True},
+            "/actions/search", headers=auth(), json={"query": "x", "limit": 100}
+        ).status_code == 200
+        assert client.post(
+            "/actions/search", headers=auth(), json={"query": "x", "limit": 101}
         ).status_code == 400
+        assert client.post(
+            "/actions/search", headers=auth(), json={"query": "x", "limit": True}
+        ).status_code == 400
+
+
+def test_holdout_redaction_tombstone_and_redacted_bytes_never_search_or_read(tmp_path: Path) -> None:
+    configured = make_settings(tmp_path)
+    redacted_id = "evt_cccccccccccccccc"
+    visible_id = "evt_dddddddddddddddd"
+    put_event(configured.data_root, redacted_id, "private-redacted-payload-marker")
+    put_event(configured.data_root, visible_id, "public-visible-marker")
+    put_redaction(configured.data_root, redacted_id, "tombstone-redaction-marker")
+
+    app = create_chatgpt_action_app_from_settings(configured)
+    with TestClient(app, base_url="http://internal:8787") as client:
+        by_payload = client.post(
+            "/actions/search",
+            headers=auth(),
+            json={"query": "private-redacted-payload-marker"},
+        )
+        by_tombstone = client.post(
+            "/actions/search",
+            headers=auth(),
+            json={"query": "tombstone-redaction-marker"},
+        )
+        visible = client.post(
+            "/actions/search",
+            headers=auth(),
+            json={"query": "public-visible-marker"},
+        )
+        read = client.post(
+            "/actions/read", headers=auth(), json={"event_id": redacted_id}
+        )
+
+    assert by_payload.status_code == 200 and by_payload.json() == []
+    assert by_tombstone.status_code == 200 and by_tombstone.json() == []
+    assert [row["event_id"] for row in visible.json()] == [visible_id]
+    assert read.status_code == 404
+    assert "redact" not in read.text.lower()
+    assert "tombstone-redaction-marker" not in read.text
 
 
 def test_holdout_empty_canonical_data_returns_empty_search_without_fabrication(

--- a/tests/holdout/test_chatgpt_action_holdout.py
+++ b/tests/holdout/test_chatgpt_action_holdout.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import pytest
@@ -10,13 +9,18 @@ from starlette.testclient import TestClient
 
 from fossil_core.runtime.chatgpt_action_server import (
     ChatGPTActionServerSettings,
-    build_chatgpt_action_adapter,
     create_chatgpt_action_app_from_settings,
 )
 
 
 TOKEN = "holdout-token-0123456789abcdef-0123456789"
 PUBLIC_ORIGIN = "https://fossil-action.holdout.invalid"
+ACTION_PATHS = {
+    "/actions/search",
+    "/actions/read",
+    "/actions/lineage",
+    "/actions/capabilities",
+}
 
 
 def repo_root() -> Path:
@@ -31,8 +35,7 @@ def make_settings(
     trusted_proxy_cidrs: tuple[str, ...] = (),
 ) -> ChatGPTActionServerSettings:
     data_root = tmp_path / "fossil-data"
-    events = data_root / "canonical" / "events"
-    events.mkdir(parents=True, exist_ok=True)
+    (data_root / "canonical" / "events").mkdir(parents=True, exist_ok=True)
     return ChatGPTActionServerSettings(
         repository_root=repo_root(),
         data_root=data_root,
@@ -57,12 +60,15 @@ def auth() -> dict[str, str]:
         {"authorization": "Bearer"},
         {"authorization": "Bearer wrong"},
         {"authorization": f"Bearer {TOKEN} "},
+        {"authorization": f"Bearer {TOKEN}\textra"},
         {"authorization": f"Bearer {TOKEN.upper()}"},
     ],
 )
-def test_holdout_malformed_auth_fails_closed(tmp_path: Path, headers: dict[str, str]) -> None:
+def test_holdout_absent_malformed_and_wrong_auth_fail_closed(
+    tmp_path: Path, headers: dict[str, str]
+) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
-    with TestClient(app) as client:
+    with TestClient(app, base_url="http://internal:8787") as client:
         response = client.post("/actions/search", headers=headers, json={"query": "x"})
     assert response.status_code == 401
     assert response.headers["www-authenticate"] == "Bearer"
@@ -70,7 +76,7 @@ def test_holdout_malformed_auth_fails_closed(tmp_path: Path, headers: dict[str, 
 
 def test_holdout_duplicate_authorization_header_fails_closed(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
-    with TestClient(app) as client:
+    with TestClient(app, base_url="http://internal:8787") as client:
         response = client.post(
             "/actions/search",
             headers=[
@@ -83,28 +89,56 @@ def test_holdout_duplicate_authorization_header_fails_closed(tmp_path: Path) -> 
     assert response.status_code == 401
 
 
-def test_holdout_forged_forwarded_headers_cannot_rewrite_fixed_schema_origin(tmp_path: Path) -> None:
+def test_holdout_scheme_case_is_allowed_but_token_case_is_exact(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
+    with TestClient(app, base_url="http://internal:8787") as client:
+        allowed = client.post(
+            "/actions/search",
+            headers={"authorization": f"bEaReR {TOKEN}"},
+            json={"query": "x"},
+        )
+        denied = client.post(
+            "/actions/search",
+            headers={"authorization": f"Bearer {TOKEN.upper()}"},
+            json={"query": "x"},
+        )
+    assert allowed.status_code == 200
+    assert denied.status_code == 401
+
+
+def test_holdout_fixed_origin_resists_forged_forwarded_headers(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
     forged = {
         "forwarded": "proto=http;host=attacker.invalid",
-        "x-forwarded-proto": "http",
+        "x-forwarded-proto": "https",
         "x-forwarded-host": "attacker.invalid",
-        "x-forwarded-port": "80",
+        "x-forwarded-port": "443",
         "host": "internal.invalid:8787",
     }
-    with TestClient(app, base_url="http://internal.invalid:8787") as client:
-        schema = client.get("/openapi.json", headers=forged).json()
-    assert schema["servers"] == [{"url": PUBLIC_ORIGIN}]
+    with TestClient(
+        app,
+        base_url="http://internal.invalid:8787",
+        client=("203.0.113.80", 55000),
+    ) as client:
+        response = client.get("/openapi.json", headers=forged)
+    assert response.status_code == 200
+    assert response.json()["servers"] == [{"url": PUBLIC_ORIGIN}]
 
 
-def test_holdout_untrusted_forwarded_headers_fail_closed_without_fixed_origin(tmp_path: Path) -> None:
+def test_holdout_untrusted_forwarded_headers_fail_closed_without_fixed_origin(
+    tmp_path: Path,
+) -> None:
     app = create_chatgpt_action_app_from_settings(
-        make_settings(tmp_path, public_base_url=None, trusted_proxy_cidrs=("10.0.0.0/8",))
+        make_settings(
+            tmp_path,
+            public_base_url=None,
+            trusted_proxy_cidrs=("10.0.0.0/8",),
+        )
     )
     with TestClient(
         app,
         base_url="http://internal.invalid:8787",
-        client=("127.0.0.1", 50000),
+        client=("203.0.113.80", 50000),
     ) as client:
         response = client.get(
             "/openapi.json",
@@ -115,42 +149,66 @@ def test_holdout_untrusted_forwarded_headers_fail_closed_without_fixed_origin(tm
         )
     assert response.status_code == 503
     assert response.json()["error"]["code"] == "https_origin_required"
+    assert "attacker.invalid" not in response.text
+    assert "http://internal" not in response.text
 
 
-def test_holdout_trusted_proxy_can_represent_https_origin(tmp_path: Path) -> None:
+def test_holdout_trusted_proxy_requires_unambiguous_https_headers(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(
         make_settings(
             tmp_path,
             public_base_url=None,
-            trusted_proxy_cidrs=("127.0.0.1/32",),
+            trusted_proxy_cidrs=("10.0.0.0/8",),
         )
     )
     with TestClient(
         app,
         base_url="http://internal.invalid:8787",
-        client=("127.0.0.1", 50000),
+        client=("10.1.2.3", 50000),
     ) as client:
-        response = client.get(
+        valid = client.get(
             "/openapi.json",
             headers={
                 "x-forwarded-proto": "https",
                 "x-forwarded-host": "fossil-proxy.example.invalid",
             },
         )
-    assert response.status_code == 200
-    assert response.json()["servers"] == [
-        {"url": "https://fossil-proxy.example.invalid"}
-    ]
+        assert valid.status_code == 200
+        assert valid.json()["servers"] == [
+            {"url": "https://fossil-proxy.example.invalid"}
+        ]
+
+        for headers in (
+            {},
+            {"x-forwarded-proto": "http", "x-forwarded-host": "fossil.example.test"},
+            {"x-forwarded-proto": "https"},
+            {"x-forwarded-proto": "https", "x-forwarded-host": "bad host"},
+            {
+                "x-forwarded-proto": "https,http",
+                "x-forwarded-host": "fossil.example.test",
+            },
+            {
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "fossil.example.test,attacker.invalid",
+            },
+            {"x-forwarded-proto": "https", "x-forwarded-host": "user@host.invalid"},
+        ):
+            response = client.get("/openapi.json", headers=headers)
+            assert response.status_code == 503
+            assert '"url":"http://' not in response.text.replace(" ", "")
 
 
 def test_holdout_openapi_is_valid_and_custom_gpt_bounded(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
-    with TestClient(app) as client:
+    with TestClient(app, base_url="http://internal:8787") as client:
         response = client.get("/openapi.json")
     assert response.status_code == 200
     schema = response.json()
     validate_spec(schema)
+
     assert schema["openapi"].startswith("3.1.")
+    assert schema["servers"] == [{"url": PUBLIC_ORIGIN}]
+    assert set(schema["paths"]) == ACTION_PATHS
     assert isinstance(schema["components"]["schemas"], dict)
     assert set(schema["components"]["schemas"]) >= {
         "ErrorDetail",
@@ -160,15 +218,21 @@ def test_holdout_openapi_is_valid_and_custom_gpt_bounded(tmp_path: Path) -> None
         "LineageRequest",
         "SearchResult",
         "FossilEvent",
+        "LineageNode",
+        "Citation",
         "LineageResponse",
         "CapabilitiesResponse",
     }
-    assert set(schema["paths"]) == {
-        "/actions/search",
-        "/actions/read",
-        "/actions/lineage",
-        "/actions/capabilities",
-    }
+    for name in (
+        "SearchResult",
+        "FossilEvent",
+        "LineageNode",
+        "Citation",
+        "LineageResponse",
+        "CapabilitiesResponse",
+    ):
+        assert schema["components"]["schemas"][name].get("properties")
+
     operation_ids = [
         operation["operationId"]
         for path in schema["paths"].values()
@@ -176,16 +240,13 @@ def test_holdout_openapi_is_valid_and_custom_gpt_bounded(tmp_path: Path) -> None
     ]
     assert len(operation_ids) == len(set(operation_ids)) == 4
     assert schema["components"]["securitySchemes"]["BearerAuth"]["scheme"] == "bearer"
-
-    search_props = schema["components"]["schemas"]["SearchResult"]["properties"]
-    assert {"event_id", "pack_id", "event_type", "recorded_at"} <= set(search_props)
-    event_props = schema["components"]["schemas"]["FossilEvent"]["properties"]
-    assert {"event_id", "pack_id", "event_type", "recorded_at", "payload"} <= set(event_props)
-    capability_props = schema["components"]["schemas"]["CapabilitiesResponse"]["properties"]
-    assert capability_props["durable_writes_exposed"]["const"] is False
-    assert capability_props["mcp_exposed"]["const"] is False
+    assert schema["components"]["schemas"]["CapabilitiesResponse"]["properties"][
+        "durable_writes_exposed"
+    ]["const"] is False
 
     serialized = json.dumps(schema).lower()
+    assert '"url": "http://' not in serialized
+    assert TOKEN.lower() not in serialized
     for forbidden in (
         '"/mcp"',
         '"/ingest"',
@@ -193,15 +254,14 @@ def test_holdout_openapi_is_valid_and_custom_gpt_bounded(tmp_path: Path) -> None
         '"/actions/validate"',
         '"/actions/commit"',
         '"/actions/redact"',
-        "neo4j",
-        TOKEN.lower(),
+        '"/filesystem"',
     ):
         assert forbidden not in serialized
 
 
-def test_holdout_oversized_payloads_fail_before_service(tmp_path: Path) -> None:
+def test_holdout_oversized_and_malformed_payloads_fail_before_service(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path, max_bytes=64))
-    with TestClient(app) as client:
+    with TestClient(app, base_url="http://internal:8787") as client:
         actual = client.post(
             "/actions/search",
             headers=auth(),
@@ -209,14 +269,26 @@ def test_holdout_oversized_payloads_fail_before_service(tmp_path: Path) -> None:
         )
         declared = client.post(
             "/actions/search",
-            headers={**auth(), "content-type": "application/json", "content-length": "9999"},
+            headers={
+                **auth(),
+                "content-type": "application/json",
+                "content-length": "9999",
+            },
             content=b'{"query":"x"}',
+        )
+        malformed = client.post(
+            "/actions/search", headers=auth(), content=b"{not-json"
+        )
+        non_object = client.post(
+            "/actions/search", headers=auth(), json=["not", "object"]
         )
     assert actual.status_code == 413
     assert declared.status_code == 413
+    assert malformed.status_code == 400
+    assert non_object.status_code == 400
 
 
-def test_holdout_unknown_and_prohibited_paths_are_not_routable(tmp_path: Path) -> None:
+def test_holdout_unknown_and_mutation_like_paths_are_not_routable(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
     prohibited = [
         "/mcp",
@@ -225,13 +297,14 @@ def test_holdout_unknown_and_prohibited_paths_are_not_routable(tmp_path: Path) -
         "/actions/validate",
         "/actions/commit",
         "/actions/redact",
+        "/actions/write",
         "/neo4j",
         "/graph",
         "/filesystem",
         "/admin",
         "/unknown",
     ]
-    with TestClient(app) as client:
+    with TestClient(app, base_url="http://internal:8787") as client:
         for path in prohibited:
             assert client.get(path, headers=auth()).status_code == 404, path
             assert client.post(path, headers=auth(), json={}).status_code == 404, path
@@ -239,87 +312,74 @@ def test_holdout_unknown_and_prohibited_paths_are_not_routable(tmp_path: Path) -
 
 def test_holdout_unsupported_methods_return_405(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
-    with TestClient(app) as client:
+    with TestClient(app, base_url="http://internal:8787") as client:
         assert client.post("/openapi.json").status_code == 405
         assert client.get("/actions/search", headers=auth()).status_code == 405
         assert client.get("/actions/read", headers=auth()).status_code == 405
         assert client.get("/actions/lineage", headers=auth()).status_code == 405
-        assert client.post("/actions/capabilities", headers=auth(), json={}).status_code == 405
+        assert client.post("/actions/capabilities", headers=auth()).status_code == 405
 
 
-def test_holdout_path_traversal_event_ids_are_rejected(tmp_path: Path) -> None:
+def test_holdout_path_and_capability_smuggling_are_rejected(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
-    malicious = [
-        "../../../../etc/passwd",
-        "evt_../../../../etc/passwd",
-        "evt_................",
-        "evt_abcdefghijklmnop/../../secret",
-        "C:\\Windows\\System32\\drivers\\etc\\hosts",
-    ]
-    with TestClient(app) as client:
-        for event_id in malicious:
+    with TestClient(app, base_url="http://internal:8787") as client:
+        for event_id in (
+            "../../../../etc/passwd",
+            "evt_../../../../etc/passwd",
+            "evt_abcdefghijklmnop/../../secret",
+            "C:\\Windows\\System32\\drivers\\etc\\hosts",
+            "file:///etc/passwd",
+        ):
             response = client.post(
                 "/actions/read", headers=auth(), json={"event_id": event_id}
             )
             assert response.status_code == 400, event_id
 
-
-def test_holdout_read_only_store_has_no_mutation_surface_and_boots_without_write(tmp_path: Path) -> None:
-    configured = make_settings(tmp_path)
-    events = configured.data_root / "canonical" / "events"
-    os.chmod(events, 0o555)
-    try:
-        adapter = build_chatgpt_action_adapter(configured)
-        for forbidden in ("commit", "prepare", "validate", "redact", "put", "delete"):
-            assert not hasattr(adapter.service.event_store, forbidden)
-        app = create_chatgpt_action_app_from_settings(configured)
-        with TestClient(app) as client:
-            response = client.post("/actions/search", headers=auth(), json={"query": "empty"})
-        assert response.status_code == 200
-        assert response.json() == []
-    finally:
-        os.chmod(events, 0o755)
-
-
-def test_holdout_validation_rejects_ambiguous_limits_and_non_object_json(tmp_path: Path) -> None:
-    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
-    with TestClient(app) as client:
-        for limit in (True, False, 0, -1, 101, "5", 1.5):
-            response = client.post(
-                "/actions/search", headers=auth(), json={"query": "x", "limit": limit}
-            )
-            assert response.status_code == 400, repr(limit)
-        non_object = client.post(
+        assert client.post(
             "/actions/search",
-            headers={**auth(), "content-type": "application/json"},
-            content=b'["x"]',
+            headers=auth(),
+            json={"query": "x", "cypher": "MATCH (n) DETACH DELETE n"},
+        ).status_code == 400
+        assert client.post(
+            "/actions/read",
+            headers=auth(),
+            json={"event_id": "evt_abcdefghijklmnop", "commit": True},
+        ).status_code == 400
+        assert client.post(
+            "/actions/lineage",
+            headers=auth(),
+            json={"conversation_id": "conv_abcdefghijklmnop", "mcp": True},
+        ).status_code == 400
+
+
+def test_holdout_empty_canonical_data_returns_empty_search_without_fabrication(
+    tmp_path: Path,
+) -> None:
+    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
+    with TestClient(app, base_url="http://internal:8787") as client:
+        response = client.post(
+            "/actions/search", headers=auth(), json={"query": "anything"}
         )
-    assert non_object.status_code == 400
+    assert response.status_code == 200
+    assert response.json() == []
 
 
-def test_holdout_unexpected_fields_do_not_create_hidden_capabilities(tmp_path: Path) -> None:
+def test_holdout_secret_and_local_configuration_do_not_leak(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
-    payloads = [
-        {"query": "x", "path": "/etc/passwd"},
-        {"query": "x", "cypher": "MATCH (n) DETACH DELETE n"},
-        {"event_id": "evt_abcdefghijklmnop", "commit": True},
-        {"conversation_id": "conv_abcdefghijklmnop", "mcp": {"tool": "fossil.commit"}},
-    ]
-    with TestClient(app) as client:
-        assert client.post("/actions/search", headers=auth(), json=payloads[0]).status_code == 400
-        assert client.post("/actions/search", headers=auth(), json=payloads[1]).status_code == 400
-        assert client.post("/actions/read", headers=auth(), json=payloads[2]).status_code == 400
-        assert client.post("/actions/lineage", headers=auth(), json=payloads[3]).status_code == 400
-
-
-def test_holdout_secret_never_appears_in_public_or_error_responses(tmp_path: Path) -> None:
-    app = create_chatgpt_action_app_from_settings(make_settings(tmp_path))
-    with TestClient(app) as client:
+    with TestClient(app, base_url="http://internal:8787") as client:
         responses = [
             client.get("/openapi.json"),
             client.get("/actions/capabilities", headers=auth()),
             client.post("/actions/search", json={"query": "x"}),
             client.post("/actions/search", headers=auth(), content=b"not-json"),
+            client.post(
+                "/actions/read",
+                headers=auth(),
+                json={"event_id": "evt_aaaaaaaaaaaaaaaa"},
+            ),
         ]
     for response in responses:
         assert TOKEN not in response.text
+        assert str(tmp_path) not in response.text
+        assert "FOSSIL_ACTION_BEARER_TOKEN" not in response.text
+        assert "D:\\FossilBrokerWorker" not in response.text

--- a/tests/test_chatgpt_action.py
+++ b/tests/test_chatgpt_action.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+from openapi_spec_validator import validate_spec
 from starlette.testclient import TestClient
 
 from fossil_core.agent import AgentContext
@@ -16,6 +18,12 @@ from fossil_core.runtime.chatgpt_action import (
 
 COMMON = "pack_269099f7b2ba43b7a99b9427d64092de"
 TOKEN = "test-chatgpt-action-token"
+ACTION_PATHS = {
+    "/actions/search",
+    "/actions/read",
+    "/actions/lineage",
+    "/actions/capabilities",
+}
 
 
 def root() -> Path:
@@ -39,16 +47,25 @@ class FakeGraphiti:
 
 class FakeLineage:
     def current_conclusions(self):
-        return [{"node_id": "lin_action_current", "kind": "conclusion"}]
+        return [{"node_id": "ln_action_current", "kind": "conclusion"}]
 
     def historical_nodes(self):
-        return [{"node_id": "lin_action_history", "kind": "claim"}]
+        return [{"node_id": "ln_action_history", "kind": "claim"}]
 
     def node(self, node_id: str):
         return {"node_id": node_id, "kind": "conclusion"}
 
     def citations(self, node_id: str):
-        return [{"span_id": "span_action", "text": "fixture evidence"}]
+        return [
+            {
+                "span_id": "span_action",
+                "artifact_id": "art_action",
+                "evidence_status": "verbatim",
+                "byte_start": 0,
+                "byte_end": 16,
+                "text": "fixture evidence",
+            }
+        ]
 
     def opposing_positions(self, node_id: str):
         return []
@@ -103,6 +120,15 @@ def auth_headers() -> dict[str, str]:
     return {"authorization": f"Bearer {TOKEN}"}
 
 
+def action_app(tmp_path: Path, **kwargs):
+    return create_chatgpt_action_app(
+        compose(tmp_path),
+        context=read_context(),
+        bearer_token=TOKEN,
+        **kwargs,
+    )
+
+
 def commit_fixture_event(node) -> dict:
     context = writer_context()
     event = node.corpus_service.propose(
@@ -116,49 +142,82 @@ def commit_fixture_event(node) -> dict:
         access=node.pack_access,
         context=context,
     )
-    validated = node.corpus_service.validate(
-        event,
-        access=node.pack_access,
-        context=context,
-    )
-    return node.corpus_service.commit(
-        validated,
-        access=node.pack_access,
-        context=context,
-    )
+    validated = node.corpus_service.validate(event, access=node.pack_access, context=context)
+    return node.corpus_service.commit(validated, access=node.pack_access, context=context)
 
 
-def test_openapi_is_read_only_and_declares_bearer_auth():
+def test_openapi_is_valid_explicit_and_read_only():
     schema = chatgpt_action_openapi_schema(server_url="https://fossil.example.test/")
+    validate_spec(schema)
 
-    assert schema["openapi"] == "3.1.0"
+    assert schema["openapi"].startswith("3.1.")
     assert schema["servers"] == [{"url": "https://fossil.example.test"}]
     assert schema["security"] == [{"BearerAuth": []}]
     assert schema["components"]["securitySchemes"]["BearerAuth"]["scheme"] == "bearer"
-    assert set(schema["paths"]) == {
-        "/actions/search",
-        "/actions/read",
-        "/actions/lineage",
-        "/actions/capabilities",
+    assert set(schema["paths"]) == ACTION_PATHS
+
+    component_schemas = schema["components"]["schemas"]
+    assert isinstance(component_schemas, dict) and component_schemas
+    for name in (
+        "ErrorEnvelope",
+        "SearchRequest",
+        "ReadRequest",
+        "LineageRequest",
+        "SearchResult",
+        "FossilEvent",
+        "LineageNode",
+        "Citation",
+        "LineageResponse",
+        "CapabilitiesResponse",
+    ):
+        assert name in component_schemas
+        assert component_schemas[name]["type"] == "object"
+        assert component_schemas[name].get("properties")
+
+    operation_ids = {
+        operation["operationId"]
+        for path in schema["paths"].values()
+        for operation in path.values()
     }
-    serialized = json.dumps(schema)
+    assert operation_ids == {
+        "fossilSearch",
+        "fossilRead",
+        "fossilLineage",
+        "fossilActionCapabilities",
+    }
+
+    serialized = json.dumps(schema).lower()
     for forbidden in (
         "fossil.propose",
         "fossil.validate",
         "fossil.commit",
-        "/ingest",
-        "/mcp",
+        '"/ingest"',
+        '"/mcp"',
+        '"/actions/propose"',
+        '"/actions/commit"',
         "neo4j",
+        "graph mutation",
+        "bearer_token",
     ):
-        assert forbidden not in serialized.lower()
+        assert forbidden not in serialized
 
 
-def test_action_app_authenticates_and_does_not_publish_private_node_routes(tmp_path: Path):
-    app = create_chatgpt_action_app(
-        compose(tmp_path),
-        context=read_context(),
-        bearer_token=TOKEN,
-    )
+def test_openapi_success_response_objects_resolve_to_declared_properties():
+    schema = chatgpt_action_openapi_schema(server_url="https://fossil.example.test")
+    components = schema["components"]["schemas"]
+
+    for path_item in schema["paths"].values():
+        operation = next(iter(path_item.values()))
+        response_schema = operation["responses"]["200"]["content"]["application/json"]["schema"]
+        if response_schema.get("type") == "array":
+            response_schema = response_schema["items"]
+        assert "$ref" in response_schema
+        name = response_schema["$ref"].rsplit("/", 1)[-1]
+        assert components[name].get("properties")
+
+
+def test_action_app_authenticates_and_exposes_only_allowlisted_routes(tmp_path: Path):
+    app = action_app(tmp_path)
 
     with TestClient(app, base_url="https://fossil.example.test") as client:
         schema = client.get("/openapi.json")
@@ -168,25 +227,77 @@ def test_action_app_authenticates_and_does_not_publish_private_node_routes(tmp_p
         denied = client.get("/actions/capabilities")
         assert denied.status_code == 401
         assert denied.headers["www-authenticate"] == "Bearer"
-        assert denied.json()["error"]["code"] == "unauthorized"
 
         wrong = client.get(
-            "/actions/capabilities",
-            headers={"authorization": "Bearer wrong-token"},
+            "/actions/capabilities", headers={"authorization": "Bearer wrong-token"}
         )
         assert wrong.status_code == 401
 
         allowed = client.get("/actions/capabilities", headers=auth_headers())
         assert allowed.status_code == 200
-        assert allowed.json()["action_capabilities"] == ["search", "read", "lineage"]
-        assert allowed.json()["durable_writes_exposed"] is False
-        assert allowed.json()["ingestion_exposed"] is False
-        assert allowed.json()["mcp_exposed"] is False
-        assert allowed.json()["arbitrary_graph_mutation"] is False
+        assert allowed.json() == {
+            "service_version": "1",
+            "action_capabilities": ["search", "read", "lineage"],
+            "durable_writes_exposed": False,
+            "ingestion_exposed": False,
+            "mcp_exposed": False,
+            "arbitrary_graph_mutation": False,
+        }
 
-        assert client.get("/mcp", headers=auth_headers()).status_code == 404
-        assert client.post("/ingest", headers=auth_headers(), json={}).status_code == 404
-        assert client.post("/actions/commit", headers=auth_headers(), json={}).status_code == 404
+        for path in (
+            "/mcp",
+            "/ingest",
+            "/actions/propose",
+            "/actions/validate",
+            "/actions/commit",
+            "/actions/redact",
+            "/actions/write",
+            "/actions/admin",
+            "/neo4j",
+            "/graph",
+            "/filesystem",
+            "/etc/passwd",
+            "/unknown",
+        ):
+            response = client.post(path, headers=auth_headers(), json={})
+            assert response.status_code == 404, path
+            assert response.json()["error"]["code"] == "not_found"
+
+
+def test_auth_header_is_unambiguous_and_token_exact(tmp_path: Path):
+    app = action_app(tmp_path)
+    cases = (
+        None,
+        "",
+        TOKEN,
+        f"Basic {TOKEN}",
+        "Bearer",
+        "Bearer ",
+        f"Bearer {TOKEN} ",
+        f"Bearer {TOKEN}\textra",
+        f"Bearer {TOKEN} extra",
+        "Bearer wrong",
+    )
+    with TestClient(app, base_url="https://fossil.example.test") as client:
+        for value in cases:
+            headers = {} if value is None else {"authorization": value}
+            response = client.get("/actions/capabilities", headers=headers)
+            assert response.status_code == 401, value
+
+        lower_scheme = client.get(
+            "/actions/capabilities",
+            headers={"authorization": f"bearer {TOKEN}"},
+        )
+        assert lower_scheme.status_code == 200
+
+        duplicated = client.get(
+            "/actions/capabilities",
+            headers=[
+                ("authorization", f"Bearer {TOKEN}"),
+                ("authorization", f"Bearer {TOKEN}"),
+            ],
+        )
+        assert duplicated.status_code == 401
 
 
 def test_action_search_read_and_lineage_delegate_to_canonical_service(tmp_path: Path):
@@ -203,11 +314,7 @@ def test_action_search_read_and_lineage_delegate_to_canonical_service(tmp_path: 
         searched = client.post(
             "/actions/search",
             headers=auth_headers(),
-            json={
-                "query": "ChatGPT Action requests",
-                "limit": 10,
-                "ignored_graph_escape": "MATCH (n) DETACH DELETE n",
-            },
+            json={"query": "ChatGPT Action requests", "limit": 10},
         )
         assert searched.status_code == 200
         assert any(item["event_id"] == committed["event_id"] for item in searched.json())
@@ -224,48 +331,78 @@ def test_action_search_read_and_lineage_delegate_to_canonical_service(tmp_path: 
         lineage = client.post(
             "/actions/lineage",
             headers=auth_headers(),
-            json={
-                "conversation_id": "conv_chatgpt_action",
-                "node_id": "lin_action_current",
-            },
+            json={"conversation_id": "conv_chatgpt_action", "node_id": "ln_action_current"},
         )
         assert lineage.status_code == 200
         assert lineage.json()["conversation_id"] == "conv_chatgpt_action"
-        assert lineage.json()["node"]["node_id"] == "lin_action_current"
+        assert lineage.json()["node"]["node_id"] == "ln_action_current"
 
         missing = client.post(
             "/actions/read",
             headers=auth_headers(),
-            json={"event_id": "evt_missing_chatgpt_action"},
+            json={"event_id": "evt_aaaaaaaaaaaaaaaa"},
         )
         assert missing.status_code == 404
         assert missing.json()["error"]["code"] == "not_found"
 
 
-def test_action_request_validation_fails_closed(tmp_path: Path):
-    app = create_chatgpt_action_app(
-        compose(tmp_path),
-        context=read_context(),
-        bearer_token=TOKEN,
-        max_request_body_size=64,
-    )
+def test_request_validation_rejects_mutation_smuggling_and_traversal(tmp_path: Path):
+    app = action_app(tmp_path)
+    with TestClient(app, base_url="https://fossil.example.test") as client:
+        extra = client.post(
+            "/actions/search",
+            headers=auth_headers(),
+            json={
+                "query": "FOSSIL",
+                "graph_query": "MATCH (n) DETACH DELETE n",
+            },
+        )
+        assert extra.status_code == 400
+
+        traversal = client.post(
+            "/actions/read",
+            headers=auth_headers(),
+            json={"event_id": "../../etc/passwd"},
+        )
+        assert traversal.status_code == 400
+
+        lineage_traversal = client.post(
+            "/actions/lineage",
+            headers=auth_headers(),
+            json={"conversation_id": "../secret"},
+        )
+        assert lineage_traversal.status_code == 400
+
+        for bad_limit in (True, "10", 0, -1, 101):
+            response = client.post(
+                "/actions/search",
+                headers=auth_headers(),
+                json={"query": "FOSSIL", "limit": bad_limit},
+            )
+            assert response.status_code == 400
+
+        too_long = client.post(
+            "/actions/search",
+            headers=auth_headers(),
+            json={"query": "x" * 8193},
+        )
+        assert too_long.status_code == 400
+
+
+def test_request_size_json_and_method_validation_fail_closed(tmp_path: Path):
+    app = action_app(tmp_path, max_request_body_size=64)
 
     with TestClient(app, base_url="https://fossil.example.test") as client:
         invalid = client.post(
-            "/actions/search",
-            headers=auth_headers(),
-            content=b"not-json",
+            "/actions/search", headers=auth_headers(), content=b"not-json"
         )
         assert invalid.status_code == 400
         assert invalid.json()["error"]["code"] == "invalid_json"
 
-        empty = client.post(
-            "/actions/search",
-            headers=auth_headers(),
-            json={"query": ""},
+        non_object = client.post(
+            "/actions/search", headers=auth_headers(), json=["not", "object"]
         )
-        assert empty.status_code == 400
-        assert empty.json()["error"]["code"] == "invalid_request"
+        assert non_object.status_code == 400
 
         too_large = client.post(
             "/actions/search",
@@ -273,4 +410,35 @@ def test_action_request_validation_fails_closed(tmp_path: Path):
             content=json.dumps({"query": "x" * 100}).encode("utf-8"),
         )
         assert too_large.status_code == 413
-        assert too_large.json()["error"]["code"] == "request_too_large"
+
+        assert client.post("/openapi.json", json={}).status_code == 405
+        assert client.get("/actions/search", headers=auth_headers()).status_code == 405
+        assert client.post(
+            "/actions/capabilities", headers=auth_headers(), json={}
+        ).status_code == 405
+
+
+def test_errors_do_not_echo_internal_paths_or_secret(tmp_path: Path):
+    app = action_app(tmp_path)
+    with TestClient(app, base_url="https://fossil.example.test") as client:
+        response = client.post(
+            "/actions/read",
+            headers=auth_headers(),
+            json={"event_id": "evt_aaaaaaaaaaaaaaaa"},
+        )
+        body = response.text
+        assert TOKEN not in body
+        assert str(tmp_path) not in body
+        assert "/var/lib/fossil" not in body
+
+
+@pytest.mark.parametrize(
+    "forbidden_fragment",
+    ["secret", "token", "credential", "password"],
+)
+def test_openapi_contains_no_runtime_secret_values(forbidden_fragment: str):
+    schema = json.dumps(
+        chatgpt_action_openapi_schema(server_url="https://fossil.example.test")
+    ).lower()
+    assert TOKEN.lower() not in schema
+    assert f"replace-with-a-{forbidden_fragment}" not in schema

--- a/tests/test_chatgpt_action.py
+++ b/tests/test_chatgpt_action.py
@@ -196,7 +196,6 @@ def test_openapi_is_valid_explicit_and_read_only():
         '"/actions/propose"',
         '"/actions/commit"',
         "neo4j",
-        "graph mutation",
         "bearer_token",
     ):
         assert forbidden not in serialized

--- a/tests/test_chatgpt_action.py
+++ b/tests/test_chatgpt_action.py
@@ -18,10 +18,10 @@ from fossil_core.runtime.chatgpt_action import (
 
 COMMON = "pack_269099f7b2ba43b7a99b9427d64092de"
 TOKEN = "test-chatgpt-action-token"
+PUBLIC_ORIGIN = "https://fossil.example.test"
 ACTION_PATHS = {
     "/actions/search",
     "/actions/read",
-    "/actions/lineage",
     "/actions/capabilities",
 }
 
@@ -43,32 +43,6 @@ class FakeGraphiti:
 
     async def close(self) -> None:
         return None
-
-
-class FakeLineage:
-    def current_conclusions(self):
-        return [{"node_id": "ln_action_current", "kind": "conclusion"}]
-
-    def historical_nodes(self):
-        return [{"node_id": "ln_action_history", "kind": "claim"}]
-
-    def node(self, node_id: str):
-        return {"node_id": node_id, "kind": "conclusion"}
-
-    def citations(self, node_id: str):
-        return [
-            {
-                "span_id": "span_action",
-                "artifact_id": "art_action",
-                "evidence_status": "verbatim",
-                "byte_start": 0,
-                "byte_end": 16,
-                "text": "fixture evidence",
-            }
-        ]
-
-    def opposing_positions(self, node_id: str):
-        return []
 
 
 def config(tmp_path: Path) -> FilesystemNodeConfig:
@@ -125,6 +99,7 @@ def action_app(tmp_path: Path, **kwargs):
         compose(tmp_path),
         context=read_context(),
         bearer_token=TOKEN,
+        public_base_url=PUBLIC_ORIGIN,
         **kwargs,
     )
 
@@ -147,11 +122,11 @@ def commit_fixture_event(node) -> dict:
 
 
 def test_openapi_is_valid_explicit_and_read_only():
-    schema = chatgpt_action_openapi_schema(server_url="https://fossil.example.test/")
+    schema = chatgpt_action_openapi_schema(server_url=f"{PUBLIC_ORIGIN}/")
     validate_spec(schema)
 
     assert schema["openapi"].startswith("3.1.")
-    assert schema["servers"] == [{"url": "https://fossil.example.test"}]
+    assert schema["servers"] == [{"url": PUBLIC_ORIGIN}]
     assert schema["security"] == [{"BearerAuth": []}]
     assert schema["components"]["securitySchemes"]["BearerAuth"]["scheme"] == "bearer"
     assert set(schema["paths"]) == ACTION_PATHS
@@ -162,17 +137,15 @@ def test_openapi_is_valid_explicit_and_read_only():
         "ErrorEnvelope",
         "SearchRequest",
         "ReadRequest",
-        "LineageRequest",
         "SearchResult",
         "FossilEvent",
-        "LineageNode",
-        "Citation",
-        "LineageResponse",
         "CapabilitiesResponse",
     ):
         assert name in component_schemas
         assert component_schemas[name]["type"] == "object"
         assert component_schemas[name].get("properties")
+    for forbidden_schema in ("LineageRequest", "LineageResponse", "LineageNode", "Citation"):
+        assert forbidden_schema not in component_schemas
 
     operation_ids = {
         operation["operationId"]
@@ -182,7 +155,6 @@ def test_openapi_is_valid_explicit_and_read_only():
     assert operation_ids == {
         "fossilSearch",
         "fossilRead",
-        "fossilLineage",
         "fossilActionCapabilities",
     }
 
@@ -193,6 +165,7 @@ def test_openapi_is_valid_explicit_and_read_only():
         "fossil.commit",
         '"/ingest"',
         '"/mcp"',
+        '"/actions/lineage"',
         '"/actions/propose"',
         '"/actions/commit"',
         "neo4j",
@@ -202,7 +175,7 @@ def test_openapi_is_valid_explicit_and_read_only():
 
 
 def test_openapi_success_response_objects_resolve_to_declared_properties():
-    schema = chatgpt_action_openapi_schema(server_url="https://fossil.example.test")
+    schema = chatgpt_action_openapi_schema(server_url=PUBLIC_ORIGIN)
     components = schema["components"]["schemas"]
 
     for path_item in schema["paths"].values():
@@ -218,25 +191,20 @@ def test_openapi_success_response_objects_resolve_to_declared_properties():
 def test_action_app_authenticates_and_exposes_only_allowlisted_routes(tmp_path: Path):
     app = action_app(tmp_path)
 
-    with TestClient(app, base_url="https://fossil.example.test") as client:
+    with TestClient(app, base_url="http://internal:8787") as client:
         schema = client.get("/openapi.json")
         assert schema.status_code == 200
-        assert schema.json()["servers"] == [{"url": "https://fossil.example.test"}]
+        assert schema.json()["servers"] == [{"url": PUBLIC_ORIGIN}]
 
         denied = client.get("/actions/capabilities")
         assert denied.status_code == 401
         assert denied.headers["www-authenticate"] == "Bearer"
 
-        wrong = client.get(
-            "/actions/capabilities", headers={"authorization": "Bearer wrong-token"}
-        )
-        assert wrong.status_code == 401
-
         allowed = client.get("/actions/capabilities", headers=auth_headers())
         assert allowed.status_code == 200
         assert allowed.json() == {
             "service_version": "1",
-            "action_capabilities": ["search", "read", "lineage"],
+            "action_capabilities": ["search", "read"],
             "durable_writes_exposed": False,
             "ingestion_exposed": False,
             "mcp_exposed": False,
@@ -246,6 +214,7 @@ def test_action_app_authenticates_and_exposes_only_allowlisted_routes(tmp_path: 
         for path in (
             "/mcp",
             "/ingest",
+            "/actions/lineage",
             "/actions/propose",
             "/actions/validate",
             "/actions/commit",
@@ -277,7 +246,7 @@ def test_auth_header_is_unambiguous_and_token_exact(tmp_path: Path):
         f"Bearer {TOKEN} extra",
         "Bearer wrong",
     )
-    with TestClient(app, base_url="https://fossil.example.test") as client:
+    with TestClient(app, base_url="http://internal:8787") as client:
         for value in cases:
             headers = {} if value is None else {"authorization": value}
             response = client.get("/actions/capabilities", headers=headers)
@@ -299,17 +268,17 @@ def test_auth_header_is_unambiguous_and_token_exact(tmp_path: Path):
         assert duplicated.status_code == 401
 
 
-def test_action_search_read_and_lineage_delegate_to_canonical_service(tmp_path: Path):
+def test_action_search_and_read_delegate_to_canonical_service(tmp_path: Path):
     node = compose(tmp_path)
     committed = commit_fixture_event(node)
-    node.corpus_service.lineages["conv_chatgpt_action"] = (COMMON, FakeLineage())
     app = create_chatgpt_action_app(
         node,
         context=read_context(),
         bearer_token=TOKEN,
+        public_base_url=PUBLIC_ORIGIN,
     )
 
-    with TestClient(app, base_url="https://fossil.example.test") as client:
+    with TestClient(app, base_url="http://internal:8787") as client:
         searched = client.post(
             "/actions/search",
             headers=auth_headers(),
@@ -327,15 +296,6 @@ def test_action_search_read_and_lineage_delegate_to_canonical_service(tmp_path: 
         assert read.json()["event_id"] == committed["event_id"]
         assert read.json()["pack_id"] == COMMON
 
-        lineage = client.post(
-            "/actions/lineage",
-            headers=auth_headers(),
-            json={"conversation_id": "conv_chatgpt_action", "node_id": "ln_action_current"},
-        )
-        assert lineage.status_code == 200
-        assert lineage.json()["conversation_id"] == "conv_chatgpt_action"
-        assert lineage.json()["node"]["node_id"] == "ln_action_current"
-
         missing = client.post(
             "/actions/read",
             headers=auth_headers(),
@@ -347,14 +307,11 @@ def test_action_search_read_and_lineage_delegate_to_canonical_service(tmp_path: 
 
 def test_request_validation_rejects_mutation_smuggling_and_traversal(tmp_path: Path):
     app = action_app(tmp_path)
-    with TestClient(app, base_url="https://fossil.example.test") as client:
+    with TestClient(app, base_url="http://internal:8787") as client:
         extra = client.post(
             "/actions/search",
             headers=auth_headers(),
-            json={
-                "query": "FOSSIL",
-                "graph_query": "MATCH (n) DETACH DELETE n",
-            },
+            json={"query": "FOSSIL", "graph_query": "MATCH (n) DETACH DELETE n"},
         )
         assert extra.status_code == 400
 
@@ -364,13 +321,6 @@ def test_request_validation_rejects_mutation_smuggling_and_traversal(tmp_path: P
             json={"event_id": "../../etc/passwd"},
         )
         assert traversal.status_code == 400
-
-        lineage_traversal = client.post(
-            "/actions/lineage",
-            headers=auth_headers(),
-            json={"conversation_id": "../secret"},
-        )
-        assert lineage_traversal.status_code == 400
 
         for bad_limit in (True, "10", 0, -1, 101):
             response = client.post(
@@ -391,7 +341,7 @@ def test_request_validation_rejects_mutation_smuggling_and_traversal(tmp_path: P
 def test_request_size_json_and_method_validation_fail_closed(tmp_path: Path):
     app = action_app(tmp_path, max_request_body_size=64)
 
-    with TestClient(app, base_url="https://fossil.example.test") as client:
+    with TestClient(app, base_url="http://internal:8787") as client:
         invalid = client.post(
             "/actions/search", headers=auth_headers(), content=b"not-json"
         )
@@ -417,9 +367,24 @@ def test_request_size_json_and_method_validation_fail_closed(tmp_path: Path):
         ).status_code == 405
 
 
+def test_fixed_public_origin_ignores_forged_forwarded_and_host_headers(tmp_path: Path):
+    app = action_app(tmp_path)
+    with TestClient(app, base_url="https://attacker.invalid") as client:
+        response = client.get(
+            "/openapi.json",
+            headers={
+                "host": "attacker.invalid",
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "evil.invalid",
+            },
+        )
+    assert response.status_code == 200
+    assert response.json()["servers"] == [{"url": PUBLIC_ORIGIN}]
+
+
 def test_errors_do_not_echo_internal_paths_or_secret(tmp_path: Path):
     app = action_app(tmp_path)
-    with TestClient(app, base_url="https://fossil.example.test") as client:
+    with TestClient(app, base_url="http://internal:8787") as client:
         response = client.post(
             "/actions/read",
             headers=auth_headers(),
@@ -437,7 +402,7 @@ def test_errors_do_not_echo_internal_paths_or_secret(tmp_path: Path):
 )
 def test_openapi_contains_no_runtime_secret_values(forbidden_fragment: str):
     schema = json.dumps(
-        chatgpt_action_openapi_schema(server_url="https://fossil.example.test")
+        chatgpt_action_openapi_schema(server_url=PUBLIC_ORIGIN)
     ).lower()
     assert TOKEN.lower() not in schema
     assert f"replace-with-a-{forbidden_fragment}" not in schema

--- a/tests/test_chatgpt_action.py
+++ b/tests/test_chatgpt_action.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from starlette.testclient import TestClient
+
+from fossil_core.agent import AgentContext
+from fossil_core.runtime import FilesystemNodeConfig, compose_filesystem_node
+from fossil_core.runtime.chatgpt_action import (
+    chatgpt_action_openapi_schema,
+    create_chatgpt_action_app,
+)
+
+
+COMMON = "pack_269099f7b2ba43b7a99b9427d64092de"
+TOKEN = "test-chatgpt-action-token"
+
+
+def root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+class FakeGraphiti:
+    async def build_indices_and_constraints(self) -> None:
+        return None
+
+    async def add_episode(self, **kwargs):
+        event_id = str(json.loads(kwargs["episode_body"])["event_id"])
+        return SimpleNamespace(episode=SimpleNamespace(uuid=f"episode-{event_id}"))
+
+    async def remove_episode(self, episode_uuid: str) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+class FakeLineage:
+    def current_conclusions(self):
+        return [{"node_id": "lin_action_current", "kind": "conclusion"}]
+
+    def historical_nodes(self):
+        return [{"node_id": "lin_action_history", "kind": "claim"}]
+
+    def node(self, node_id: str):
+        return {"node_id": node_id, "kind": "conclusion"}
+
+    def citations(self, node_id: str):
+        return [{"span_id": "span_action", "text": "fixture evidence"}]
+
+    def opposing_positions(self, node_id: str):
+        return []
+
+
+def config(tmp_path: Path) -> FilesystemNodeConfig:
+    return FilesystemNodeConfig(
+        repository_root=root(),
+        data_root=tmp_path / "node-data",
+        pack_manifest_path=root() / "examples" / "packs" / "common" / "manifest.json",
+        projection_build_id="chatgpt-action-test",
+        projection_build_manifest={
+            "graphiti_version": "0.29.3",
+            "neo4j_version": "test",
+            "model_id": "test-model",
+            "ontology_version": "1.0.0",
+            "software_commit": "test",
+        },
+        poll_interval_seconds=0.01,
+    )
+
+
+def compose(tmp_path: Path):
+    return compose_filesystem_node(
+        config(tmp_path),
+        graphiti_client=FakeGraphiti(),
+        episode_type_json="json",
+    )
+
+
+def writer_context() -> AgentContext:
+    return AgentContext(
+        actor_id="chatgpt-action-writer-fixture",
+        model_id="fixture-model-v2",
+        harness_version="fixture-harness-v2",
+        skill_id="skill_research-ingestion",
+        skill_version="1.1.0",
+    )
+
+
+def read_context() -> AgentContext:
+    return AgentContext(
+        actor_id="chatgpt-action-reader-fixture",
+        model_id="fixture-model-v2",
+        harness_version="fixture-harness-v2",
+        skill_id="skill_corpus-search",
+        skill_version="1.0.0",
+    )
+
+
+def auth_headers() -> dict[str, str]:
+    return {"authorization": f"Bearer {TOKEN}"}
+
+
+def commit_fixture_event(node) -> dict:
+    context = writer_context()
+    event = node.corpus_service.propose(
+        event_type="claim.proposed",
+        pack_id=COMMON,
+        subject_refs=["clm_chatgpt_action"],
+        payload={"claim_text": "ChatGPT Action requests reuse the canonical corpus boundary."},
+        occurred_at="2026-08-20T13:00:00Z",
+        recorded_at="2026-08-20T13:00:00Z",
+        idempotency_key="chatgpt-action-fixture-v1",
+        access=node.pack_access,
+        context=context,
+    )
+    validated = node.corpus_service.validate(
+        event,
+        access=node.pack_access,
+        context=context,
+    )
+    return node.corpus_service.commit(
+        validated,
+        access=node.pack_access,
+        context=context,
+    )
+
+
+def test_openapi_is_read_only_and_declares_bearer_auth():
+    schema = chatgpt_action_openapi_schema(server_url="https://fossil.example.test/")
+
+    assert schema["openapi"] == "3.1.0"
+    assert schema["servers"] == [{"url": "https://fossil.example.test"}]
+    assert schema["security"] == [{"BearerAuth": []}]
+    assert schema["components"]["securitySchemes"]["BearerAuth"]["scheme"] == "bearer"
+    assert set(schema["paths"]) == {
+        "/actions/search",
+        "/actions/read",
+        "/actions/lineage",
+        "/actions/capabilities",
+    }
+    serialized = json.dumps(schema)
+    for forbidden in (
+        "fossil.propose",
+        "fossil.validate",
+        "fossil.commit",
+        "/ingest",
+        "/mcp",
+        "neo4j",
+    ):
+        assert forbidden not in serialized.lower()
+
+
+def test_action_app_authenticates_and_does_not_publish_private_node_routes(tmp_path: Path):
+    app = create_chatgpt_action_app(
+        compose(tmp_path),
+        context=read_context(),
+        bearer_token=TOKEN,
+    )
+
+    with TestClient(app, base_url="https://fossil.example.test") as client:
+        schema = client.get("/openapi.json")
+        assert schema.status_code == 200
+        assert schema.json()["servers"] == [{"url": "https://fossil.example.test"}]
+
+        denied = client.get("/actions/capabilities")
+        assert denied.status_code == 401
+        assert denied.headers["www-authenticate"] == "Bearer"
+        assert denied.json()["error"]["code"] == "unauthorized"
+
+        wrong = client.get(
+            "/actions/capabilities",
+            headers={"authorization": "Bearer wrong-token"},
+        )
+        assert wrong.status_code == 401
+
+        allowed = client.get("/actions/capabilities", headers=auth_headers())
+        assert allowed.status_code == 200
+        assert allowed.json()["action_capabilities"] == ["search", "read", "lineage"]
+        assert allowed.json()["durable_writes_exposed"] is False
+        assert allowed.json()["ingestion_exposed"] is False
+        assert allowed.json()["mcp_exposed"] is False
+        assert allowed.json()["arbitrary_graph_mutation"] is False
+
+        assert client.get("/mcp", headers=auth_headers()).status_code == 404
+        assert client.post("/ingest", headers=auth_headers(), json={}).status_code == 404
+        assert client.post("/actions/commit", headers=auth_headers(), json={}).status_code == 404
+
+
+def test_action_search_read_and_lineage_delegate_to_canonical_service(tmp_path: Path):
+    node = compose(tmp_path)
+    committed = commit_fixture_event(node)
+    node.corpus_service.lineages["conv_chatgpt_action"] = (COMMON, FakeLineage())
+    app = create_chatgpt_action_app(
+        node,
+        context=read_context(),
+        bearer_token=TOKEN,
+    )
+
+    with TestClient(app, base_url="https://fossil.example.test") as client:
+        searched = client.post(
+            "/actions/search",
+            headers=auth_headers(),
+            json={
+                "query": "ChatGPT Action requests",
+                "limit": 10,
+                "ignored_graph_escape": "MATCH (n) DETACH DELETE n",
+            },
+        )
+        assert searched.status_code == 200
+        assert any(item["event_id"] == committed["event_id"] for item in searched.json())
+
+        read = client.post(
+            "/actions/read",
+            headers=auth_headers(),
+            json={"event_id": committed["event_id"]},
+        )
+        assert read.status_code == 200
+        assert read.json()["event_id"] == committed["event_id"]
+        assert read.json()["pack_id"] == COMMON
+
+        lineage = client.post(
+            "/actions/lineage",
+            headers=auth_headers(),
+            json={
+                "conversation_id": "conv_chatgpt_action",
+                "node_id": "lin_action_current",
+            },
+        )
+        assert lineage.status_code == 200
+        assert lineage.json()["conversation_id"] == "conv_chatgpt_action"
+        assert lineage.json()["node"]["node_id"] == "lin_action_current"
+
+        missing = client.post(
+            "/actions/read",
+            headers=auth_headers(),
+            json={"event_id": "evt_missing_chatgpt_action"},
+        )
+        assert missing.status_code == 404
+        assert missing.json()["error"]["code"] == "not_found"
+
+
+def test_action_request_validation_fails_closed(tmp_path: Path):
+    app = create_chatgpt_action_app(
+        compose(tmp_path),
+        context=read_context(),
+        bearer_token=TOKEN,
+        max_request_body_size=64,
+    )
+
+    with TestClient(app, base_url="https://fossil.example.test") as client:
+        invalid = client.post(
+            "/actions/search",
+            headers=auth_headers(),
+            content=b"not-json",
+        )
+        assert invalid.status_code == 400
+        assert invalid.json()["error"]["code"] == "invalid_json"
+
+        empty = client.post(
+            "/actions/search",
+            headers=auth_headers(),
+            json={"query": ""},
+        )
+        assert empty.status_code == 400
+        assert empty.json()["error"]["code"] == "invalid_request"
+
+        too_large = client.post(
+            "/actions/search",
+            headers=auth_headers(),
+            content=json.dumps({"query": "x" * 100}).encode("utf-8"),
+        )
+        assert too_large.status_code == 413
+        assert too_large.json()["error"]["code"] == "request_too_large"

--- a/tests/test_chatgpt_action_architecture.py
+++ b/tests/test_chatgpt_action_architecture.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
+from fossil_core.runtime import chatgpt_action
 from fossil_core.runtime.chatgpt_action_server import (
     ChatGPTActionServerSettings,
     build_chatgpt_action_adapter,
@@ -15,22 +17,50 @@ def root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
-def test_action_source_does_not_publish_private_protocols_or_projection_clients() -> None:
-    action = (root() / "src" / "fossil_core" / "runtime" / "chatgpt_action.py").read_text(
-        encoding="utf-8"
-    )
-    server = (
-        root() / "src" / "fossil_core" / "runtime" / "chatgpt_action_server.py"
-    ).read_text(encoding="utf-8")
+def imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
 
-    assert '"/mcp"' not in action
-    assert '"/ingest"' not in action
-    assert "from graphiti" not in server.lower()
-    assert "import graphiti" not in server.lower()
-    assert "from neo4j" not in server.lower()
-    assert "import neo4j" not in server.lower()
-    assert "DurableEventStore(" not in server
-    assert "proxy_headers=False" in server
+
+def test_action_route_allowlist_is_exact_and_write_tools_are_not_mapped() -> None:
+    assert chatgpt_action._ACTION_ROUTE_ALLOWLIST == frozenset(
+        {
+            "/openapi.json",
+            "/actions/search",
+            "/actions/read",
+            "/actions/lineage",
+            "/actions/capabilities",
+        }
+    )
+    assert chatgpt_action._ACTION_PATHS == {
+        "/actions/search": "fossil.search",
+        "/actions/read": "fossil.read",
+        "/actions/lineage": "fossil.lineage",
+    }
+    assert set(chatgpt_action._ACTION_PATHS.values()).isdisjoint(
+        {"fossil.propose", "fossil.validate", "fossil.commit", "fossil.manage"}
+    )
+
+
+def test_standalone_server_does_not_import_projection_or_mutable_event_store() -> None:
+    server_path = root() / "src" / "fossil_core" / "runtime" / "chatgpt_action_server.py"
+    modules = imported_modules(server_path)
+    assert not any("graphiti" in module.lower() for module in modules)
+    assert not any("neo4j" in module.lower() for module in modules)
+    assert not any(
+        module.endswith("event_store") and "adapters.filesystem" in module
+        for module in modules
+    )
+
+    source = server_path.read_text(encoding="utf-8")
+    assert "DurableEventStore(" not in source
+    assert "proxy_headers=False" in source
 
 
 def test_read_only_adapter_exposes_no_mutation_methods(tmp_path: Path) -> None:
@@ -63,7 +93,7 @@ def test_read_only_adapter_exposes_no_mutation_methods(tmp_path: Path) -> None:
         assert not hasattr(store, forbidden)
 
 
-def test_container_and_ci_encode_non_root_read_only_contract() -> None:
+def test_container_and_ci_encode_non_root_loopback_read_only_contract() -> None:
     dockerfile = (root() / "docker" / "chatgpt-action" / "Dockerfile").read_text(
         encoding="utf-8"
     )
@@ -74,8 +104,11 @@ def test_container_and_ci_encode_non_root_read_only_contract() -> None:
     assert "useradd --uid 10001" in dockerfile
     assert "USER fossil" in dockerfile
     assert 'ENTRYPOINT ["fossil-chatgpt-action"]' in dockerfile
+    assert "127.0.0.1:8787:8787" in workflow
     assert ":/var/lib/fossil:ro" in workflow
     assert 'test "$(docker exec fossil-chatgpt-action id -u)" = "10001"' in workflow
+    assert "HostIp" in workflow
+    assert 'eq .Destination "/var/lib/fossil"' in workflow
     assert "canonical mount unexpectedly writable" in workflow
 
 
@@ -86,6 +119,7 @@ def test_no_real_secret_is_committed_to_action_package() -> None:
         root() / ".github" / "workflows" / "chatgpt-action-container.yml",
         root() / "docs" / "operations" / "CHATGPT-ACTION-PDD.md",
         root() / "docs" / "operations" / "CHATGPT-ACTION-SDD.md",
+        root() / "docs" / "operations" / "CHATGPT-ACTION-INVARIANTS.md",
     ]
     combined = "\n".join(path.read_text(encoding="utf-8") for path in paths)
 

--- a/tests/test_chatgpt_action_architecture.py
+++ b/tests/test_chatgpt_action_architecture.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fossil_core.runtime.chatgpt_action_server import (
+    ChatGPTActionServerSettings,
+    build_chatgpt_action_adapter,
+)
+
+
+TOKEN = "architecture-token-0123456789abcdef"
+
+
+def root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def test_action_source_does_not_publish_private_protocols_or_projection_clients() -> None:
+    action = (root() / "src" / "fossil_core" / "runtime" / "chatgpt_action.py").read_text(
+        encoding="utf-8"
+    )
+    server = (
+        root() / "src" / "fossil_core" / "runtime" / "chatgpt_action_server.py"
+    ).read_text(encoding="utf-8")
+
+    assert '"/mcp"' not in action
+    assert '"/ingest"' not in action
+    assert "Graphiti" not in server
+    assert "neo4j" not in server.lower()
+    assert "DurableEventStore(" not in server
+    assert "proxy_headers=False" in server
+
+
+def test_read_only_adapter_exposes_no_mutation_methods(tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    (data_root / "canonical" / "events").mkdir(parents=True)
+    settings = ChatGPTActionServerSettings(
+        repository_root=root(),
+        data_root=data_root,
+        pack_manifest_path=Path("examples/packs/common/manifest.json"),
+        bearer_token=TOKEN,
+    )
+    adapter = build_chatgpt_action_adapter(settings)
+    store = adapter.service.event_store
+
+    assert {name for name in ("get", "iter_events", "is_redacted") if hasattr(store, name)} == {
+        "get",
+        "iter_events",
+        "is_redacted",
+    }
+    for forbidden in (
+        "commit",
+        "prepare",
+        "validate",
+        "redact",
+        "put",
+        "delete",
+        "write",
+        "publish",
+    ):
+        assert not hasattr(store, forbidden)
+
+
+def test_container_and_ci_encode_non_root_read_only_contract() -> None:
+    dockerfile = (root() / "docker" / "chatgpt-action" / "Dockerfile").read_text(
+        encoding="utf-8"
+    )
+    workflow = (
+        root() / ".github" / "workflows" / "chatgpt-action-container.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "useradd --uid 10001" in dockerfile
+    assert "USER fossil" in dockerfile
+    assert 'ENTRYPOINT ["fossil-chatgpt-action"]' in dockerfile
+    assert ":/var/lib/fossil:ro" in workflow
+    assert 'test "$(docker exec fossil-chatgpt-action id -u)" = "10001"' in workflow
+    assert "canonical mount unexpectedly writable" in workflow
+
+
+def test_no_real_secret_is_committed_to_action_package() -> None:
+    paths = [
+        root() / "config" / "chatgpt-action.env.example",
+        root() / "docker" / "chatgpt-action" / "Dockerfile",
+        root() / ".github" / "workflows" / "chatgpt-action-container.yml",
+        root() / "docs" / "operations" / "CHATGPT-ACTION-PDD.md",
+        root() / "docs" / "operations" / "CHATGPT-ACTION-SDD.md",
+    ]
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in paths)
+
+    assert "sk-" not in combined
+    assert "ghp_" not in combined
+    assert "-----BEGIN PRIVATE KEY-----" not in combined
+    assert TOKEN not in combined

--- a/tests/test_chatgpt_action_architecture.py
+++ b/tests/test_chatgpt_action_architecture.py
@@ -25,8 +25,10 @@ def test_action_source_does_not_publish_private_protocols_or_projection_clients(
 
     assert '"/mcp"' not in action
     assert '"/ingest"' not in action
-    assert "Graphiti" not in server
-    assert "neo4j" not in server.lower()
+    assert "from graphiti" not in server.lower()
+    assert "import graphiti" not in server.lower()
+    assert "from neo4j" not in server.lower()
+    assert "import neo4j" not in server.lower()
     assert "DurableEventStore(" not in server
     assert "proxy_headers=False" in server
 

--- a/tests/test_chatgpt_action_architecture.py
+++ b/tests/test_chatgpt_action_architecture.py
@@ -28,23 +28,27 @@ def imported_modules(path: Path) -> set[str]:
     return modules
 
 
-def test_action_route_allowlist_is_exact_and_write_tools_are_not_mapped() -> None:
+def test_action_route_allowlist_is_exact_and_write_or_lineage_tools_are_not_mapped() -> None:
     assert chatgpt_action._ACTION_ROUTE_ALLOWLIST == frozenset(
         {
             "/openapi.json",
             "/actions/search",
             "/actions/read",
-            "/actions/lineage",
             "/actions/capabilities",
         }
     )
     assert chatgpt_action._ACTION_PATHS == {
         "/actions/search": "fossil.search",
         "/actions/read": "fossil.read",
-        "/actions/lineage": "fossil.lineage",
     }
     assert set(chatgpt_action._ACTION_PATHS.values()).isdisjoint(
-        {"fossil.propose", "fossil.validate", "fossil.commit", "fossil.manage"}
+        {
+            "fossil.lineage",
+            "fossil.propose",
+            "fossil.validate",
+            "fossil.commit",
+            "fossil.manage",
+        }
     )
 
 
@@ -61,9 +65,11 @@ def test_standalone_server_does_not_import_projection_or_mutable_event_store() -
     source = server_path.read_text(encoding="utf-8")
     assert "DurableEventStore(" not in source
     assert "proxy_headers=False" in source
+    assert 'bucket.name == "_redactions"' in source
+    assert "self.is_redacted(event_id)" in source
 
 
-def test_read_only_adapter_exposes_no_mutation_methods(tmp_path: Path) -> None:
+def test_read_only_adapter_exposes_no_mutation_methods_or_lineage_provider(tmp_path: Path) -> None:
     data_root = tmp_path / "data"
     (data_root / "canonical" / "events").mkdir(parents=True)
     settings = ChatGPTActionServerSettings(
@@ -75,6 +81,7 @@ def test_read_only_adapter_exposes_no_mutation_methods(tmp_path: Path) -> None:
     adapter = build_chatgpt_action_adapter(settings)
     store = adapter.service.event_store
 
+    assert adapter.service.lineages == {}
     assert {name for name in ("get", "iter_events", "is_redacted") if hasattr(store, name)} == {
         "get",
         "iter_events",
@@ -91,6 +98,17 @@ def test_read_only_adapter_exposes_no_mutation_methods(tmp_path: Path) -> None:
         "publish",
     ):
         assert not hasattr(store, forbidden)
+
+
+def test_origin_and_streaming_guards_are_encoded_in_public_middleware() -> None:
+    source = (
+        root() / "src" / "fossil_core" / "runtime" / "chatgpt_action.py"
+    ).read_text(encoding="utf-8")
+    assert "request.url.scheme == \"https\"" not in source
+    assert "return self._trusted_proxy_origin(request)" in source
+    assert "async for chunk in request.stream():" in source
+    assert "total > self.max_request_body_size" in source
+    assert "await request.body()" not in source
 
 
 def test_container_and_ci_encode_non_root_loopback_read_only_contract() -> None:

--- a/tests/test_chatgpt_action_server.py
+++ b/tests/test_chatgpt_action_server.py
@@ -43,6 +43,7 @@ def test_settings_parse_secretless_runtime_configuration(tmp_path: Path) -> None
             "FOSSIL_ACTION_PORT": "8787",
             "FOSSIL_ACTION_MAX_REQUEST_BYTES": "32768",
             "FOSSIL_ACTION_PUBLIC_BASE_URL": "https://fossil.example.test/",
+            "FOSSIL_ACTION_TRUSTED_PROXY_CIDRS": "10.0.0.0/8, 192.168.65.1/32",
         }
     )
 
@@ -53,6 +54,7 @@ def test_settings_parse_secretless_runtime_configuration(tmp_path: Path) -> None
     assert parsed.port == 8787
     assert parsed.max_request_body_size == 32768
     assert parsed.public_base_url == "https://fossil.example.test"
+    assert parsed.trusted_proxy_cidrs == ("10.0.0.0/8", "192.168.65.1/32")
 
 
 def test_settings_fail_closed_for_invalid_runtime_configuration(tmp_path: Path) -> None:
@@ -94,13 +96,18 @@ def test_settings_fail_closed_for_invalid_runtime_configuration(tmp_path: Path) 
     for url in (
         "http://fossil.example.test",
         "https://",
+        "https://user:pass@fossil.example.test",
         "https://fossil.example.test/path",
+        "https://fossil.example.test?query=1",
     ):
         with pytest.raises(ValueError, match="origin-only https"):
             settings(tmp_path, public_base_url=url)
 
+    with pytest.raises(ValueError, match="invalid FOSSIL_ACTION_TRUSTED_PROXY_CIDRS"):
+        settings(tmp_path, trusted_proxy_cidrs=("not-a-cidr",))
 
-def test_standalone_adapter_bootstraps_without_neo4j(
+
+def test_standalone_adapter_bootstraps_empty_data_without_neo4j(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("NEO4J_PASSWORD", raising=False)
@@ -112,8 +119,15 @@ def test_standalone_adapter_bootstraps_without_neo4j(
     assert adapter.service.event_store.root == (
         tmp_path / "fossil-data" / "canonical" / "events"
     )
-    assert not hasattr(adapter.service.event_store, "commit")
-    assert not hasattr(adapter.service.event_store, "redact")
+    for mutation_method in (
+        "commit",
+        "prepare",
+        "validate",
+        "redact",
+        "put",
+        "delete",
+    ):
+        assert not hasattr(adapter.service.event_store, mutation_method)
 
 
 def test_standalone_adapter_requires_existing_canonical_store(tmp_path: Path) -> None:
@@ -129,14 +143,17 @@ def test_standalone_adapter_requires_existing_canonical_store(tmp_path: Path) ->
 
 
 def test_event_read_rejects_filesystem_escape_identifiers(tmp_path: Path) -> None:
-    app = create_chatgpt_action_app_from_settings(settings(tmp_path))
+    app = create_chatgpt_action_app_from_settings(
+        settings(tmp_path, public_base_url="https://fossil.example.test")
+    )
     headers = {"authorization": f"Bearer {TOKEN}"}
-    with TestClient(app) as client:
+    with TestClient(app, base_url="http://internal:8787") as client:
         for event_id in (
             "../../../../etc/passwd",
             "evt_../../../../etc/passwd",
             "evt_abcdefghijklmnop/../../secret",
             "C:\\Windows\\win.ini",
+            "file:///etc/passwd",
         ):
             response = client.post(
                 "/actions/read", headers=headers, json={"event_id": event_id}
@@ -145,28 +162,99 @@ def test_event_read_rejects_filesystem_escape_identifiers(tmp_path: Path) -> Non
             assert response.json()["error"]["code"] == "invalid_request"
 
 
-def test_deployed_action_app_exposes_only_read_edge(tmp_path: Path) -> None:
+def test_fixed_https_origin_overrides_all_forwarded_headers(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(
         settings(tmp_path, public_base_url="https://fossil.example.test")
     )
-
-    with TestClient(app, base_url="http://internal:8787") as client:
+    with TestClient(
+        app, base_url="http://internal:8787", client=("203.0.113.44", 50000)
+    ) as client:
         schema = client.get(
             "/openapi.json",
             headers={
-                "x-forwarded-proto": "http",
+                "x-forwarded-proto": "https",
                 "x-forwarded-host": "attacker.invalid",
             },
         )
         assert schema.status_code == 200
         assert schema.json()["servers"] == [{"url": "https://fossil.example.test"}]
-        assert set(schema.json()["paths"]) == {
-            "/actions/search",
-            "/actions/read",
-            "/actions/lineage",
-            "/actions/capabilities",
-        }
 
+
+def test_trusted_proxy_headers_generate_public_https_origin(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(
+        settings(tmp_path, trusted_proxy_cidrs=("10.0.0.0/8",))
+    )
+    with TestClient(
+        app, base_url="http://internal:8787", client=("10.20.30.40", 50000)
+    ) as client:
+        schema = client.get(
+            "/openapi.json",
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "fossil.example.test",
+            },
+        )
+        assert schema.status_code == 200
+        assert schema.json()["servers"] == [{"url": "https://fossil.example.test"}]
+
+
+def test_forged_or_incomplete_proxy_headers_never_publish_http_or_attacker_origin(
+    tmp_path: Path,
+) -> None:
+    app = create_chatgpt_action_app_from_settings(
+        settings(tmp_path, trusted_proxy_cidrs=("10.0.0.0/8",))
+    )
+
+    with TestClient(
+        app, base_url="http://internal:8787", client=("203.0.113.44", 50000)
+    ) as untrusted:
+        forged = untrusted.get(
+            "/openapi.json",
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "attacker.invalid",
+            },
+        )
+        assert forged.status_code == 503
+        assert "attacker.invalid" not in forged.text
+        assert "http://internal" not in forged.text
+
+    with TestClient(
+        app, base_url="http://internal:8787", client=("10.20.30.40", 50000)
+    ) as trusted:
+        for headers in (
+            {},
+            {"x-forwarded-proto": "http", "x-forwarded-host": "fossil.example.test"},
+            {"x-forwarded-proto": "https"},
+            {"x-forwarded-proto": "https", "x-forwarded-host": "bad host"},
+            {
+                "x-forwarded-proto": "https,http",
+                "x-forwarded-host": "fossil.example.test",
+            },
+            {
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "fossil.example.test,attacker.invalid",
+            },
+        ):
+            response = trusted.get("/openapi.json", headers=headers)
+            assert response.status_code == 503
+            assert "http://internal" not in response.text
+
+
+def test_direct_https_request_needs_no_proxy_headers(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(settings(tmp_path))
+    with TestClient(app, base_url="https://fossil.example.test") as client:
+        response = client.get("/openapi.json")
+        assert response.status_code == 200
+        assert response.json()["servers"] == [{"url": "https://fossil.example.test"}]
+
+
+def test_deployed_action_app_exposes_only_read_edge_and_empty_search(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(
+        settings(tmp_path, public_base_url="https://fossil.example.test")
+    )
+
+    with TestClient(app, base_url="http://internal:8787") as client:
         denied = client.post("/actions/search", json={"query": "FOSSIL"})
         assert denied.status_code == 401
 
@@ -195,17 +283,22 @@ def test_deployed_action_app_exposes_only_read_edge(tmp_path: Path) -> None:
             assert client.get(path, headers=headers).status_code == 404
 
 
-def test_container_contract_keeps_secret_runtime_only() -> None:
+def test_container_contract_keeps_secret_runtime_only_and_avoids_proxy_autotrust() -> None:
     dockerfile = (root() / "docker" / "chatgpt-action" / "Dockerfile").read_text(
         encoding="utf-8"
     )
     example = (root() / "config" / "chatgpt-action.env.example").read_text(
         encoding="utf-8"
     )
+    server = (
+        root() / "src" / "fossil_core" / "runtime" / "chatgpt_action_server.py"
+    ).read_text(encoding="utf-8")
 
     assert "FOSSIL_ACTION_BEARER_TOKEN=" not in dockerfile
     assert "USER fossil" in dockerfile
     assert 'ENTRYPOINT ["fossil-chatgpt-action"]' in dockerfile
     assert "replace-with-a-random-secret" in example
     assert "FOSSIL_ACTION_PUBLIC_BASE_URL=https://fossil-action.example.invalid" in example
+    assert "FOSSIL_ACTION_TRUSTED_PROXY_CIDRS=" in example
+    assert "proxy_headers=False" in server
     assert TOKEN not in example

--- a/tests/test_chatgpt_action_server.py
+++ b/tests/test_chatgpt_action_server.py
@@ -1,304 +1,364 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
+from fossil_core.runtime.chatgpt_action import add_chatgpt_action_api
 from fossil_core.runtime.chatgpt_action_server import (
     ChatGPTActionServerSettings,
     build_chatgpt_action_adapter,
+    create_chatgpt_action_app_from_environment,
     create_chatgpt_action_app_from_settings,
 )
 
 
-TOKEN = "a" * 48
+TOKEN = "server-test-token-0123456789abcdef"
+PUBLIC_ORIGIN = "https://fossil-action.example.test"
+COMMON = "pack_269099f7b2ba43b7a99b9427d64092de"
 
 
 def root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
-def settings(tmp_path: Path, **overrides) -> ChatGPTActionServerSettings:
-    data_root = tmp_path / "fossil-data"
+def settings(
+    tmp_path: Path,
+    *,
+    public_base_url: str | None = PUBLIC_ORIGIN,
+    trusted_proxy_cidrs: tuple[str, ...] = (),
+    max_bytes: int = 65536,
+) -> ChatGPTActionServerSettings:
+    data_root = tmp_path / "data"
     (data_root / "canonical" / "events").mkdir(parents=True, exist_ok=True)
-    values = {
-        "repository_root": root(),
-        "data_root": data_root,
-        "pack_manifest_path": Path("examples/packs/common/manifest.json"),
-        "bearer_token": TOKEN,
-    }
-    values.update(overrides)
-    return ChatGPTActionServerSettings(**values)
-
-
-def test_settings_parse_secretless_runtime_configuration(tmp_path: Path) -> None:
-    parsed = ChatGPTActionServerSettings.from_environment(
-        {
-            "FOSSIL_REPOSITORY_ROOT": str(root()),
-            "FOSSIL_DATA_ROOT": str(tmp_path / "data"),
-            "FOSSIL_PACK_MANIFEST": "examples/packs/common/manifest.json",
-            "FOSSIL_ACTION_BEARER_TOKEN": TOKEN,
-            "FOSSIL_ACTION_HOST": "0.0.0.0",
-            "FOSSIL_ACTION_PORT": "8787",
-            "FOSSIL_ACTION_MAX_REQUEST_BYTES": "32768",
-            "FOSSIL_ACTION_PUBLIC_BASE_URL": "https://fossil.example.test/",
-            "FOSSIL_ACTION_TRUSTED_PROXY_CIDRS": "10.0.0.0/8, 192.168.65.1/32",
-        }
-    )
-
-    assert parsed.repository_root == root()
-    assert parsed.data_root == tmp_path / "data"
-    assert parsed.pack_manifest_path == Path("examples/packs/common/manifest.json")
-    assert parsed.host == "0.0.0.0"
-    assert parsed.port == 8787
-    assert parsed.max_request_body_size == 32768
-    assert parsed.public_base_url == "https://fossil.example.test"
-    assert parsed.trusted_proxy_cidrs == ("10.0.0.0/8", "192.168.65.1/32")
-
-
-def test_settings_fail_closed_for_invalid_runtime_configuration(tmp_path: Path) -> None:
-    base = {
-        "FOSSIL_REPOSITORY_ROOT": str(root()),
-        "FOSSIL_DATA_ROOT": str(tmp_path / "data"),
-    }
-
-    with pytest.raises(ValueError, match="non-empty"):
-        ChatGPTActionServerSettings.from_environment(base)
-
-    with pytest.raises(ValueError, match="at least 32"):
-        ChatGPTActionServerSettings.from_environment(
-            {**base, "FOSSIL_ACTION_BEARER_TOKEN": "too-short"}
-        )
-
-    with pytest.raises(ValueError, match="PORT must be an integer"):
-        ChatGPTActionServerSettings.from_environment(
-            {
-                **base,
-                "FOSSIL_ACTION_BEARER_TOKEN": TOKEN,
-                "FOSSIL_ACTION_PORT": "not-a-port",
-            }
-        )
-
-    with pytest.raises(ValueError, match="MAX_REQUEST_BYTES must be an integer"):
-        ChatGPTActionServerSettings.from_environment(
-            {
-                **base,
-                "FOSSIL_ACTION_BEARER_TOKEN": TOKEN,
-                "FOSSIL_ACTION_MAX_REQUEST_BYTES": "not-a-number",
-            }
-        )
-
-    for value in (0, 1024 * 1024 + 1):
-        with pytest.raises(ValueError, match="between 1 and 1048576"):
-            settings(tmp_path, max_request_body_size=value)
-
-    for url in (
-        "http://fossil.example.test",
-        "https://",
-        "https://user:pass@fossil.example.test",
-        "https://fossil.example.test/path",
-        "https://fossil.example.test?query=1",
-    ):
-        with pytest.raises(ValueError, match="origin-only https"):
-            settings(tmp_path, public_base_url=url)
-
-    with pytest.raises(ValueError, match="invalid FOSSIL_ACTION_TRUSTED_PROXY_CIDRS"):
-        settings(tmp_path, trusted_proxy_cidrs=("not-a-cidr",))
-
-
-def test_standalone_adapter_bootstraps_empty_data_without_neo4j(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.delenv("NEO4J_PASSWORD", raising=False)
-    adapter = build_chatgpt_action_adapter(settings(tmp_path))
-
-    assert adapter.context.skill_id == "skill_corpus-search"
-    assert adapter.context.skill_version == "1.0.0"
-    assert adapter.invoke("fossil.search", {"query": "nothing-yet"}) == []
-    assert adapter.service.event_store.root == (
-        tmp_path / "fossil-data" / "canonical" / "events"
-    )
-    for mutation_method in (
-        "commit",
-        "prepare",
-        "validate",
-        "redact",
-        "put",
-        "delete",
-    ):
-        assert not hasattr(adapter.service.event_store, mutation_method)
-
-
-def test_standalone_adapter_requires_existing_canonical_store(tmp_path: Path) -> None:
-    configured = ChatGPTActionServerSettings(
+    return ChatGPTActionServerSettings(
         repository_root=root(),
-        data_root=tmp_path / "missing-data",
+        data_root=data_root,
         pack_manifest_path=Path("examples/packs/common/manifest.json"),
         bearer_token=TOKEN,
+        max_request_body_size=max_bytes,
+        public_base_url=public_base_url,
+        trusted_proxy_cidrs=trusted_proxy_cidrs,
     )
 
-    with pytest.raises(FileNotFoundError, match="canonical event store does not exist"):
-        build_chatgpt_action_adapter(configured)
+
+def auth() -> dict[str, str]:
+    return {"authorization": f"Bearer {TOKEN}"}
 
 
-def test_event_read_rejects_filesystem_escape_identifiers(tmp_path: Path) -> None:
-    app = create_chatgpt_action_app_from_settings(
-        settings(tmp_path, public_base_url="https://fossil.example.test")
+def write_event(data_root: Path, event_id: str, marker: str) -> dict:
+    suffix = event_id.removeprefix("evt_")
+    path = data_root / "canonical" / "events" / suffix[:2] / f"{event_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    event = {
+        "schema_version": "dkg.event.v1",
+        "event_id": event_id,
+        "event_type": "claim.proposed",
+        "occurred_at": "2026-08-20T12:00:00Z",
+        "recorded_at": "2026-08-20T12:00:00Z",
+        "pack_id": COMMON,
+        "actor": {"actor_type": "human", "actor_id": "fixture"},
+        "subject_refs": ["clm_fixture"],
+        "caused_by_event_ids": [],
+        "correlation_id": None,
+        "idempotency_key": f"fixture-{event_id}",
+        "evidence_refs": [],
+        "source_snapshot_refs": [],
+        "payload": {"claim_text": marker},
+    }
+    path.write_text(json.dumps(event), encoding="utf-8")
+    return event
+
+
+def write_redaction(data_root: Path, event_id: str, marker: str) -> None:
+    suffix = event_id.removeprefix("evt_")
+    path = (
+        data_root
+        / "canonical"
+        / "events"
+        / "_redactions"
+        / suffix[:2]
+        / f"{event_id}.json"
     )
-    headers = {"authorization": f"Bearer {TOKEN}"}
-    with TestClient(app, base_url="http://internal:8787") as client:
-        for event_id in (
-            "../../../../etc/passwd",
-            "evt_../../../../etc/passwd",
-            "evt_abcdefghijklmnop/../../secret",
-            "C:\\Windows\\win.ini",
-            "file:///etc/passwd",
-        ):
-            response = client.post(
-                "/actions/read", headers=headers, json={"event_id": event_id}
-            )
-            assert response.status_code == 400
-            assert response.json()["error"]["code"] == "invalid_request"
-
-
-def test_fixed_https_origin_overrides_all_forwarded_headers(tmp_path: Path) -> None:
-    app = create_chatgpt_action_app_from_settings(
-        settings(tmp_path, public_base_url="https://fossil.example.test")
-    )
-    with TestClient(
-        app, base_url="http://internal:8787", client=("203.0.113.44", 50000)
-    ) as client:
-        schema = client.get(
-            "/openapi.json",
-            headers={
-                "x-forwarded-proto": "https",
-                "x-forwarded-host": "attacker.invalid",
-            },
-        )
-        assert schema.status_code == 200
-        assert schema.json()["servers"] == [{"url": "https://fossil.example.test"}]
-
-
-def test_trusted_proxy_headers_generate_public_https_origin(tmp_path: Path) -> None:
-    app = create_chatgpt_action_app_from_settings(
-        settings(tmp_path, trusted_proxy_cidrs=("10.0.0.0/8",))
-    )
-    with TestClient(
-        app, base_url="http://internal:8787", client=("10.20.30.40", 50000)
-    ) as client:
-        schema = client.get(
-            "/openapi.json",
-            headers={
-                "x-forwarded-proto": "https",
-                "x-forwarded-host": "fossil.example.test",
-            },
-        )
-        assert schema.status_code == 200
-        assert schema.json()["servers"] == [{"url": "https://fossil.example.test"}]
-
-
-def test_forged_or_incomplete_proxy_headers_never_publish_http_or_attacker_origin(
-    tmp_path: Path,
-) -> None:
-    app = create_chatgpt_action_app_from_settings(
-        settings(tmp_path, trusted_proxy_cidrs=("10.0.0.0/8",))
-    )
-
-    with TestClient(
-        app, base_url="http://internal:8787", client=("203.0.113.44", 50000)
-    ) as untrusted:
-        forged = untrusted.get(
-            "/openapi.json",
-            headers={
-                "x-forwarded-proto": "https",
-                "x-forwarded-host": "attacker.invalid",
-            },
-        )
-        assert forged.status_code == 503
-        assert "attacker.invalid" not in forged.text
-        assert "http://internal" not in forged.text
-
-    with TestClient(
-        app, base_url="http://internal:8787", client=("10.20.30.40", 50000)
-    ) as trusted:
-        for headers in (
-            {},
-            {"x-forwarded-proto": "http", "x-forwarded-host": "fossil.example.test"},
-            {"x-forwarded-proto": "https"},
-            {"x-forwarded-proto": "https", "x-forwarded-host": "bad host"},
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
             {
-                "x-forwarded-proto": "https,http",
-                "x-forwarded-host": "fossil.example.test",
-            },
-            {
-                "x-forwarded-proto": "https",
-                "x-forwarded-host": "fossil.example.test,attacker.invalid",
-            },
-        ):
-            response = trusted.get("/openapi.json", headers=headers)
-            assert response.status_code == 503
-            assert "http://internal" not in response.text
-
-
-def test_direct_https_request_needs_no_proxy_headers(tmp_path: Path) -> None:
-    app = create_chatgpt_action_app_from_settings(settings(tmp_path))
-    with TestClient(app, base_url="https://fossil.example.test") as client:
-        response = client.get("/openapi.json")
-        assert response.status_code == 200
-        assert response.json()["servers"] == [{"url": "https://fossil.example.test"}]
-
-
-def test_deployed_action_app_exposes_only_read_edge_and_empty_search(tmp_path: Path) -> None:
-    app = create_chatgpt_action_app_from_settings(
-        settings(tmp_path, public_base_url="https://fossil.example.test")
+                "event_id": event_id,
+                "pack_id": COMMON,
+                "redacted_at": "2026-08-20T12:30:00Z",
+                "reason": marker,
+                "authority": "fixture",
+            }
+        ),
+        encoding="utf-8",
     )
 
-    with TestClient(app, base_url="http://internal:8787") as client:
-        denied = client.post("/actions/search", json={"query": "FOSSIL"})
-        assert denied.status_code == 401
 
-        headers = {"authorization": f"Bearer {TOKEN}"}
-        searched = client.post(
-            "/actions/search", headers=headers, json={"query": "FOSSIL"}
+def test_settings_from_environment_and_validation(tmp_path: Path):
+    env = {
+        "FOSSIL_REPOSITORY_ROOT": str(root()),
+        "FOSSIL_DATA_ROOT": str(tmp_path / "data"),
+        "FOSSIL_PACK_MANIFEST": "examples/packs/common/manifest.json",
+        "FOSSIL_ACTION_BEARER_TOKEN": TOKEN,
+        "FOSSIL_ACTION_HOST": "0.0.0.0",
+        "FOSSIL_ACTION_PORT": "8787",
+        "FOSSIL_ACTION_MAX_REQUEST_BYTES": "65536",
+        "FOSSIL_ACTION_PUBLIC_BASE_URL": PUBLIC_ORIGIN,
+        "FOSSIL_ACTION_TRUSTED_PROXY_CIDRS": "172.30.1.10/32,10.0.0.0/8",
+    }
+    parsed = ChatGPTActionServerSettings.from_environment(env)
+    assert parsed.host == "0.0.0.0"
+    assert parsed.port == 8787
+    assert parsed.max_request_body_size == 65536
+    assert parsed.public_base_url == PUBLIC_ORIGIN
+    assert parsed.trusted_proxy_cidrs == ("172.30.1.10/32", "10.0.0.0/8")
+
+    with pytest.raises(ValueError):
+        ChatGPTActionServerSettings.from_environment({**env, "FOSSIL_ACTION_PORT": "bad"})
+    with pytest.raises(ValueError):
+        ChatGPTActionServerSettings.from_environment(
+            {**env, "FOSSIL_ACTION_PUBLIC_BASE_URL": "http://example.test"}
         )
-        assert searched.status_code == 200
-        assert searched.json() == []
+    with pytest.raises(ValueError):
+        ChatGPTActionServerSettings.from_environment(
+            {**env, "FOSSIL_ACTION_TRUSTED_PROXY_CIDRS": "0.0.0.0/not-a-prefix"}
+        )
 
-        capabilities = client.get("/actions/capabilities", headers=headers)
+
+def test_standalone_adapter_is_read_only_and_has_no_lineage_provider(tmp_path: Path):
+    configured = settings(tmp_path)
+    adapter = build_chatgpt_action_adapter(configured)
+
+    assert adapter.service.lineages == {}
+    store = adapter.service.event_store
+    assert hasattr(store, "get") and hasattr(store, "iter_events")
+    for forbidden in ("commit", "prepare", "validate", "redact", "put", "delete", "write"):
+        assert not hasattr(store, forbidden)
+
+    app = create_chatgpt_action_app_from_settings(configured)
+    with TestClient(app, base_url="http://internal:8787") as client:
+        schema = client.get("/openapi.json")
+        assert schema.status_code == 200
+        assert set(schema.json()["paths"]) == {
+            "/actions/search",
+            "/actions/read",
+            "/actions/capabilities",
+        }
+        assert "/actions/lineage" not in schema.json()["paths"]
+
+        capabilities = client.get("/actions/capabilities", headers=auth())
         assert capabilities.status_code == 200
-        assert capabilities.json()["durable_writes_exposed"] is False
+        assert capabilities.json()["action_capabilities"] == ["search", "read"]
 
-        for path in (
-            "/mcp",
-            "/ingest",
-            "/actions/propose",
-            "/actions/validate",
-            "/actions/commit",
-            "/actions/redact",
-            "/neo4j",
-            "/graph",
-            "/filesystem",
-        ):
-            assert client.get(path, headers=headers).status_code == 404
+        lineage = client.post(
+            "/actions/lineage",
+            headers=auth(),
+            json={"conversation_id": "conv_abcdefghijklmnop"},
+        )
+        assert lineage.status_code == 404
 
 
-def test_container_contract_keeps_secret_runtime_only_and_avoids_proxy_autotrust() -> None:
-    dockerfile = (root() / "docker" / "chatgpt-action" / "Dockerfile").read_text(
-        encoding="utf-8"
+def test_empty_canonical_store_returns_empty_search(tmp_path: Path):
+    app = create_chatgpt_action_app_from_settings(settings(tmp_path))
+    with TestClient(app, base_url="http://internal:8787") as client:
+        response = client.post(
+            "/actions/search", headers=auth(), json={"query": "anything"}
+        )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_redacted_event_and_tombstone_never_cross_search_or_read_boundary(tmp_path: Path):
+    configured = settings(tmp_path)
+    redacted_id = "evt_aaaaaaaaaaaaaaaa"
+    visible_id = "evt_bbbbbbbbbbbbbbbb"
+    write_event(configured.data_root, redacted_id, "redacted-payload-marker")
+    write_event(configured.data_root, visible_id, "visible-payload-marker")
+    write_redaction(configured.data_root, redacted_id, "tombstone-only-marker")
+
+    app = create_chatgpt_action_app_from_settings(configured)
+    with TestClient(app, base_url="http://internal:8787") as client:
+        redacted_payload_search = client.post(
+            "/actions/search",
+            headers=auth(),
+            json={"query": "redacted-payload-marker"},
+        )
+        tombstone_search = client.post(
+            "/actions/search",
+            headers=auth(),
+            json={"query": "tombstone-only-marker"},
+        )
+        visible_search = client.post(
+            "/actions/search",
+            headers=auth(),
+            json={"query": "visible-payload-marker"},
+        )
+        redacted_read = client.post(
+            "/actions/read", headers=auth(), json={"event_id": redacted_id}
+        )
+
+    assert redacted_payload_search.status_code == 200
+    assert redacted_payload_search.json() == []
+    assert tombstone_search.status_code == 200
+    assert tombstone_search.json() == []
+    assert visible_search.status_code == 200
+    assert [item["event_id"] for item in visible_search.json()] == [visible_id]
+    assert redacted_read.status_code == 404
+    assert "redact" not in redacted_read.text.lower()
+    assert "tombstone-only-marker" not in redacted_read.text
+
+
+def test_direct_https_host_is_not_an_origin_authority(tmp_path: Path):
+    configured = settings(tmp_path, public_base_url=None)
+    app = create_chatgpt_action_app_from_settings(configured)
+    with TestClient(
+        app,
+        base_url="https://attacker-controlled.example",
+        client=("203.0.113.80", 50000),
+    ) as client:
+        response = client.get(
+            "/openapi.json",
+            headers={"host": "attacker-controlled.example"},
+        )
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "https_origin_required"
+    assert "attacker-controlled.example" not in response.text
+
+
+def test_trusted_proxy_https_origin_is_accepted_and_untrusted_forgery_is_not(tmp_path: Path):
+    configured = settings(
+        tmp_path,
+        public_base_url=None,
+        trusted_proxy_cidrs=("10.0.0.0/8",),
     )
-    example = (root() / "config" / "chatgpt-action.env.example").read_text(
-        encoding="utf-8"
-    )
-    server = (
-        root() / "src" / "fossil_core" / "runtime" / "chatgpt_action_server.py"
-    ).read_text(encoding="utf-8")
+    app = create_chatgpt_action_app_from_settings(configured)
 
-    assert "FOSSIL_ACTION_BEARER_TOKEN=" not in dockerfile
-    assert "USER fossil" in dockerfile
-    assert 'ENTRYPOINT ["fossil-chatgpt-action"]' in dockerfile
-    assert "replace-with-a-random-secret" in example
-    assert "FOSSIL_ACTION_PUBLIC_BASE_URL=https://fossil-action.example.invalid" in example
-    assert "FOSSIL_ACTION_TRUSTED_PROXY_CIDRS=" in example
-    assert "proxy_headers=False" in server
-    assert TOKEN not in example
+    with TestClient(
+        app,
+        base_url="http://internal:8787",
+        client=("10.1.2.3", 50000),
+    ) as trusted:
+        good = trusted.get(
+            "/openapi.json",
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "public.example.test",
+            },
+        )
+    assert good.status_code == 200
+    assert good.json()["servers"] == [{"url": "https://public.example.test"}]
+
+    with TestClient(
+        app,
+        base_url="http://internal:8787",
+        client=("203.0.113.80", 50000),
+    ) as untrusted:
+        bad = untrusted.get(
+            "/openapi.json",
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "attacker.invalid",
+            },
+        )
+    assert bad.status_code == 503
+    assert "attacker.invalid" not in bad.text
+
+
+class CountingAdapter:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.service = SimpleNamespace(service_version="test")
+
+    def invoke(self, tool_name: str, arguments: dict):
+        self.calls += 1
+        return []
+
+
+def streamed_app(adapter: CountingAdapter) -> Starlette:
+    return add_chatgpt_action_api(
+        Starlette(),
+        adapter=adapter,
+        bearer_token=TOKEN,
+        max_request_body_size=64,
+        public_base_url=PUBLIC_ORIGIN,
+    )
+
+
+@pytest.mark.parametrize(
+    "extra_headers",
+    [
+        {"transfer-encoding": "chunked"},
+        {"content-length": "10"},
+    ],
+)
+def test_streaming_limit_rejects_chunked_or_underdeclared_body_before_adapter(
+    extra_headers: dict[str, str],
+) -> None:
+    adapter = CountingAdapter()
+    app = streamed_app(adapter)
+
+    def chunks():
+        yield b'{"query":"'
+        yield b"x" * 40
+        yield b"y" * 40
+        yield b'"}'
+
+    with TestClient(app, base_url="http://internal:8787") as client:
+        response = client.post(
+            "/actions/search",
+            headers={**auth(), **extra_headers, "content-type": "application/json"},
+            content=chunks(),
+        )
+
+    assert response.status_code == 413
+    assert response.json()["error"]["code"] == "request_too_large"
+    assert adapter.calls == 0
+
+
+def test_declared_oversize_is_rejected_before_adapter(tmp_path: Path) -> None:
+    adapter = CountingAdapter()
+    app = streamed_app(adapter)
+    with TestClient(app, base_url="http://internal:8787") as client:
+        response = client.post(
+            "/actions/search",
+            headers={
+                **auth(),
+                "content-type": "application/json",
+                "content-length": "9999",
+            },
+            content=b'{"query":"x"}',
+        )
+    assert response.status_code == 413
+    assert adapter.calls == 0
+
+
+def test_environment_composition_uses_same_hardened_app(tmp_path: Path):
+    data_root = tmp_path / "data"
+    (data_root / "canonical" / "events").mkdir(parents=True)
+    env = {
+        "FOSSIL_REPOSITORY_ROOT": str(root()),
+        "FOSSIL_DATA_ROOT": str(data_root),
+        "FOSSIL_PACK_MANIFEST": "examples/packs/common/manifest.json",
+        "FOSSIL_ACTION_BEARER_TOKEN": TOKEN,
+        "FOSSIL_ACTION_PUBLIC_BASE_URL": PUBLIC_ORIGIN,
+    }
+    app = create_chatgpt_action_app_from_environment(env)
+    with TestClient(app, base_url="http://internal:8787") as client:
+        schema = client.get("/openapi.json")
+        empty = client.post(
+            "/actions/search", headers=auth(), json={"query": "nothing"}
+        )
+        lineage = client.post(
+            "/actions/lineage",
+            headers=auth(),
+            json={"conversation_id": "conv_abcdefghijklmnop"},
+        )
+    assert schema.status_code == 200
+    assert "/actions/lineage" not in schema.json()["paths"]
+    assert empty.status_code == 200 and empty.json() == []
+    assert lineage.status_code == 404

--- a/tests/test_chatgpt_action_server.py
+++ b/tests/test_chatgpt_action_server.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from fossil_core.runtime.chatgpt_action_server import (
+    ChatGPTActionServerSettings,
+    build_chatgpt_action_adapter,
+    create_chatgpt_action_app_from_settings,
+)
+
+
+TOKEN = "a" * 48
+
+
+def root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def settings(tmp_path: Path) -> ChatGPTActionServerSettings:
+    return ChatGPTActionServerSettings(
+        repository_root=root(),
+        data_root=tmp_path / "fossil-data",
+        pack_manifest_path=Path("examples/packs/common/manifest.json"),
+        bearer_token=TOKEN,
+    )
+
+
+def test_settings_parse_secretless_runtime_configuration(tmp_path: Path) -> None:
+    parsed = ChatGPTActionServerSettings.from_environment(
+        {
+            "FOSSIL_REPOSITORY_ROOT": str(root()),
+            "FOSSIL_DATA_ROOT": str(tmp_path / "data"),
+            "FOSSIL_PACK_MANIFEST": "examples/packs/common/manifest.json",
+            "FOSSIL_ACTION_BEARER_TOKEN": TOKEN,
+            "FOSSIL_ACTION_HOST": "0.0.0.0",
+            "FOSSIL_ACTION_PORT": "8787",
+        }
+    )
+
+    assert parsed.repository_root == root()
+    assert parsed.data_root == tmp_path / "data"
+    assert parsed.pack_manifest_path == Path("examples/packs/common/manifest.json")
+    assert parsed.host == "0.0.0.0"
+    assert parsed.port == 8787
+
+
+def test_settings_fail_closed_without_strong_runtime_token(tmp_path: Path) -> None:
+    base = {
+        "FOSSIL_REPOSITORY_ROOT": str(root()),
+        "FOSSIL_DATA_ROOT": str(tmp_path / "data"),
+    }
+
+    with pytest.raises(ValueError, match="non-empty"):
+        ChatGPTActionServerSettings.from_environment(base)
+
+    with pytest.raises(ValueError, match="at least 32"):
+        ChatGPTActionServerSettings.from_environment(
+            {**base, "FOSSIL_ACTION_BEARER_TOKEN": "too-short"}
+        )
+
+    with pytest.raises(ValueError, match="integer"):
+        ChatGPTActionServerSettings.from_environment(
+            {
+                **base,
+                "FOSSIL_ACTION_BEARER_TOKEN": TOKEN,
+                "FOSSIL_ACTION_PORT": "not-a-port",
+            }
+        )
+
+
+def test_standalone_adapter_bootstraps_without_neo4j(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("NEO4J_PASSWORD", raising=False)
+    adapter = build_chatgpt_action_adapter(settings(tmp_path))
+
+    assert adapter.context.skill_id == "skill_corpus-search"
+    assert adapter.context.skill_version == "1.0.0"
+    assert adapter.invoke("fossil.search", {"query": "nothing-yet"}) == []
+    assert (tmp_path / "fossil-data" / "canonical" / "events").is_dir()
+
+
+def test_deployed_action_app_exposes_only_read_edge(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(settings(tmp_path))
+
+    with TestClient(app, base_url="http://localhost") as client:
+        schema = client.get("/openapi.json")
+        assert schema.status_code == 200
+        assert set(schema.json()["paths"]) == {
+            "/actions/search",
+            "/actions/read",
+            "/actions/lineage",
+            "/actions/capabilities",
+        }
+
+        denied = client.post("/actions/search", json={"query": "FOSSIL"})
+        assert denied.status_code == 401
+
+        headers = {"authorization": f"Bearer {TOKEN}"}
+        searched = client.post(
+            "/actions/search", headers=headers, json={"query": "FOSSIL"}
+        )
+        assert searched.status_code == 200
+        assert searched.json() == []
+
+        capabilities = client.get("/actions/capabilities", headers=headers)
+        assert capabilities.status_code == 200
+        assert capabilities.json()["durable_writes_exposed"] is False
+
+        assert client.get("/mcp").status_code == 404
+        assert client.post("/ingest", headers=headers, json={}).status_code == 404
+        assert client.post("/actions/commit", headers=headers, json={}).status_code == 404
+
+
+def test_container_contract_keeps_secret_runtime_only() -> None:
+    dockerfile = (root() / "docker" / "chatgpt-action" / "Dockerfile").read_text(
+        encoding="utf-8"
+    )
+    example = (root() / "config" / "chatgpt-action.env.example").read_text(
+        encoding="utf-8"
+    )
+
+    assert "FOSSIL_ACTION_BEARER_TOKEN=" not in dockerfile
+    assert "USER fossil" in dockerfile
+    assert 'ENTRYPOINT ["fossil-chatgpt-action"]' in dockerfile
+    assert "replace-with-a-random-secret" in example
+    assert TOKEN not in example

--- a/tests/test_chatgpt_action_server.py
+++ b/tests/test_chatgpt_action_server.py
@@ -19,15 +19,17 @@ def root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
-def settings(tmp_path: Path) -> ChatGPTActionServerSettings:
+def settings(tmp_path: Path, **overrides) -> ChatGPTActionServerSettings:
     data_root = tmp_path / "fossil-data"
     (data_root / "canonical" / "events").mkdir(parents=True, exist_ok=True)
-    return ChatGPTActionServerSettings(
-        repository_root=root(),
-        data_root=data_root,
-        pack_manifest_path=Path("examples/packs/common/manifest.json"),
-        bearer_token=TOKEN,
-    )
+    values = {
+        "repository_root": root(),
+        "data_root": data_root,
+        "pack_manifest_path": Path("examples/packs/common/manifest.json"),
+        "bearer_token": TOKEN,
+    }
+    values.update(overrides)
+    return ChatGPTActionServerSettings(**values)
 
 
 def test_settings_parse_secretless_runtime_configuration(tmp_path: Path) -> None:
@@ -39,6 +41,8 @@ def test_settings_parse_secretless_runtime_configuration(tmp_path: Path) -> None
             "FOSSIL_ACTION_BEARER_TOKEN": TOKEN,
             "FOSSIL_ACTION_HOST": "0.0.0.0",
             "FOSSIL_ACTION_PORT": "8787",
+            "FOSSIL_ACTION_MAX_REQUEST_BYTES": "32768",
+            "FOSSIL_ACTION_PUBLIC_BASE_URL": "https://fossil.example.test/",
         }
     )
 
@@ -47,9 +51,11 @@ def test_settings_parse_secretless_runtime_configuration(tmp_path: Path) -> None
     assert parsed.pack_manifest_path == Path("examples/packs/common/manifest.json")
     assert parsed.host == "0.0.0.0"
     assert parsed.port == 8787
+    assert parsed.max_request_body_size == 32768
+    assert parsed.public_base_url == "https://fossil.example.test"
 
 
-def test_settings_fail_closed_without_strong_runtime_token(tmp_path: Path) -> None:
+def test_settings_fail_closed_for_invalid_runtime_configuration(tmp_path: Path) -> None:
     base = {
         "FOSSIL_REPOSITORY_ROOT": str(root()),
         "FOSSIL_DATA_ROOT": str(tmp_path / "data"),
@@ -63,7 +69,7 @@ def test_settings_fail_closed_without_strong_runtime_token(tmp_path: Path) -> No
             {**base, "FOSSIL_ACTION_BEARER_TOKEN": "too-short"}
         )
 
-    with pytest.raises(ValueError, match="integer"):
+    with pytest.raises(ValueError, match="PORT must be an integer"):
         ChatGPTActionServerSettings.from_environment(
             {
                 **base,
@@ -71,6 +77,27 @@ def test_settings_fail_closed_without_strong_runtime_token(tmp_path: Path) -> No
                 "FOSSIL_ACTION_PORT": "not-a-port",
             }
         )
+
+    with pytest.raises(ValueError, match="MAX_REQUEST_BYTES must be an integer"):
+        ChatGPTActionServerSettings.from_environment(
+            {
+                **base,
+                "FOSSIL_ACTION_BEARER_TOKEN": TOKEN,
+                "FOSSIL_ACTION_MAX_REQUEST_BYTES": "not-a-number",
+            }
+        )
+
+    for value in (0, 1024 * 1024 + 1):
+        with pytest.raises(ValueError, match="between 1 and 1048576"):
+            settings(tmp_path, max_request_body_size=value)
+
+    for url in (
+        "http://fossil.example.test",
+        "https://",
+        "https://fossil.example.test/path",
+    ):
+        with pytest.raises(ValueError, match="origin-only https"):
+            settings(tmp_path, public_base_url=url)
 
 
 def test_standalone_adapter_bootstraps_without_neo4j(
@@ -101,12 +128,38 @@ def test_standalone_adapter_requires_existing_canonical_store(tmp_path: Path) ->
         build_chatgpt_action_adapter(configured)
 
 
-def test_deployed_action_app_exposes_only_read_edge(tmp_path: Path) -> None:
+def test_event_read_rejects_filesystem_escape_identifiers(tmp_path: Path) -> None:
     app = create_chatgpt_action_app_from_settings(settings(tmp_path))
+    headers = {"authorization": f"Bearer {TOKEN}"}
+    with TestClient(app) as client:
+        for event_id in (
+            "../../../../etc/passwd",
+            "evt_../../../../etc/passwd",
+            "evt_abcdefghijklmnop/../../secret",
+            "C:\\Windows\\win.ini",
+        ):
+            response = client.post(
+                "/actions/read", headers=headers, json={"event_id": event_id}
+            )
+            assert response.status_code == 400
+            assert response.json()["error"]["code"] == "invalid_request"
 
-    with TestClient(app, base_url="http://localhost") as client:
-        schema = client.get("/openapi.json")
+
+def test_deployed_action_app_exposes_only_read_edge(tmp_path: Path) -> None:
+    app = create_chatgpt_action_app_from_settings(
+        settings(tmp_path, public_base_url="https://fossil.example.test")
+    )
+
+    with TestClient(app, base_url="http://internal:8787") as client:
+        schema = client.get(
+            "/openapi.json",
+            headers={
+                "x-forwarded-proto": "http",
+                "x-forwarded-host": "attacker.invalid",
+            },
+        )
         assert schema.status_code == 200
+        assert schema.json()["servers"] == [{"url": "https://fossil.example.test"}]
         assert set(schema.json()["paths"]) == {
             "/actions/search",
             "/actions/read",
@@ -128,9 +181,18 @@ def test_deployed_action_app_exposes_only_read_edge(tmp_path: Path) -> None:
         assert capabilities.status_code == 200
         assert capabilities.json()["durable_writes_exposed"] is False
 
-        assert client.get("/mcp").status_code == 404
-        assert client.post("/ingest", headers=headers, json={}).status_code == 404
-        assert client.post("/actions/commit", headers=headers, json={}).status_code == 404
+        for path in (
+            "/mcp",
+            "/ingest",
+            "/actions/propose",
+            "/actions/validate",
+            "/actions/commit",
+            "/actions/redact",
+            "/neo4j",
+            "/graph",
+            "/filesystem",
+        ):
+            assert client.get(path, headers=headers).status_code == 404
 
 
 def test_container_contract_keeps_secret_runtime_only() -> None:
@@ -145,4 +207,5 @@ def test_container_contract_keeps_secret_runtime_only() -> None:
     assert "USER fossil" in dockerfile
     assert 'ENTRYPOINT ["fossil-chatgpt-action"]' in dockerfile
     assert "replace-with-a-random-secret" in example
+    assert "FOSSIL_ACTION_PUBLIC_BASE_URL=https://fossil-action.example.invalid" in example
     assert TOKEN not in example

--- a/tests/test_chatgpt_action_server.py
+++ b/tests/test_chatgpt_action_server.py
@@ -20,9 +20,11 @@ def root() -> Path:
 
 
 def settings(tmp_path: Path) -> ChatGPTActionServerSettings:
+    data_root = tmp_path / "fossil-data"
+    (data_root / "canonical" / "events").mkdir(parents=True, exist_ok=True)
     return ChatGPTActionServerSettings(
         repository_root=root(),
-        data_root=tmp_path / "fossil-data",
+        data_root=data_root,
         pack_manifest_path=Path("examples/packs/common/manifest.json"),
         bearer_token=TOKEN,
     )
@@ -80,7 +82,23 @@ def test_standalone_adapter_bootstraps_without_neo4j(
     assert adapter.context.skill_id == "skill_corpus-search"
     assert adapter.context.skill_version == "1.0.0"
     assert adapter.invoke("fossil.search", {"query": "nothing-yet"}) == []
-    assert (tmp_path / "fossil-data" / "canonical" / "events").is_dir()
+    assert adapter.service.event_store.root == (
+        tmp_path / "fossil-data" / "canonical" / "events"
+    )
+    assert not hasattr(adapter.service.event_store, "commit")
+    assert not hasattr(adapter.service.event_store, "redact")
+
+
+def test_standalone_adapter_requires_existing_canonical_store(tmp_path: Path) -> None:
+    configured = ChatGPTActionServerSettings(
+        repository_root=root(),
+        data_root=tmp_path / "missing-data",
+        pack_manifest_path=Path("examples/packs/common/manifest.json"),
+        bearer_token=TOKEN,
+    )
+
+    with pytest.raises(FileNotFoundError, match="canonical event store does not exist"):
+        build_chatgpt_action_adapter(configured)
 
 
 def test_deployed_action_app_exposes_only_read_edge(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds a bounded, bearer-authenticated, read-only ChatGPT Custom GPT Action compatibility edge plus a secretless Windows/Docker Desktop deployment package over the existing FOSSIL `ThinMCPAdapter` / `CorpusService` boundary.

Public discovery is only `GET /openapi.json`. Bearer-protected Action operations are only:

- `POST /actions/search`
- `POST /actions/read`
- `GET /actions/capabilities`

The standalone Action intentionally does **not** advertise `/actions/lineage`: the current standalone `CorpusService` composition has no durable lineage provider, so lineage remains available only through correctly configured FOSSIL domain/MCP boundaries until a real read-only provider is added and tested end-to-end.

Security/release hardening in the current revision includes:

- `_redactions` tombstones are excluded from normal search, and any event with a tombstone is suppressed even if stale event bytes remain;
- redacted reads return bounded generic 404 behavior without tombstone metadata;
- request bodies are bounded while streaming, covering chunked, absent, and understated `Content-Length` cases before adapter invocation;
- OpenAPI origin generation accepts only a fixed HTTPS public origin or validated forwarded HTTPS origin from an explicitly trusted proxy CIDR; direct HTTPS `Host` is not authority;
- `/mcp`, `/ingest`, proposal/validation/commit/redaction/write/admin, graph/Neo4j mutation/query, arbitrary filesystem, and shell routes remain unavailable;
- OpenAPI 3.1 keeps non-empty `components.schemas`, explicit response properties, and a truthful search/read/capabilities surface;
- the production image runs non-root, canonical data is mounted read-only, and Docker Desktop publication is loopback-only.

## Target environment

Windows + Docker Desktop WSL 2 Linux engine. Persistent source/data/local secret material remains under `D:\FossilBrokerWorker\chatgpt-action\`; Podman and Linux-native systemd are not required. No real bearer secret, tunnel/provider credential, DNS/TLS change, or Custom GPT credential is created or handled by this PR.

## Verification

Exact correction head: `4deefec2a003c5382d0ef13ddb62db4838832ab6`.

- DKG contract tests: PASS — run `32391455576`.
- ChatGPT Action container: PASS — run `32391455827`; includes non-root/loopback/read-only checks, redaction negative control, route isolation, fixed-origin forgery resistance, and trusted-proxy HTTPS smoke.
- Dependency integrity: PASS — run `32391455749`; vulnerability scan, reproducible install/pyproject consistency, and architecture boundaries all pass.
- ChatGPT Action mutation assurance: PASS — run `32391455655`; **21 killed / 0 survived / 0 harness errors**.

The mutation set explicitly covers lineage reintroduction, redaction-path/event re-inclusion, streaming-size-check removal, and direct-HTTPS Host trust in addition to the original auth/route/write/container/OpenAPI mutants.

Design and verification package lives under `docs/operations/CHATGPT-ACTION*.md`.

Tracks #231 and coordination task `FOSSIL-CHATGPT-ACTION-FIXES` in #94. This PR remains draft, unmerged, and undeployed.