### PR TITLE
Add Bearer authentication to public MCP edge

### DIFF
--- a/.github/workflows/public-mcp-assurance.yml
+++ b/.github/workflows/public-mcp-assurance.yml
@@ -1,0 +1,34 @@
+name: Public MCP assurance
+
+on:
+  pull_request:
+    paths:
+      - "src/fossil_core/runtime/network.py"
+      - "tests/test_fossil_node_network.py"
+      - "tests/holdout/test_public_mcp_holdout.py"
+      - "scripts/run_public_mcp_mutations.py"
+      - "scripts/verify_public_mcp_edge.py"
+      - "docs/operations/PUBLIC-MCP*.md"
+      - "config/fossil-mcp.env.example"
+      - ".github/workflows/public-mcp-assurance.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  assurance:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install secretless test dependencies
+        run: python -m pip install -e '.[test]'
+      - name: Public MCP holdout
+        run: pytest -q tests/holdout/test_public_mcp_holdout.py tests/test_fossil_node_network.py
+      - name: Targeted mutation assurance
+        run: python scripts/run_public_mcp_mutations.py

--- a/config/fossil-mcp.env.example
+++ b/config/fossil-mcp.env.example
@@ -1,0 +1,5 @@
+# Host-local configuration for the generic public FOSSIL MCP edge.
+# Copy this file outside Git and replace the placeholder locally.
+# Never commit a populated copy or print the token in logs, issues, or CI output.
+
+FOSSIL_MCP_BEARER_TOKEN=replace-with-a-random-secret-of-at-least-32-characters

--- a/docs/operations/PUBLIC-MCP-INVARIANTS.md
+++ b/docs/operations/PUBLIC-MCP-INVARIANTS.md
@@ -1,0 +1,87 @@
+# Public MCP requirements and invariants
+
+This document is the assurance contract for the generic public FOSSIL MCP edge in issue #231.
+
+## Required external shape
+
+```text
+Any MCP-capable client
+        |
+        | HTTPS + Authorization: Bearer <API_TOKEN>
+        v
+https://fossil.design-bakery.com/mcp
+        |
+        v
+local FOSSIL MCP server -> ThinMCPAdapter -> CorpusService
+```
+
+The edge is client-agnostic. It is not a ChatGPT Action, OpenAPI service, or OpenAI-specific integration.
+
+## Invariants
+
+1. **HTTPS only.** The external acceptance URL is `https://fossil.design-bakery.com/mcp`.
+2. **Authentication precedes MCP parsing and tool dispatch.** Missing, malformed, duplicate, or incorrect bearer credentials fail with a generic `401` and must not reach a tool.
+3. **The bearer token is authentication, not semantic authorization.** Pack scope, Skill capabilities, actor provenance, proposal validation, and durable commit rules remain enforced by FOSSIL after authentication.
+4. **Real MCP transport only.** `/mcp` speaks the pinned MCP Streamable HTTP protocol; no REST/OpenAPI compatibility layer is required.
+5. **Bounded requests.** The MCP request-body limit remains active for authenticated callers. Authentication also runs before parsing an unauthenticated oversized or malformed request.
+6. **Explicit public-host transport security.** Keep the MCP SDK `host` value loopback (`127.0.0.1`) and explicitly configure `TransportSecuritySettings` for the public hostname. Do not work around HTTP 421 by setting the SDK `host` argument to the public hostname without an explicit Host/Origin policy.
+7. **Public routing is MCP-only.** The internet-facing tunnel/reverse proxy routes `/mcp`; `/healthz`, `/readyz`, and `/ingest` remain local/private operational routes even though they exist on the node application.
+8. **No graph/admin escape.** No arbitrary Neo4j/Cypher, graph mutation, filesystem, shell, admin, OpenAPI, or `/actions/*` route is part of the public MCP contract.
+9. **Secrets stay local.** The real token is never committed, logged, returned in errors, written into CI artifacts, or supplied on a command line.
+10. **Canonical FOSSIL semantics survive the network edge.** Existing redaction, pack isolation, lifecycle, lineage, proposal/validation/commit, and projection-outage invariants remain authoritative.
+
+## Public-host configuration
+
+For a reverse proxy that preserves the public `Host` header, configure the MCP SDK explicitly:
+
+```python
+from mcp.server.transport_security import TransportSecuritySettings
+
+security = TransportSecuritySettings(
+    enable_dns_rebinding_protection=True,
+    allowed_hosts=[
+        "fossil.design-bakery.com",
+        "fossil.design-bakery.com:*",
+    ],
+    allowed_origins=[],
+)
+
+app = create_node_network_app(
+    node,
+    context=context,
+    bearer_token=token,
+    host="127.0.0.1",
+    transport_security=security,
+)
+```
+
+The public MCP clients in the current target are non-browser clients, so they do not need an `Origin` header. If browser-origin access is deliberately added later, its origins must be explicitly reviewed and allowlisted rather than using a wildcard.
+
+## Cloud/CI assurance
+
+`tests/holdout/test_public_mcp_holdout.py` exercises:
+
+- absent/malformed/wrong/duplicate bearer credentials;
+- token non-reflection;
+- public hostname allowlisting and forged Host/Origin rejection;
+- auth-before-parse behavior;
+- MCP body-size enforcement;
+- bearer token not widening a read-only Skill into write authority;
+- pack-scope rejection on the reviewed ingestion route;
+- absence of graph/filesystem/shell/admin/vendor-specific HTTP routes.
+
+`scripts/run_public_mcp_mutations.py` deliberately weakens those controls and requires every targeted mutant to be killed by the holdout suite.
+
+## What still requires the real local PC
+
+Cloud tests cannot prove Windows/WSL networking, the real DNS/tunnel mapping, host-local secret injection, PC sleep/reboot behavior, or reachability from the public internet. Local acceptance should therefore be mechanical rather than exploratory:
+
+1. run the exact reviewed FOSSIL SHA locally;
+2. inject the real bearer token through the host-local environment;
+3. configure explicit MCP transport security for `fossil.design-bakery.com`;
+4. expose only `/mcp` through the HTTPS tunnel/reverse proxy;
+5. from a machine outside the local process, run `scripts/verify_public_mcp_edge.py`;
+6. restart the local FOSSIL process/tunnel once and rerun the same verifier;
+7. record only the exact SHA and sanitized PASS/FAIL receipt.
+
+A local failure is evidence about the WSL/tunnel/deployment boundary; it is not permission to weaken the MCP, FOSSIL authorization, or redaction invariants.

--- a/docs/operations/PUBLIC-MCP.md
+++ b/docs/operations/PUBLIC-MCP.md
@@ -1,0 +1,26 @@
+# Public FOSSIL MCP edge
+
+The FOSSIL network app exposes the existing `ThinMCPAdapter` tool boundary at
+`/mcp`. It requires a host-local bearer token before any MCP request reaches
+the MCP server or canonical `CorpusService`.
+
+Configure the token in one of two ways:
+
+- pass `bearer_token=` to `create_node_network_app()`; or
+- set `FOSSIL_MCP_BEARER_TOKEN` in the local process environment.
+
+The app fails to construct when no token is configured. Requests must send:
+
+```text
+Authorization: Bearer <API_TOKEN>
+```
+
+Missing, malformed, duplicate, and incorrect authorization headers receive a
+generic `401` response with `WWW-Authenticate: Bearer`. The token is compared
+without logging or reflecting its value. `/healthz` and `/readyz` remain public
+operational probes; MCP, ingestion, and all other HTTP routes require the
+token. Pack, Skill, and capability authorization remains enforced by the
+existing FOSSIL boundary after authentication.
+
+Use [`config/fossil-mcp.env.example`](../../config/fossil-mcp.env.example) only
+as a placeholder template. Keep the populated environment file outside Git.

--- a/docs/operations/PUBLIC-MCP.md
+++ b/docs/operations/PUBLIC-MCP.md
@@ -17,10 +17,22 @@ Authorization: Bearer <API_TOKEN>
 
 Missing, malformed, duplicate, and incorrect authorization headers receive a
 generic `401` response with `WWW-Authenticate: Bearer`. The token is compared
-without logging or reflecting its value. `/healthz` and `/readyz` remain public
-operational probes; MCP, ingestion, and all other HTTP routes require the
-token. Pack, Skill, and capability authorization remains enforced by the
-existing FOSSIL boundary after authentication.
+without logging or reflecting its value. Pack, Skill, and capability
+authorization remains enforced by the existing FOSSIL boundary after
+authentication.
+
+The node application also has `/healthz`, `/readyz`, and `/ingest` for local
+operations. They are **not part of the public internet contract**. Configure the
+public tunnel/reverse proxy so `fossil.design-bakery.com` forwards only `/mcp`;
+non-MCP paths must remain blocked externally. `/healthz` and `/readyz` may stay
+unauthenticated on the local listener for local operational probing, while
+`/ingest` remains bearer-protected locally.
+
+For the public hostname, keep the MCP SDK listener host as loopback and supply
+an explicit `TransportSecuritySettings` allowlist for
+`fossil.design-bakery.com`; see `PUBLIC-MCP-INVARIANTS.md`. Do not work around a
+421 Host rejection by changing the SDK `host` value to the public hostname
+without an explicit Host/Origin policy.
 
 Use [`config/fossil-mcp.env.example`](../../config/fossil-mcp.env.example) only
 as a placeholder template. Keep the populated environment file outside Git.

--- a/scripts/run_public_mcp_mutations.py
+++ b/scripts/run_public_mcp_mutations.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NETWORK = ROOT / "src" / "fossil_core" / "runtime" / "network.py"
+
+
+@dataclass(frozen=True)
+class Mutant:
+    name: str
+    replacements: tuple[tuple[str, str], ...]
+    rationale: str
+
+
+MUTANTS = (
+    Mutant(
+        "bypass_bearer_rejection",
+        (("        if not valid:\n", "        if False:\n"),),
+        "Missing, malformed, and incorrect bearer credentials must fail closed.",
+    ),
+    Mutant(
+        "accept_duplicate_authorization",
+        (("        if len(authorization_values) == 1:\n", "        if authorization_values:\n"),),
+        "Duplicate Authorization headers must never be accepted by selecting one value.",
+    ),
+    Mutant(
+        "accept_any_presented_token",
+        (("                and hmac.compare_digest(presented, self.token)\n", "                and True\n"),),
+        "The presented bearer value must exactly match the configured secret.",
+    ),
+    Mutant(
+        "make_mcp_public_without_auth",
+        (
+            (
+                '        public_paths=frozenset({"/healthz", "/readyz"}),\n',
+                '        public_paths=frozenset({"/healthz", "/readyz", "/mcp"}),\n',
+            ),
+        ),
+        "The MCP route must never bypass bearer authentication.",
+    ),
+    Mutant(
+        "make_ingest_public_without_auth",
+        (
+            (
+                '        public_paths=frozenset({"/healthz", "/readyz"}),\n',
+                '        public_paths=frozenset({"/healthz", "/readyz", "/ingest"}),\n',
+            ),
+        ),
+        "Reviewed ingestion must not become unauthenticated through route widening.",
+    ),
+    Mutant(
+        "remove_mcp_body_limit",
+        (
+            (
+                "        max_request_body_size=max_mcp_request_body_size,\n",
+                "        max_request_body_size=1024 * 1024 * 1024,\n",
+            ),
+        ),
+        "Authenticated MCP requests must remain bounded.",
+    ),
+    Mutant(
+        "disable_mcp_transport_security",
+        (
+            (
+                "        transport_security=transport_security,\n",
+                "        transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),\n",
+            ),
+        ),
+        "The explicit public Host/Origin allowlist must reach the MCP transport unchanged.",
+    ),
+    Mutant(
+        "reflect_token_in_auth_error",
+        (
+            (
+                '                        "detail": "Bearer authentication required",\n',
+                '                        "detail": "Bearer authentication required: " + self.token,\n',
+            ),
+        ),
+        "Authentication errors must never reflect the configured bearer token.",
+    ),
+)
+
+
+TEST_COMMAND = [
+    sys.executable,
+    "-m",
+    "pytest",
+    "-q",
+    "tests/holdout/test_public_mcp_holdout.py",
+    "tests/test_fossil_node_network.py",
+]
+
+
+def apply_mutant(mutant: Mutant) -> str:
+    original = NETWORK.read_text(encoding="utf-8")
+    mutated = original
+    for old, new in mutant.replacements:
+        if old not in mutated:
+            raise RuntimeError(f"mutant {mutant.name}: anchor not found: {old!r}")
+        mutated = mutated.replace(old, new, 1)
+    NETWORK.write_text(mutated, encoding="utf-8")
+    return original
+
+
+def main() -> int:
+    survivors: list[str] = []
+    killed: list[str] = []
+    harness_errors: list[str] = []
+    env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+
+    for mutant in MUTANTS:
+        try:
+            original = apply_mutant(mutant)
+        except RuntimeError as exc:
+            harness_errors.append(mutant.name)
+            print(f"HARNESS_ERROR: {exc}")
+            continue
+
+        try:
+            completed = subprocess.run(
+                TEST_COMMAND,
+                cwd=ROOT,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=False,
+            )
+        finally:
+            NETWORK.write_text(original, encoding="utf-8")
+
+        if completed.returncode == 0:
+            survivors.append(mutant.name)
+            status = "SURVIVED"
+            print(completed.stdout)
+        else:
+            killed.append(mutant.name)
+            status = "KILLED"
+        print(f"{status}: {mutant.name} — {mutant.rationale}")
+
+    print(
+        "mutation summary: "
+        f"killed={len(killed)} survived={len(survivors)} "
+        f"harness_errors={len(harness_errors)} total={len(MUTANTS)}"
+    )
+    if harness_errors:
+        print("harness errors: " + ", ".join(harness_errors))
+    if survivors:
+        print("surviving mutants: " + ", ".join(survivors))
+    if harness_errors or survivors:
+        return 1
+    print("surviving mutants: none")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_public_mcp_edge.py
+++ b/scripts/verify_public_mcp_edge.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+PROTOCOL_VERSION = "2026-07-28"
+TOKEN_ENV = "FOSSIL_MCP_BEARER_TOKEN"
+EXPECTED_TOOLS = (
+    "fossil.search",
+    "fossil.read",
+    "fossil.lineage",
+    "fossil.propose",
+    "fossil.validate",
+    "fossil.commit",
+    "fossil.manage",
+)
+
+
+def _request(
+    url: str,
+    *,
+    token: str | None = None,
+    method: str = "tools/list",
+    name: str | None = None,
+    timeout: float = 10.0,
+) -> tuple[int, bytes, dict[str, str]]:
+    params: dict[str, Any] = {
+        "_meta": {
+            "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientInfo": {
+                "name": "fossil-public-edge-verifier",
+                "version": "1",
+            },
+            "io.modelcontextprotocol/clientCapabilities": {},
+        }
+    }
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params,
+        }
+    ).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "MCP-Protocol-Version": PROTOCOL_VERSION,
+        "Mcp-Method": method,
+    }
+    if name is not None:
+        headers["Mcp-Name"] = name
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, response.read(), dict(response.headers.items())
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read(), dict(exc.headers.items())
+
+
+def _probe_private_route(url: str, timeout: float) -> int:
+    request = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status
+    except urllib.error.HTTPError as exc:
+        return exc.code
+
+
+def _fail(message: str) -> int:
+    print(json.dumps({"status": "FAIL", "reason": message}, sort_keys=True))
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify the externally reachable generic FOSSIL MCP edge without printing secrets."
+    )
+    parser.add_argument(
+        "--url",
+        default="https://fossil.design-bakery.com/mcp",
+        help="Public MCP URL; must use HTTPS.",
+    )
+    parser.add_argument("--timeout", type=float, default=10.0)
+    args = parser.parse_args()
+
+    parsed = urllib.parse.urlsplit(args.url)
+    if parsed.scheme != "https" or not parsed.netloc or parsed.path != "/mcp":
+        return _fail("expected an HTTPS URL with path /mcp")
+
+    token = os.environ.get(TOKEN_ENV)
+    if not token:
+        return _fail(f"{TOKEN_ENV} is not set")
+    if any(character.isspace() for character in token):
+        return _fail(f"{TOKEN_ENV} contains whitespace")
+
+    unauth_status, unauth_body, unauth_headers = _request(
+        args.url,
+        timeout=args.timeout,
+    )
+    if unauth_status != 401:
+        return _fail(f"missing-token request returned HTTP {unauth_status}, expected 401")
+    if unauth_headers.get("WWW-Authenticate", "").lower() != "bearer":
+        return _fail("missing-token response did not advertise Bearer authentication")
+    if token.encode() in unauth_body:
+        return _fail("token appeared in an unauthenticated response body")
+
+    wrong_status, wrong_body, _ = _request(
+        args.url,
+        token="fossil-public-edge-deliberately-wrong-token",
+        timeout=args.timeout,
+    )
+    if wrong_status != 401:
+        return _fail(f"wrong-token request returned HTTP {wrong_status}, expected 401")
+    if token.encode() in wrong_body:
+        return _fail("token appeared in a wrong-token response body")
+
+    valid_status, valid_body, _ = _request(
+        args.url,
+        token=token,
+        timeout=args.timeout,
+    )
+    if valid_status != 200:
+        return _fail(f"valid-token tools/list returned HTTP {valid_status}, expected 200")
+    if token.encode() in valid_body:
+        return _fail("token appeared in a valid response body")
+    try:
+        payload = json.loads(valid_body)
+        tool_names = tuple(tool["name"] for tool in payload["result"]["tools"])
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        return _fail(f"tools/list response was not the expected MCP JSON shape: {type(exc).__name__}")
+    if tool_names != EXPECTED_TOOLS:
+        return _fail(f"unexpected MCP tool surface: {tool_names!r}")
+
+    public_root = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+    exposed: dict[str, int] = {}
+    for path in ("/healthz", "/readyz", "/ingest", "/openapi.json", "/admin"):
+        status = _probe_private_route(public_root + path, args.timeout)
+        if status not in (403, 404):
+            exposed[path] = status
+    if exposed:
+        return _fail(f"non-MCP routes are publicly reachable: {exposed}")
+
+    receipt = {
+        "status": "PASS",
+        "endpoint": f"{parsed.scheme}://{parsed.netloc}{parsed.path}",
+        "protocol_version": PROTOCOL_VERSION,
+        "missing_token_http": unauth_status,
+        "wrong_token_http": wrong_status,
+        "valid_token_http": valid_status,
+        "tools": list(tool_names),
+        "public_non_mcp_routes": "blocked",
+    }
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/fossil_core/runtime/network.py
+++ b/src/fossil_core/runtime/network.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import hmac
 import inspect
 import json
 import os
@@ -16,6 +17,7 @@ from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
+from starlette.types import Receive, Scope, Send
 
 from fossil_core.adapters.mcp import ThinMCPAdapter
 from fossil_core.adapters.mcp.server import build_mcp_server
@@ -31,6 +33,55 @@ from .node import FilesystemFossilNode
 
 
 Probe = Callable[[], Any | Awaitable[Any]]
+MCP_BEARER_TOKEN_ENV = "FOSSIL_MCP_BEARER_TOKEN"
+
+
+class BearerAuthMiddleware:
+    """Fail-closed bearer authentication for the public FOSSIL HTTP edge."""
+
+    def __init__(self, app: Any, token: str, *, public_paths: frozenset[str]):
+        if not token or any(character.isspace() for character in token):
+            raise ValueError("FOSSIL MCP bearer token must be non-empty and whitespace-free")
+        self.app = app
+        self.token = token
+        self.public_paths = public_paths
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or scope.get("path") in self.public_paths:
+            await self.app(scope, receive, send)
+            return
+
+        authorization_values = [
+            value.decode("latin-1")
+            for name, value in scope.get("headers", [])
+            if name.lower() == b"authorization"
+        ]
+        valid = False
+        if len(authorization_values) == 1:
+            scheme, separator, presented = authorization_values[0].partition(" ")
+            valid = (
+                separator == " "
+                and scheme.lower() == "bearer"
+                and bool(presented)
+                and not any(character.isspace() for character in presented)
+                and hmac.compare_digest(presented, self.token)
+            )
+
+        if not valid:
+            response = JSONResponse(
+                {
+                    "error": {
+                        "code": "authentication_required",
+                        "detail": "Bearer authentication required",
+                    }
+                },
+                status_code=401,
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+            await response(scope, receive, send)
+            return
+
+        await self.app(scope, receive, send)
 
 
 async def _await_if_needed(value: Any) -> Any:
@@ -253,6 +304,7 @@ def create_node_network_app(
     context: AgentContext,
     readiness_probe: NodeReadinessProbe | None = None,
     transport_security: TransportSecuritySettings | None = None,
+    bearer_token: str | None = None,
     host: str = "127.0.0.1",
     max_ingest_bytes: int = 16 * 1024 * 1024,
     max_mcp_request_body_size: int = 1024 * 1024,
@@ -266,6 +318,15 @@ def create_node_network_app(
 
     if max_ingest_bytes < 1 or max_mcp_request_body_size < 1:
         raise ValueError("request body limits must be positive")
+
+    resolved_bearer_token = (
+        bearer_token if bearer_token is not None else os.environ.get(MCP_BEARER_TOKEN_ENV)
+    )
+    if not resolved_bearer_token:
+        raise ValueError(
+            "FOSSIL MCP bearer token is required; pass bearer_token or set "
+            f"{MCP_BEARER_TOKEN_ENV}"
+        )
 
     mcp_adapter = ThinMCPAdapter(
         service=node.corpus_service,
@@ -358,6 +419,11 @@ def create_node_network_app(
             Mount("/", app=mcp_app),
         ],
         lifespan=lifespan,
+    )
+    app.add_middleware(
+        BearerAuthMiddleware,
+        token=resolved_bearer_token,
+        public_paths=frozenset({"/healthz", "/readyz"}),
     )
     app.state.fossil_node = node
     app.state.mcp_server = mcp

--- a/tests/holdout/test_public_mcp_holdout.py
+++ b/tests/holdout/test_public_mcp_holdout.py
@@ -68,27 +68,25 @@ def compose(tmp_path: Path):
     )
 
 
-def writer_context() -> AgentContext:
+def context(skill_id: str, skill_version: str) -> AgentContext:
     return AgentContext(
-        actor_id="public-mcp-holdout-writer",
+        actor_id=f"public-mcp-holdout-{skill_id}",
         model_id="fixture-model",
         harness_version="fixture-harness",
-        skill_id="skill_research-ingestion",
-        skill_version="1.1.0",
+        skill_id=skill_id,
+        skill_version=skill_version,
     )
+
+
+def writer_context() -> AgentContext:
+    return context("skill_research-ingestion", "1.1.0")
 
 
 def reader_context() -> AgentContext:
-    return AgentContext(
-        actor_id="public-mcp-holdout-reader",
-        model_id="fixture-model",
-        harness_version="fixture-harness",
-        skill_id="skill_corpus-search",
-        skill_version="1.0.0",
-    )
+    return context("skill_corpus-search", "1.0.0")
 
 
-def security() -> TransportSecuritySettings:
+def public_security() -> TransportSecuritySettings:
     return TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
         allowed_hosts=[PUBLIC_HOST, f"{PUBLIC_HOST}:*"],
@@ -104,6 +102,7 @@ def mcp_headers(
     token: str | None = TOKEN,
     *,
     method: str = "tools/list",
+    name: str | None = None,
 ) -> dict[str, str]:
     headers = {
         "content-type": "application/json",
@@ -111,6 +110,8 @@ def mcp_headers(
         "mcp-protocol-version": "2026-07-28",
         "mcp-method": method,
     }
+    if name is not None:
+        headers["mcp-name"] = name
     if token is not None:
         headers.update(auth_headers(token))
     return headers
@@ -140,17 +141,16 @@ def envelope(method: str, params: dict | None = None, *, request_id: int = 1) ->
 def make_app(
     tmp_path: Path,
     *,
-    context: AgentContext | None = None,
+    agent_context: AgentContext | None = None,
     transport_security: TransportSecuritySettings | None = None,
-    host: str = "127.0.0.1",
     max_mcp_request_body_size: int = 1024 * 1024,
 ):
     return create_node_network_app(
         compose(tmp_path),
-        context=context or writer_context(),
+        context=agent_context or writer_context(),
         bearer_token=TOKEN,
         transport_security=transport_security,
-        host=host,
+        host="127.0.0.1",
         max_mcp_request_body_size=max_mcp_request_body_size,
     )
 
@@ -181,11 +181,7 @@ def test_holdout_authentication_fails_closed(
     if authorization is not None:
         headers["authorization"] = authorization
     with TestClient(app, base_url="http://localhost") as client:
-        response = client.post(
-            "/mcp",
-            headers=headers,
-            json=envelope("tools/list"),
-        )
+        response = client.post("/mcp", headers=headers, json=envelope("tools/list"))
     assert response.status_code == 401
     assert response.headers["www-authenticate"] == "Bearer"
     assert TOKEN not in response.text
@@ -221,14 +217,14 @@ def test_holdout_public_hostname_requires_explicit_transport_security(
 ) -> None:
     default_app = make_app(tmp_path / "default")
     with TestClient(default_app, base_url=f"https://{PUBLIC_HOST}") as client:
-        default_response = client.post(
+        rejected = client.post(
             "/mcp",
             headers=mcp_headers(),
             json=envelope("tools/list"),
         )
-    assert default_response.status_code == 421
+    assert rejected.status_code == 421
 
-    public_app = make_app(tmp_path / "public", transport_security=security())
+    public_app = make_app(tmp_path / "public", transport_security=public_security())
     with TestClient(public_app, base_url=f"https://{PUBLIC_HOST}") as client:
         allowed = client.post(
             "/mcp",
@@ -250,13 +246,6 @@ def test_holdout_public_hostname_requires_explicit_transport_security(
     assert tuple(tool["name"] for tool in allowed.json()["result"]["tools"]) == EXPECTED_TOOLS
     assert forged_host.status_code == 421
     assert forged_origin.status_code == 403
-
-
-def test_holdout_non_loopback_host_cannot_silently_disable_rebinding_protection(
-    tmp_path: Path,
-) -> None:
-    with pytest.raises(ValueError, match="explicit transport_security"):
-        make_app(tmp_path, host=PUBLIC_HOST)
 
 
 def test_holdout_unauthenticated_requests_are_rejected_before_parsing_or_dispatch(
@@ -295,11 +284,7 @@ def test_holdout_authenticated_mcp_body_limit_remains_enforced(tmp_path: Path) -
         envelope("tools/list", {"padding": "x" * 4096})
     ).encode()
     with TestClient(app, base_url="http://localhost") as client:
-        response = client.post(
-            "/mcp",
-            headers=mcp_headers(),
-            content=oversized,
-        )
+        response = client.post("/mcp", headers=mcp_headers(), content=oversized)
     assert response.status_code == 413
 
 
@@ -308,7 +293,7 @@ def test_holdout_bearer_token_does_not_replace_fossil_skill_authority(
 ) -> None:
     app = make_app(
         tmp_path,
-        context=reader_context(),
+        agent_context=reader_context(),
         transport_security=TransportSecuritySettings(
             enable_dns_rebinding_protection=False
         ),
@@ -328,7 +313,7 @@ def test_holdout_bearer_token_does_not_replace_fossil_skill_authority(
     with TestClient(app, base_url="http://localhost") as client:
         response = client.post(
             "/mcp",
-            headers=mcp_headers(method="tools/call"),
+            headers=mcp_headers(method="tools/call", name="fossil.propose"),
             json=envelope("tools/call", proposal),
         )
     assert response.status_code == 200

--- a/tests/holdout/test_public_mcp_holdout.py
+++ b/tests/holdout/test_public_mcp_holdout.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from mcp.server.transport_security import TransportSecuritySettings
+from starlette.testclient import TestClient
+
+from fossil_core.agent import AgentContext
+from fossil_core.runtime import FilesystemNodeConfig, compose_filesystem_node
+from fossil_core.runtime.network import create_node_network_app
+
+
+COMMON = "pack_269099f7b2ba43b7a99b9427d64092de"
+PUBLIC_HOST = "fossil.design-bakery.com"
+TOKEN = "public-mcp-holdout-token-0123456789abcdef"
+EXPECTED_TOOLS = (
+    "fossil.search",
+    "fossil.read",
+    "fossil.lineage",
+    "fossil.propose",
+    "fossil.validate",
+    "fossil.commit",
+    "fossil.manage",
+)
+
+
+def root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+class FakeGraphiti:
+    async def build_indices_and_constraints(self) -> None:
+        return None
+
+    async def add_episode(self, **kwargs):
+        event_id = str(json.loads(kwargs["episode_body"])["event_id"])
+        return SimpleNamespace(episode=SimpleNamespace(uuid=f"episode-{event_id}"))
+
+    async def remove_episode(self, episode_uuid: str) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+def compose(tmp_path: Path):
+    config = FilesystemNodeConfig(
+        repository_root=root(),
+        data_root=tmp_path / "node-data",
+        pack_manifest_path=root() / "examples" / "packs" / "common" / "manifest.json",
+        projection_build_id="public-mcp-holdout",
+        projection_build_manifest={
+            "graphiti_version": "0.29.3",
+            "neo4j_version": "test",
+            "model_id": "test-model",
+            "ontology_version": "1.0.0",
+            "software_commit": "holdout",
+        },
+        poll_interval_seconds=0.01,
+    )
+    return compose_filesystem_node(
+        config,
+        graphiti_client=FakeGraphiti(),
+        episode_type_json="json",
+    )
+
+
+def writer_context() -> AgentContext:
+    return AgentContext(
+        actor_id="public-mcp-holdout-writer",
+        model_id="fixture-model",
+        harness_version="fixture-harness",
+        skill_id="skill_research-ingestion",
+        skill_version="1.1.0",
+    )
+
+
+def reader_context() -> AgentContext:
+    return AgentContext(
+        actor_id="public-mcp-holdout-reader",
+        model_id="fixture-model",
+        harness_version="fixture-harness",
+        skill_id="skill_corpus-search",
+        skill_version="1.0.0",
+    )
+
+
+def security() -> TransportSecuritySettings:
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=[PUBLIC_HOST, f"{PUBLIC_HOST}:*"],
+        allowed_origins=[],
+    )
+
+
+def auth_headers(token: str = TOKEN) -> dict[str, str]:
+    return {"authorization": f"Bearer {token}"}
+
+
+def mcp_headers(
+    token: str | None = TOKEN,
+    *,
+    method: str = "tools/list",
+) -> dict[str, str]:
+    headers = {
+        "content-type": "application/json",
+        "accept": "application/json, text/event-stream",
+        "mcp-protocol-version": "2026-07-28",
+        "mcp-method": method,
+    }
+    if token is not None:
+        headers.update(auth_headers(token))
+    return headers
+
+
+def envelope(method: str, params: dict | None = None, *, request_id: int = 1) -> dict:
+    payload_params = dict(params or {})
+    payload_params.setdefault(
+        "_meta",
+        {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientInfo": {
+                "name": "fossil-public-holdout",
+                "version": "1",
+            },
+            "io.modelcontextprotocol/clientCapabilities": {},
+        },
+    )
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": method,
+        "params": payload_params,
+    }
+
+
+def make_app(
+    tmp_path: Path,
+    *,
+    context: AgentContext | None = None,
+    transport_security: TransportSecuritySettings | None = None,
+    host: str = "127.0.0.1",
+    max_mcp_request_body_size: int = 1024 * 1024,
+):
+    return create_node_network_app(
+        compose(tmp_path),
+        context=context or writer_context(),
+        bearer_token=TOKEN,
+        transport_security=transport_security,
+        host=host,
+        max_mcp_request_body_size=max_mcp_request_body_size,
+    )
+
+
+@pytest.mark.parametrize(
+    "authorization",
+    [
+        None,
+        "",
+        "Basic abc",
+        "Bearer",
+        "Bearer wrong",
+        f"Bearer {TOKEN} ",
+        f"Bearer {TOKEN}\textra",
+        f"Bearer {TOKEN.upper()}",
+    ],
+)
+def test_holdout_authentication_fails_closed(
+    tmp_path: Path, authorization: str | None
+) -> None:
+    app = make_app(
+        tmp_path,
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        ),
+    )
+    headers = mcp_headers(token=None)
+    if authorization is not None:
+        headers["authorization"] = authorization
+    with TestClient(app, base_url="http://localhost") as client:
+        response = client.post(
+            "/mcp",
+            headers=headers,
+            json=envelope("tools/list"),
+        )
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+    assert TOKEN not in response.text
+
+
+def test_holdout_duplicate_authorization_header_fails_closed(tmp_path: Path) -> None:
+    app = make_app(
+        tmp_path,
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        ),
+    )
+    headers = [
+        ("authorization", f"Bearer {TOKEN}"),
+        ("authorization", "Bearer attacker"),
+        ("content-type", "application/json"),
+        ("accept", "application/json, text/event-stream"),
+        ("mcp-protocol-version", "2026-07-28"),
+        ("mcp-method", "tools/list"),
+    ]
+    with TestClient(app, base_url="http://localhost") as client:
+        response = client.post(
+            "/mcp",
+            headers=headers,
+            content=json.dumps(envelope("tools/list")).encode(),
+        )
+    assert response.status_code == 401
+    assert TOKEN not in response.text
+
+
+def test_holdout_public_hostname_requires_explicit_transport_security(
+    tmp_path: Path,
+) -> None:
+    default_app = make_app(tmp_path / "default")
+    with TestClient(default_app, base_url=f"https://{PUBLIC_HOST}") as client:
+        default_response = client.post(
+            "/mcp",
+            headers=mcp_headers(),
+            json=envelope("tools/list"),
+        )
+    assert default_response.status_code == 421
+
+    public_app = make_app(tmp_path / "public", transport_security=security())
+    with TestClient(public_app, base_url=f"https://{PUBLIC_HOST}") as client:
+        allowed = client.post(
+            "/mcp",
+            headers=mcp_headers(),
+            json=envelope("tools/list"),
+        )
+        forged_host = client.post(
+            "/mcp",
+            headers={**mcp_headers(), "host": "attacker.invalid"},
+            json=envelope("tools/list"),
+        )
+        forged_origin = client.post(
+            "/mcp",
+            headers={**mcp_headers(), "origin": "https://attacker.invalid"},
+            json=envelope("tools/list"),
+        )
+
+    assert allowed.status_code == 200
+    assert tuple(tool["name"] for tool in allowed.json()["result"]["tools"]) == EXPECTED_TOOLS
+    assert forged_host.status_code == 421
+    assert forged_origin.status_code == 403
+
+
+def test_holdout_non_loopback_host_cannot_silently_disable_rebinding_protection(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="explicit transport_security"):
+        make_app(tmp_path, host=PUBLIC_HOST)
+
+
+def test_holdout_unauthenticated_requests_are_rejected_before_parsing_or_dispatch(
+    tmp_path: Path,
+) -> None:
+    app = make_app(
+        tmp_path,
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        ),
+        max_mcp_request_body_size=128,
+    )
+    huge_invalid = b"{" + (b"x" * 4096)
+    with TestClient(app, base_url="http://localhost") as client:
+        response = client.post(
+            "/mcp",
+            headers={
+                "content-type": "application/json",
+                "accept": "application/json, text/event-stream",
+                "mcp-protocol-version": "2026-07-28",
+            },
+            content=huge_invalid,
+        )
+    assert response.status_code == 401
+
+
+def test_holdout_authenticated_mcp_body_limit_remains_enforced(tmp_path: Path) -> None:
+    app = make_app(
+        tmp_path,
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        ),
+        max_mcp_request_body_size=256,
+    )
+    oversized = json.dumps(
+        envelope("tools/list", {"padding": "x" * 4096})
+    ).encode()
+    with TestClient(app, base_url="http://localhost") as client:
+        response = client.post(
+            "/mcp",
+            headers=mcp_headers(),
+            content=oversized,
+        )
+    assert response.status_code == 413
+
+
+def test_holdout_bearer_token_does_not_replace_fossil_skill_authority(
+    tmp_path: Path,
+) -> None:
+    app = make_app(
+        tmp_path,
+        context=reader_context(),
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        ),
+    )
+    proposal = {
+        "name": "fossil.propose",
+        "arguments": {
+            "event_type": "claim.proposed",
+            "pack_id": COMMON,
+            "subject_refs": ["clm_public_holdout"],
+            "payload": {"claim_text": "Bearer auth must not grant write authority."},
+            "occurred_at": "2026-08-20T20:00:00Z",
+            "recorded_at": "2026-08-20T20:00:00Z",
+            "idempotency_key": "public-mcp-holdout-reader-write-v1",
+        },
+    }
+    with TestClient(app, base_url="http://localhost") as client:
+        response = client.post(
+            "/mcp",
+            headers=mcp_headers(method="tools/call"),
+            json=envelope("tools/call", proposal),
+        )
+    assert response.status_code == 200
+    serialized = response.text
+    assert "does not grant corpus capability propose" in serialized
+    assert '"isError":true' in serialized.replace(" ", "")
+
+
+def test_holdout_graph_shell_filesystem_and_vendor_specific_routes_are_absent(
+    tmp_path: Path,
+) -> None:
+    app = make_app(
+        tmp_path,
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        ),
+    )
+    prohibited = (
+        "/neo4j",
+        "/graph",
+        "/filesystem",
+        "/shell",
+        "/admin",
+        "/openapi.json",
+        "/actions/search",
+        "/actions/read",
+    )
+    with TestClient(app, base_url="http://localhost") as client:
+        for path in prohibited:
+            response = client.post(path, headers=auth_headers(), json={})
+            assert response.status_code == 404, path
+
+
+def test_holdout_ingest_is_authenticated_and_pack_scope_still_fails_closed(
+    tmp_path: Path,
+) -> None:
+    app = make_app(
+        tmp_path,
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        ),
+    )
+    payload = {
+        "pack_id": "pack_forbidden_public_holdout",
+        "source": {},
+        "claims": [],
+        "review_ref": "review:public-holdout",
+        "occurred_at": "2026-08-20T20:00:00Z",
+        "recorded_at": "2026-08-20T20:00:00Z",
+        "correlation_id": "public-mcp-holdout",
+    }
+    with TestClient(app, base_url="http://localhost") as client:
+        unauthenticated = client.post("/ingest", json=payload)
+        authenticated = client.post(
+            "/ingest",
+            headers=auth_headers(),
+            json=payload,
+        )
+    assert unauthenticated.status_code == 401
+    assert authenticated.status_code == 403
+    assert authenticated.json()["error"]["code"] == "unauthorized_pack"

--- a/tests/test_fossil_node_network.py
+++ b/tests/test_fossil_node_network.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from mcp import Client
 from mcp.server.transport_security import TransportSecuritySettings
 from starlette.testclient import TestClient
@@ -18,6 +19,7 @@ from fossil_core.runtime.network import NodeReadinessProbe, create_node_network_
 
 
 COMMON = "pack_269099f7b2ba43b7a99b9427d64092de"
+BEARER_TOKEN = "node-02-test-bearer-token"
 EXPECTED_TOOLS = (
     "fossil.search",
     "fossil.read",
@@ -126,6 +128,10 @@ def _tool_error_text(result) -> str:
     return "\n".join(getattr(block, "text", "") for block in result.content)
 
 
+def auth_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {BEARER_TOKEN}"}
+
+
 def test_mcp_server_preserves_frozen_tools_and_corpus_semantics(tmp_path: Path):
     node = compose(tmp_path)
     node.corpus_service.lineages["conv_node_02"] = (COMMON, FakeLineage())
@@ -229,6 +235,7 @@ def test_streamable_http_transport_and_health_readiness_are_independent(tmp_path
     app = create_node_network_app(
         node,
         context=agent_context(),
+        bearer_token=BEARER_TOKEN,
         readiness_probe=NodeReadinessProbe(node, projection_check=projection_down),
         transport_security=TransportSecuritySettings(
             enable_dns_rebinding_protection=False
@@ -266,6 +273,7 @@ def test_streamable_http_transport_and_health_readiness_are_independent(tmp_path
         response = client.post(
             "/mcp",
             headers={
+                **auth_headers(),
                 "content-type": "application/json",
                 "accept": "application/json, text/event-stream",
                 "mcp-protocol-version": "2026-07-28",
@@ -283,6 +291,7 @@ def test_reviewed_http_ingest_is_durable_before_projection(tmp_path: Path):
     app = create_node_network_app(
         node,
         context=agent_context(),
+        bearer_token=BEARER_TOKEN,
         transport_security=TransportSecuritySettings(
             enable_dns_rebinding_protection=False
         ),
@@ -321,7 +330,7 @@ def test_reviewed_http_ingest_is_durable_before_projection(tmp_path: Path):
     }
 
     with TestClient(app, base_url="http://localhost") as client:
-        response = client.post("/ingest", json=payload)
+        response = client.post("/ingest", headers=auth_headers(), json=payload)
         assert response.status_code == 201
         receipt = response.json()
 
@@ -346,6 +355,7 @@ def test_reviewed_http_ingest_rejects_pack_spoofing_and_invalid_payload(tmp_path
     app = create_node_network_app(
         node,
         context=agent_context(),
+        bearer_token=BEARER_TOKEN,
         transport_security=TransportSecuritySettings(
             enable_dns_rebinding_protection=False
         ),
@@ -354,6 +364,7 @@ def test_reviewed_http_ingest_rejects_pack_spoofing_and_invalid_payload(tmp_path
     with TestClient(app, base_url="http://localhost") as client:
         denied = client.post(
             "/ingest",
+            headers=auth_headers(),
             json={
                 "pack_id": "pack_forbidden_node_02",
                 "source": {},
@@ -367,8 +378,73 @@ def test_reviewed_http_ingest_rejects_pack_spoofing_and_invalid_payload(tmp_path
         assert denied.status_code == 403
         assert denied.json()["error"]["code"] == "unauthorized_pack"
 
-        invalid = client.post("/ingest", content=b"not-json")
+        invalid = client.post("/ingest", headers=auth_headers(), content=b"not-json")
         assert invalid.status_code == 400
         assert invalid.json()["error"]["code"] == "invalid_json"
 
     assert list(node.event_store.iter_events()) == []
+
+
+def test_public_mcp_requires_exact_bearer_token_before_tool_execution(tmp_path: Path):
+    node = compose(tmp_path)
+    app = create_node_network_app(
+        node,
+        context=agent_context(),
+        bearer_token=BEARER_TOKEN,
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        ),
+    )
+    envelope = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientInfo": {"name": "auth-test", "version": "1"},
+                "io.modelcontextprotocol/clientCapabilities": {},
+            }
+        },
+    }
+
+    with TestClient(app, base_url="http://localhost") as client:
+        for headers in ({}, {"Authorization": "Bearer wrong-token"}, {"Authorization": "Basic anything"}):
+            response = client.post(
+                "/mcp",
+                headers={
+                    **headers,
+                    "content-type": "application/json",
+                    "accept": "application/json, text/event-stream",
+                    "mcp-protocol-version": "2026-07-28",
+                },
+                json=envelope,
+            )
+            assert response.status_code == 401
+            assert response.headers["www-authenticate"] == "Bearer"
+            assert response.json() == {
+                "error": {
+                    "code": "authentication_required",
+                    "detail": "Bearer authentication required",
+                }
+            }
+
+        valid = client.post(
+            "/mcp",
+            headers={
+                **auth_headers(),
+                "content-type": "application/json",
+                "accept": "application/json, text/event-stream",
+                "mcp-protocol-version": "2026-07-28",
+                "mcp-method": "tools/list",
+            },
+            json=envelope,
+        )
+        assert valid.status_code == 200
+        assert tuple(tool["name"] for tool in valid.json()["result"]["tools"]) == EXPECTED_TOOLS
+
+
+def test_network_app_requires_token_configuration(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("FOSSIL_MCP_BEARER_TOKEN", raising=False)
+    with pytest.raises(ValueError, match="FOSSIL MCP bearer token is required"):
+        create_node_network_app(compose(tmp_path), context=agent_context())


### PR DESCRIPTION
Implements the authentication portion of #231 / FOSSIL-PUBLIC-MCP-LOCAL.

Changes:
- adds fail-closed Bearer authentication around the existing network app;
- protects /mcp, /ingest, and all non-operational HTTP routes before MCP or CorpusService execution;
- keeps /healthz and /readyz available as operational probes;
- compares the token with hmac.compare_digest and never reflects or logs it;
- rejects missing, malformed, duplicate, and incorrect credentials with generic 401 + WWW-Authenticate: Bearer;
- requires an explicit token or host-local FOSSIL_MCP_BEARER_TOKEN;
- adds a placeholder env template and operator notes.

Verification:
- focused network tests: 7 passed;
- full suite: 705 passed, 1 skipped;
- no deployment or real secret handling performed.

This does not modify the draft ChatGPT Action/OpenAPI path in PR #235.